### PR TITLE
feat: add app skeleton with view switching and async event loop

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,46 @@
+use crossterm::event::{KeyCode, KeyEvent};
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum ActiveView {
+    #[default]
+    Log,
+    Pr,
+    Branch,
+    Worktree,
+}
+
+impl ActiveView {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Log => "Log",
+            Self::Pr => "PR",
+            Self::Branch => "Branch",
+            Self::Worktree => "Worktree",
+        }
+    }
+}
+
+pub struct App {
+    pub active_view: ActiveView,
+    pub should_quit: bool,
+}
+
+impl App {
+    pub fn new() -> Self {
+        Self {
+            active_view: ActiveView::default(),
+            should_quit: false,
+        }
+    }
+
+    pub fn handle_key(&mut self, key: KeyEvent) {
+        match key.code {
+            KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
+            KeyCode::Char('1') => self.active_view = ActiveView::Log,
+            KeyCode::Char('2') => self.active_view = ActiveView::Pr,
+            KeyCode::Char('3') => self.active_view = ActiveView::Branch,
+            KeyCode::Char('4') => self.active_view = ActiveView::Worktree,
+            _ => {}
+        }
+    }
+}

--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,50 @@
+use std::time::Duration;
+
+use crossterm::event::{self, Event as CtEvent, KeyEvent};
+use tokio::sync::mpsc;
+
+#[derive(Debug)]
+pub enum Event {
+    Key(KeyEvent),
+    Tick,
+    #[allow(dead_code)]
+    Resize(u16, u16),
+}
+
+pub struct EventHandler {
+    rx: mpsc::UnboundedReceiver<Event>,
+}
+
+impl EventHandler {
+    pub fn new(tick_rate: Duration) -> Self {
+        let (tx, rx) = mpsc::unbounded_channel();
+
+        tokio::spawn(async move {
+            loop {
+                if event::poll(tick_rate).unwrap_or(false) {
+                    match event::read() {
+                        Ok(CtEvent::Key(key)) => {
+                            if tx.send(Event::Key(key)).is_err() {
+                                return;
+                            }
+                        }
+                        Ok(CtEvent::Resize(w, h)) => {
+                            if tx.send(Event::Resize(w, h)).is_err() {
+                                return;
+                            }
+                        }
+                        _ => {}
+                    }
+                } else if tx.send(Event::Tick).is_err() {
+                    return;
+                }
+            }
+        });
+
+        Self { rx }
+    }
+
+    pub async fn next(&mut self) -> Option<Event> {
+        self.rx.recv().await
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,52 +1,43 @@
-use std::io;
+mod app;
+mod event;
+mod ui;
 
-use crossterm::{
-    ExecutableCommand,
-    event::{self, Event, KeyCode, KeyEventKind},
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
-};
-use ratatui::{
-    DefaultTerminal, Frame,
-    layout::{Constraint, Layout},
-    style::{Color, Style},
-    text::Text,
-    widgets::{Block, Borders, Paragraph},
-};
+use std::time::Duration;
 
-fn main() -> anyhow::Result<()> {
-    enable_raw_mode()?;
-    io::stdout().execute(EnterAlternateScreen)?;
+use crossterm::event::KeyEventKind;
 
-    let terminal = ratatui::init();
-    let result = run(terminal);
+use crate::app::App;
+use crate::event::{Event, EventHandler};
 
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mut terminal = ratatui::init();
+    let result = run(&mut terminal).await;
     ratatui::restore();
-    disable_raw_mode()?;
-    io::stdout().execute(LeaveAlternateScreen)?;
-
     result
 }
 
-fn run(mut terminal: DefaultTerminal) -> anyhow::Result<()> {
-    loop {
-        terminal.draw(ui)?;
+async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
+    let mut app = App::new();
+    let mut events = EventHandler::new(Duration::from_millis(250));
 
-        if let Event::Key(key) = event::read()?
-            && key.kind == KeyEventKind::Press
-            && matches!(key.code, KeyCode::Char('q') | KeyCode::Esc)
-        {
-            return Ok(());
+    loop {
+        terminal.draw(|frame| ui::draw(frame, &app))?;
+
+        match events.next().await {
+            Some(Event::Key(key)) if key.kind == KeyEventKind::Press => {
+                app.handle_key(key);
+            }
+            Some(Event::Resize(_, _)) => {}
+            Some(Event::Tick) => {}
+            Some(Event::Key(_)) => {}
+            None => break,
+        }
+
+        if app.should_quit {
+            break;
         }
     }
-}
 
-fn ui(frame: &mut Frame) {
-    let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(frame.area());
-
-    let title = Paragraph::new(Text::raw("Git Control Tower"))
-        .block(Block::default().borders(Borders::ALL).title(" gct "));
-    frame.render_widget(title, chunks[0]);
-
-    let status = Paragraph::new("Press q to quit").style(Style::default().fg(Color::DarkGray));
-    frame.render_widget(status, chunks[1]);
+    Ok(())
 }

--- a/src/ui/branch_view.rs
+++ b/src/ui/branch_view.rs
@@ -1,0 +1,11 @@
+use ratatui::{
+    Frame,
+    layout::Rect,
+    widgets::{Block, Borders, Paragraph},
+};
+
+pub fn draw(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title(" Branch ");
+    let content = Paragraph::new("Branch View").block(block);
+    frame.render_widget(content, area);
+}

--- a/src/ui/log_view.rs
+++ b/src/ui/log_view.rs
@@ -1,0 +1,11 @@
+use ratatui::{
+    Frame,
+    layout::Rect,
+    widgets::{Block, Borders, Paragraph},
+};
+
+pub fn draw(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title(" Log ");
+    let content = Paragraph::new("Log View").block(block);
+    frame.render_widget(content, area);
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,0 +1,31 @@
+mod branch_view;
+mod log_view;
+mod pr_view;
+mod worktree_view;
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout},
+    style::{Color, Style},
+    widgets::Paragraph,
+};
+
+use crate::app::{ActiveView, App};
+
+pub fn draw(frame: &mut Frame, app: &App) {
+    let chunks = Layout::vertical([Constraint::Min(1), Constraint::Length(1)]).split(frame.area());
+
+    match app.active_view {
+        ActiveView::Log => log_view::draw(frame, chunks[0]),
+        ActiveView::Pr => pr_view::draw(frame, chunks[0]),
+        ActiveView::Branch => branch_view::draw(frame, chunks[0]),
+        ActiveView::Worktree => worktree_view::draw(frame, chunks[0]),
+    }
+
+    let status = Paragraph::new(format!(
+        " [{}]  1:Log  2:PR  3:Branch  4:Worktree  q:Quit",
+        app.active_view.label()
+    ))
+    .style(Style::default().fg(Color::White).bg(Color::DarkGray));
+    frame.render_widget(status, chunks[1]);
+}

--- a/src/ui/pr_view.rs
+++ b/src/ui/pr_view.rs
@@ -1,0 +1,11 @@
+use ratatui::{
+    Frame,
+    layout::Rect,
+    widgets::{Block, Borders, Paragraph},
+};
+
+pub fn draw(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title(" PR ");
+    let content = Paragraph::new("PR View").block(block);
+    frame.render_widget(content, area);
+}

--- a/src/ui/worktree_view.rs
+++ b/src/ui/worktree_view.rs
@@ -1,0 +1,11 @@
+use ratatui::{
+    Frame,
+    layout::Rect,
+    widgets::{Block, Borders, Paragraph},
+};
+
+pub fn draw(frame: &mut Frame, area: Rect) {
+    let block = Block::default().borders(Borders::ALL).title(" Worktree ");
+    let content = Paragraph::new("Worktree View").block(block);
+    frame.render_widget(content, area);
+}


### PR DESCRIPTION
## Summary

Establish the core application architecture needed for all subsequent view implementations. Replaces the minimal static TUI with a tokio-based async event loop, centralized app state, and keyboard-driven navigation across four placeholder views.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Introduce `App` struct with `ActiveView` enum (Log, PR, Branch, Worktree) for centralized state management
- Replace synchronous `event::read()` with a tokio mpsc channel-based async event loop (`EventHandler`), preparing for future async git/gh command execution
- Add four placeholder views under `src/ui/`, each rendering a titled border panel
- Add a status bar showing the active view and key hints (`1:Log 2:PR 3:Branch 4:Worktree q:Quit`)
- Switch `main()` to `#[tokio::main]` async runtime

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [ ] Tests pass (no tests yet)

## Test Plan

1. `cargo run` — app launches in Log View (default)
2. Press `1`, `2`, `3`, `4` — view switches instantly, status bar updates
3. Press `q` — app exits cleanly, terminal is restored