### PR TITLE
feat(pr): display PR list with author/reviewer filtering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
-use crate::git::types::Commit;
+use crate::git::types::{Commit, PullRequest};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ActiveView {
@@ -22,11 +22,36 @@ impl ActiveView {
     }
 }
 
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum PrFilter {
+    #[default]
+    All,
+    AuthoredByMe,
+    ReviewRequested,
+}
+
+impl PrFilter {
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::All => "All",
+            Self::AuthoredByMe => "Authored",
+            Self::ReviewRequested => "Review Requested",
+        }
+    }
+}
+
 pub struct App {
     pub active_view: ActiveView,
     pub should_quit: bool,
+    // Log View
     pub commits: Vec<Commit>,
     pub log_scroll: usize,
+    // PR View
+    pub pull_requests: Vec<PullRequest>,
+    pub pr_scroll: usize,
+    pub pr_filter: PrFilter,
+    pub gh_user: String,
+    pub prs_loaded: bool,
 }
 
 impl App {
@@ -36,7 +61,25 @@ impl App {
             should_quit: false,
             commits: Vec::new(),
             log_scroll: 0,
+            pull_requests: Vec::new(),
+            pr_scroll: 0,
+            pr_filter: PrFilter::default(),
+            gh_user: String::new(),
+            prs_loaded: false,
         }
+    }
+
+    pub fn filtered_prs(&self) -> Vec<&PullRequest> {
+        self.pull_requests
+            .iter()
+            .filter(|pr| match self.pr_filter {
+                PrFilter::All => true,
+                PrFilter::AuthoredByMe => pr.author == self.gh_user,
+                PrFilter::ReviewRequested => {
+                    pr.review_requests.iter().any(|r| r.login == self.gh_user)
+                }
+            })
+            .collect()
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) {
@@ -46,11 +89,11 @@ impl App {
             KeyCode::Char('2') => self.active_view = ActiveView::Pr,
             KeyCode::Char('3') => self.active_view = ActiveView::Branch,
             KeyCode::Char('4') => self.active_view = ActiveView::Worktree,
-            _ => {
-                if self.active_view == ActiveView::Log {
-                    self.handle_log_key(key.code);
-                }
-            }
+            _ => match self.active_view {
+                ActiveView::Log => self.handle_log_key(key.code),
+                ActiveView::Pr => self.handle_pr_key(key.code),
+                _ => {}
+            },
         }
     }
 
