### PR TITLE
feat(git): add async command execution layer and output parsers

### DIFF
--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -1,0 +1,34 @@
+use anyhow::{Context, Result, bail};
+use tokio::process::Command;
+
+#[allow(dead_code)]
+pub async fn run_git(args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .output()
+        .await
+        .context("failed to execute git")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("git {} failed: {}", args.join(" "), stderr.trim());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[allow(dead_code)]
+pub async fn run_gh(args: &[&str]) -> Result<String> {
+    let output = Command::new("gh")
+        .args(args)
+        .output()
+        .await
+        .context("failed to execute gh")?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        bail!("gh {} failed: {}", args.join(" "), stderr.trim());
+    }
+
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -1,0 +1,3 @@
+pub mod command;
+pub mod parser;
+pub mod types;

--- a/src/git/parser.rs
+++ b/src/git/parser.rs
@@ -1,0 +1,207 @@
+use crate::git::types::{Branch, Commit, Worktree};
+
+/// Parse output of `git log --format="%h%x00%s%x00%an%x00%ad" --date=short`
+/// with optional `--graph` prefix per line.
+#[allow(dead_code)]
+pub fn parse_log(output: &str) -> Vec<Commit> {
+    output
+        .lines()
+        .filter_map(|line| {
+            // Graph characters are everything before the first field separator
+            let (graph, fields) = match line.find('\x00') {
+                Some(pos) => (line[..pos].to_string(), &line[pos..]),
+                None => return None,
+            };
+
+            // Extract the hash from graph prefix (last non-whitespace, non-graph-char token)
+            let hash_start = graph
+                .rfind(|c: char| "*|\\/_ ".contains(c))
+                .map_or(0, |i| i + 1);
+            let hash = graph[hash_start..].trim().to_string();
+            let graph_prefix = graph[..hash_start].to_string();
+
+            let parts: Vec<&str> = fields.split('\x00').collect();
+            if parts.len() < 4 {
+                return None;
+            }
+
+            Some(Commit {
+                hash,
+                message: parts[1].to_string(),
+                author: parts[2].to_string(),
+                date: parts[3].to_string(),
+                graph: graph_prefix,
+            })
+        })
+        .collect()
+}
+
+/// Parse output of `git branch -vv`
+#[allow(dead_code)]
+pub fn parse_branches(output: &str, merged_output: &str) -> Vec<Branch> {
+    let merged_names: Vec<&str> = merged_output
+        .lines()
+        .map(|l| l.trim().trim_start_matches("* "))
+        .collect();
+
+    output
+        .lines()
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                return None;
+            }
+
+            let is_current = trimmed.starts_with('*');
+            let rest = if is_current {
+                trimmed[1..].trim()
+            } else {
+                trimmed
+            };
+
+            // Branch name is the first token
+            let name = rest.split_whitespace().next()?.to_string();
+
+            // Extract upstream from [origin/xxx] or [origin/xxx: ahead N]
+            let upstream = rest.find('[').and_then(|start| {
+                let after = &rest[start + 1..];
+                let close = after.find(']')?;
+                let inner = &after[..close];
+                // Strip trailing status like ": ahead 1, behind 2"
+                let name = inner.split(':').next().unwrap_or(inner).trim();
+                Some(name.to_string())
+            });
+
+            let is_merged = merged_names.contains(&name.as_str());
+
+            Some(Branch {
+                name,
+                is_current,
+                upstream,
+                is_merged,
+            })
+        })
+        .collect()
+}
+
+/// Parse output of `git worktree list --porcelain`
+#[allow(dead_code)]
+pub fn parse_worktrees(output: &str) -> Vec<Worktree> {
+    let mut worktrees = Vec::new();
+    let mut path = String::new();
+    let mut head = String::new();
+    let mut branch = None;
+    let mut is_bare = false;
+
+    for line in output.lines() {
+        if let Some(p) = line.strip_prefix("worktree ") {
+            path = p.to_string();
+        } else if let Some(h) = line.strip_prefix("HEAD ") {
+            head = h.to_string();
+        } else if let Some(b) = line.strip_prefix("branch ") {
+            branch = Some(b.trim_start_matches("refs/heads/").to_string());
+        } else if line == "bare" {
+            is_bare = true;
+        } else if line.is_empty() && !path.is_empty() {
+            worktrees.push(Worktree {
+                path: path.clone(),
+                head: head.clone(),
+                branch: branch.take(),
+                is_bare,
+            });
+            path.clear();
+            head.clear();
+            is_bare = false;
+        }
+    }
+
+    // Handle last entry without trailing newline
+    if !path.is_empty() {
+        worktrees.push(Worktree {
+            path,
+            head,
+            branch,
+            is_bare,
+        });
+    }
+
+    worktrees
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_log() {
+        let output = "* abc1234\x00fix bug\x00Alice\x002024-01-15\n\
+                       * def5678\x00add feature\x00Bob\x002024-01-14\n";
+        let commits = parse_log(output);
+        assert_eq!(commits.len(), 2);
+        assert_eq!(commits[0].hash, "abc1234");
+        assert_eq!(commits[0].message, "fix bug");
+        assert_eq!(commits[0].author, "Alice");
+        assert_eq!(commits[0].date, "2024-01-15");
+        assert_eq!(commits[1].hash, "def5678");
+        assert_eq!(commits[1].message, "add feature");
+    }
+
+    #[test]
+    fn test_parse_branches() {
+        let output = "* main       abc1234 [origin/main] latest commit\n\
+                         feature-a  def5678 [origin/feature-a: ahead 1] wip\n\
+                         old-branch ghi9012 some old work\n";
+        let merged = "  old-branch\n";
+        let branches = parse_branches(output, merged);
+
+        assert_eq!(branches.len(), 3);
+
+        assert_eq!(branches[0].name, "main");
+        assert!(branches[0].is_current);
+        assert_eq!(branches[0].upstream.as_deref(), Some("origin/main"));
+        assert!(!branches[0].is_merged);
+
+        assert_eq!(branches[1].name, "feature-a");
+        assert!(!branches[1].is_current);
+        assert_eq!(branches[1].upstream.as_deref(), Some("origin/feature-a"));
+
+        assert_eq!(branches[2].name, "old-branch");
+        assert!(branches[2].is_merged);
+        assert!(branches[2].upstream.is_none());
+    }
+
+    #[test]
+    fn test_parse_worktrees() {
+        let output = "worktree /home/user/repo\n\
+                       HEAD abc1234567890\n\
+                       branch refs/heads/main\n\
+                       \n\
+                       worktree /home/user/repo-feature\n\
+                       HEAD def5678901234\n\
+                       branch refs/heads/feature-x\n\
+                       \n";
+        let worktrees = parse_worktrees(output);
+
+        assert_eq!(worktrees.len(), 2);
+        assert_eq!(worktrees[0].path, "/home/user/repo");
+        assert_eq!(worktrees[0].head, "abc1234567890");
+        assert_eq!(worktrees[0].branch.as_deref(), Some("main"));
+        assert!(!worktrees[0].is_bare);
+
+        assert_eq!(worktrees[1].path, "/home/user/repo-feature");
+        assert_eq!(worktrees[1].branch.as_deref(), Some("feature-x"));
+    }
+
+    #[test]
+    fn test_parse_worktrees_bare() {
+        let output = "worktree /home/user/repo.git\n\
+                       HEAD abc1234567890\n\
+                       bare\n\
+                       \n";
+        let worktrees = parse_worktrees(output);
+
+        assert_eq!(worktrees.len(), 1);
+        assert!(worktrees[0].is_bare);
+        assert!(worktrees[0].branch.is_none());
+    }
+}

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -1,0 +1,55 @@
+use serde::Deserialize;
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Commit {
+    pub hash: String,
+    pub message: String,
+    pub author: String,
+    pub date: String,
+    pub graph: String,
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Branch {
+    pub name: String,
+    pub is_current: bool,
+    pub upstream: Option<String>,
+    pub is_merged: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct PullRequest {
+    pub number: u64,
+    pub title: String,
+    #[serde(deserialize_with = "deserialize_author")]
+    pub author: String,
+    pub state: String,
+    #[serde(rename = "headRefName")]
+    pub head_ref: String,
+    #[serde(rename = "updatedAt")]
+    pub updated_at: String,
+}
+
+fn deserialize_author<'de, D>(deserializer: D) -> Result<String, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    struct Author {
+        login: String,
+    }
+    let author = Author::deserialize(deserializer)?;
+    Ok(author.login)
+}
+
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct Worktree {
+    pub path: String,
+    pub head: String,
+    pub branch: Option<String>,
+    pub is_bare: bool,
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod app;
 mod event;
+mod git;
 mod ui;
 
 use std::time::Duration;


### PR DESCRIPTION
## Summary

Build the shared data access layer that all view implementations will depend on. Adds async git/gh CLI wrappers via tokio, shared data types with serde support for JSON parsing, and parsers for git log, branch, and worktree output — all with unit tests.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add `run_git()` / `run_gh()` async functions that execute CLI commands via `tokio::process::Command` and return stdout or an error with stderr context
- Define shared data types: `Commit`, `Branch`, `PullRequest` (with serde JSON deserialization), `Worktree`
- Implement parsers for `git log` (custom format with graph), `git branch -vv` (with upstream and merged status), and `git worktree list --porcelain`
- Add 4 unit tests covering branch parsing edge cases, worktree bare repos, and log output

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (4 parser tests)

## Test Plan

1. `cargo test` — all 4 parser unit tests pass
2. `cargo run` — existing UI unaffected (view switching and quit still work)