@@ -63,6 +106,37 @@ impl App {
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.log_scroll = self.log_scroll.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_pr_key(&mut self, code: KeyCode) {
+        let filtered_len = self.filtered_prs().len();
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if filtered_len > 0 && self.pr_scroll + 1 < filtered_len {
+                    self.pr_scroll += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.pr_scroll = self.pr_scroll.saturating_sub(1);
+            }
+            KeyCode::Char('a') => {
+                self.pr_filter = if self.pr_filter == PrFilter::AuthoredByMe {
+                    PrFilter::All
+                } else {
+                    PrFilter::AuthoredByMe
+                };
+                self.pr_scroll = 0;
+            }
+            KeyCode::Char('r') => {
+                self.pr_filter = if self.pr_filter == PrFilter::ReviewRequested {
+                    PrFilter::All
+                } else {
+                    PrFilter::ReviewRequested
+                };
+                self.pr_scroll = 0;
             }
             _ => {}
         }

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -16,7 +16,6 @@ pub async fn run_git(args: &[&str]) -> Result<String> {
     Ok(String::from_utf8_lossy(&output.stdout).into_owned())
 }
 
-#[allow(dead_code)]
 pub async fn run_gh(args: &[&str]) -> Result<String> {
     let output = Command::new("gh")
         .args(args)

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -20,7 +20,6 @@ pub struct Branch {
 }
 
 #[derive(Debug, Clone, Deserialize)]
-#[allow(dead_code)]
 pub struct PullRequest {
     pub number: u64,
     pub title: String,
@@ -28,9 +27,18 @@ pub struct PullRequest {
     pub author: String,
     pub state: String,
     #[serde(rename = "headRefName")]
+    #[allow(dead_code)]
     pub head_ref: String,
     #[serde(rename = "updatedAt")]
+    #[allow(dead_code)]
     pub updated_at: String,
+    #[serde(rename = "reviewRequests", default)]
+    pub review_requests: Vec<ReviewRequest>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ReviewRequest {
+    pub login: String,
 }
 
 fn deserialize_author<'de, D>(deserializer: D) -> Result<String, D::Error>

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,8 +9,9 @@ use crossterm::event::KeyEventKind;
 
 use crate::app::App;
 use crate::event::{Event, EventHandler};
-use crate::git::command::run_git;
+use crate::git::command::{run_gh, run_git};
 use crate::git::parser::parse_log;
+use crate::git::types::PullRequest;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -36,6 +37,27 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
     {
         app.commits = parse_log(&output);
     }
+
+    // Load GitHub user
+    if let Ok(user) = run_gh(&["api", "user", "--jq", ".login"]).await {
+        app.gh_user = user.trim().to_string();
+    }
+
+    // Load PR list
+    if let Ok(output) = run_gh(&[
+        "pr",
+        "list",
+        "--json",
+        "number,title,author,state,headRefName,updatedAt,reviewRequests",
+        "--limit",
+        "50",
+    ])
+    .await
+        && let Ok(prs) = serde_json::from_str::<Vec<PullRequest>>(&output)
+    {
+        app.pull_requests = prs;
+    }
+    app.prs_loaded = true;
 
     loop {
         terminal.draw(|frame| ui::draw(frame, &app))?;

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -17,7 +17,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
 
     match app.active_view {
         ActiveView::Log => log_view::draw(frame, chunks[0], app),
-        ActiveView::Pr => pr_view::draw(frame, chunks[0]),
+        ActiveView::Pr => pr_view::draw(frame, chunks[0], app),
         ActiveView::Branch => branch_view::draw(frame, chunks[0]),
         ActiveView::Worktree => worktree_view::draw(frame, chunks[0]),
     }

--- a/src/ui/pr_view.rs
+++ b/src/ui/pr_view.rs
@@ -1,11 +1,76 @@
 use ratatui::{
     Frame,
-    layout::Rect,
-    widgets::{Block, Borders, Paragraph},
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState, Paragraph},
 };
 
-pub fn draw(frame: &mut Frame, area: Rect) {
+use crate::app::App;
+
+pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(area);
+
+    // Filter bar
+    let filter_text = format!(
+        " Filter: [{}]  a:Authored  r:Review Requested  j/k:Navigate",
+        app.pr_filter.label()
+    );
+    let filter_bar =
+        Paragraph::new(filter_text).style(Style::default().fg(Color::Cyan).bg(Color::Black));
+    frame.render_widget(filter_bar, chunks[0]);
+
     let block = Block::default().borders(Borders::ALL).title(" PR ");
-    let content = Paragraph::new("PR View").block(block);
-    frame.render_widget(content, area);
+
+    if !app.prs_loaded {
+        let loading = List::new(vec![ListItem::new("Loading...")]).block(block);
+        frame.render_widget(loading, chunks[1]);
+        return;
+    }
+
+    let filtered = app.filtered_prs();
+
+    if filtered.is_empty() {
+        let empty = List::new(vec![ListItem::new("No PRs found")]).block(block);
+        frame.render_widget(empty, chunks[1]);
+        return;
+    }
+
+    let items: Vec<ListItem> = filtered
+        .iter()
+        .map(|pr| {
+            let state_color = match pr.state.as_str() {
+                "OPEN" => Color::Green,
+                "CLOSED" => Color::Red,
+                "MERGED" => Color::Magenta,
+                _ => Color::White,
+            };
+
+            let line = Line::from(vec![
+                Span::styled(
+                    format!("#{:<5} ", pr.number),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(
+                    format!("{:<8} ", pr.state),
+                    Style::default().fg(state_color),
+                ),
+                Span::raw(&pr.title),
+                Span::styled(
+                    format!("  ({})", pr.author),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+
+    let mut state = ListState::default();
+    state.select(Some(app.pr_scroll));
+
+    frame.render_stateful_widget(list, chunks[1], &mut state);
 }


### PR DESCRIPTION
## Summary

Enable the core PR discovery workflow by populating the PR View with live GitHub data. Users can now browse open PRs and filter to find their own or those requesting their review.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Fetch up to 50 PRs via `gh pr list --json ...` on startup and detect the current GitHub user via `gh api user`
- Render PRs in a scrollable list with number (yellow), state (color-coded: green/red/magenta), title, and author
- Add filter bar at the top showing current filter mode and key hints
- Toggle filters: `a` for "authored by me", `r` for "review requested" — resets scroll on toggle
- Add `PrFilter` enum, `filtered_prs()` method, and PR-specific key handling to `App`
- Add `reviewRequests` field to `PullRequest` type for reviewer filtering

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (4 existing parser tests)

## Test Plan

1. `cargo run` → press `2` to switch to PR View
2. Verify PR list shows real PRs from the repository with colored state indicators
3. Press `j`/`k` — highlight moves through the list
4. Press `a` — filters to PRs authored by you; press `a` again to clear
5. Press `r` — filters to PRs requesting your review; press `r` again to clear
6. Press `1` to return to Log View, `q` to quit