### PR TITLE
feat(pr): add PR detail view with markdown rendering

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
-use crate::git::types::{Commit, PullRequest};
+use crate::git::types::{Commit, PrDetail, PullRequest};
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ActiveView {
@@ -52,6 +52,10 @@ pub struct App {
     pub pr_filter: PrFilter,
     pub gh_user: String,
     pub prs_loaded: bool,
+    // PR Detail
+    pub pr_detail: Option<PrDetail>,
+    pub pr_detail_scroll: usize,
+    pub pr_detail_requested: Option<u64>,
 }
 
 impl App {
@@ -66,6 +70,9 @@ impl App {
             pr_filter: PrFilter::default(),
             gh_user: String::new(),
             prs_loaded: false,
+            pr_detail: None,
+            pr_detail_scroll: 0,
+            pr_detail_requested: None,
         }
     }
 
@@ -83,6 +90,12 @@ impl App {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) {
+        // PR detail: Esc/Backspace goes back to list instead of quitting
+        if self.active_view == ActiveView::Pr && self.pr_detail.is_some() {
+            self.handle_pr_detail_key(key.code);
+            return;
+        }
+
         match key.code {
             KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
             KeyCode::Char('1') => self.active_view = ActiveView::Log,
@@ -112,7 +125,8 @@ impl App {
     }
 
     fn handle_pr_key(&mut self, code: KeyCode) {
-        let filtered_len = self.filtered_prs().len();
+        let filtered = self.filtered_prs();
+        let filtered_len = filtered.len();
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
                 if filtered_len > 0 && self.pr_scroll + 1 < filtered_len {
@@ -121,6 +135,12 @@ impl App {
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.pr_scroll = self.pr_scroll.saturating_sub(1);
+            }
+            KeyCode::Enter => {
+                if let Some(pr) = filtered.get(self.pr_scroll) {
+                    self.pr_detail_requested = Some(pr.number);
+                    self.pr_detail_scroll = 0;
+                }
             }
             KeyCode::Char('a') => {
                 self.pr_filter = if self.pr_filter == PrFilter::AuthoredByMe {
@@ -137,6 +157,22 @@ impl App {
                     PrFilter::ReviewRequested
                 };
                 self.pr_scroll = 0;
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_pr_detail_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Esc | KeyCode::Backspace | KeyCode::Char('q') => {
+                self.pr_detail = None;
+                self.pr_detail_scroll = 0;
+            }
+            KeyCode::Char('j') | KeyCode::Down => {
+                self.pr_detail_scroll += 1;
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.pr_detail_scroll = self.pr_detail_scroll.saturating_sub(1);
             }
             _ => {}
         }

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -53,6 +53,23 @@ where
     Ok(author.login)
 }
 
+#[derive(Debug, Clone, Deserialize)]
+pub struct PrDetail {
+    pub number: u64,
+    pub title: String,
+    #[serde(deserialize_with = "deserialize_author")]
+    pub author: String,
+    pub state: String,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub additions: u64,
+    #[serde(default)]
+    pub deletions: u64,
+    #[serde(rename = "headRefName")]
+    pub head_ref: String,
+}
+
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct Worktree {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ use crate::app::App;
 use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git};
 use crate::git::parser::parse_log;
-use crate::git::types::PullRequest;
+use crate::git::types::{PrDetail, PullRequest};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -70,6 +70,23 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
             Some(Event::Tick) => {}
             Some(Event::Key(_)) => {}
             None => break,
+        }
+
+        // Load PR detail if requested
+        if let Some(number) = app.pr_detail_requested.take() {
+            let num_str = number.to_string();
+            if let Ok(output) = run_gh(&[
+                "pr",
+                "view",
+                &num_str,
+                "--json",
+                "number,title,author,state,body,additions,deletions,headRefName",
+            ])
+            .await
+                && let Ok(detail) = serde_json::from_str::<PrDetail>(&output)
+            {
+                app.pr_detail = Some(detail);
+            }
         }
 
         if app.should_quit {

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -1,0 +1,94 @@
+use ratatui::{
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+};
+
+/// Convert markdown text to styled ratatui Lines.
+/// Supports: headings (#), bold (**), inline code (`), unordered lists (- ), code blocks (```).
+pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    let mut in_code_block = false;
+
+    for raw_line in text.lines() {
+        if raw_line.starts_with("```") {
+            in_code_block = !in_code_block;
+            continue;
+        }
+
+        if in_code_block {
+            lines.push(Line::from(Span::styled(
+                format!("  {raw_line}"),
+                Style::default().fg(Color::Green),
+            )));
+            continue;
+        }
+
+        if let Some(heading) = raw_line.strip_prefix("### ") {
+            lines.push(Line::from(Span::styled(
+                format!("   {heading}"),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )));
+        } else if let Some(heading) = raw_line.strip_prefix("## ") {
+            lines.push(Line::from(Span::styled(
+                format!("  {heading}"),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )));
+        } else if let Some(heading) = raw_line.strip_prefix("# ") {
+            lines.push(Line::from(Span::styled(
+                heading.to_string(),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            )));
+        } else if let Some(item) = raw_line.strip_prefix("- ") {
+            lines.push(Line::from(vec![
+                Span::styled("  • ", Style::default().fg(Color::Yellow)),
+                Span::raw(render_inline(item)),
+            ]));
+        } else if let Some(item) = raw_line.strip_prefix("* ") {
+            lines.push(Line::from(vec![
+                Span::styled("  • ", Style::default().fg(Color::Yellow)),
+                Span::raw(render_inline(item)),
+            ]));
+        } else if raw_line.is_empty() {
+            lines.push(Line::from(""));
+        } else {
+            lines.push(Line::from(render_inline(raw_line)));
+        }
+    }
+
+    lines
+}
+
+/// Simple inline rendering: strip markdown syntax for plain text display.
+/// A full inline parser with mixed spans would be more complex; this is pragmatic.
+fn render_inline(text: &str) -> String {
+    text.replace("**", "").replace('`', "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_heading() {
+        let lines = render_markdown("# Title\n## Subtitle\n### Section");
+        assert_eq!(lines.len(), 3);
+    }
+
+    #[test]
+    fn test_list() {
+        let lines = render_markdown("- item one\n- item two");
+        assert_eq!(lines.len(), 2);
+    }
+
+    #[test]
+    fn test_code_block() {
+        let lines = render_markdown("```\nlet x = 1;\n```");
+        assert_eq!(lines.len(), 1); // only the code line, ``` markers are skipped
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,7 @@
 mod branch_view;
 mod log_view;
+pub mod markdown;
+mod pr_detail;
 mod pr_view;
 mod worktree_view;
 

--- a/src/ui/pr_detail.rs
+++ b/src/ui/pr_detail.rs
@@ -1,0 +1,81 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph, Wrap},
+};
+
+use crate::git::types::PrDetail;
+use crate::ui::markdown::render_markdown;
+
+pub fn draw(frame: &mut Frame, area: Rect, detail: &PrDetail, scroll: usize) {
+    let chunks = Layout::vertical([Constraint::Length(4), Constraint::Min(1)]).split(area);
+
+    // Header: metadata
+    let header_lines = vec![
+        Line::from(vec![
+            Span::styled(
+                format!("#{} ", detail.number),
+                Style::default().fg(Color::Yellow),
+            ),
+            Span::styled(&detail.title, Style::default().add_modifier(Modifier::BOLD)),
+        ]),
+        Line::from(vec![
+            Span::styled("Author: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&detail.author),
+            Span::raw("  "),
+            Span::styled("State: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                &detail.state,
+                Style::default().fg(match detail.state.as_str() {
+                    "OPEN" => Color::Green,
+                    "CLOSED" => Color::Red,
+                    "MERGED" => Color::Magenta,
+                    _ => Color::White,
+                }),
+            ),
+            Span::raw("  "),
+            Span::styled("Branch: ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&detail.head_ref),
+        ]),
+        Line::from(vec![
+            Span::styled(
+                format!("+{}", detail.additions),
+                Style::default().fg(Color::Green),
+            ),
+            Span::raw(" / "),
+            Span::styled(
+                format!("-{}", detail.deletions),
+                Style::default().fg(Color::Red),
+            ),
+        ]),
+    ];
+
+    let header = Paragraph::new(header_lines).block(
+        Block::default()
+            .borders(Borders::BOTTOM)
+            .title(" PR Detail "),
+    );
+    frame.render_widget(header, chunks[0]);
+
+    // Body: markdown
+    let body_lines = if detail.body.is_empty() {
+        vec![Line::from(Span::styled(
+            "(no description)",
+            Style::default().fg(Color::DarkGray),
+        ))]
+    } else {
+        render_markdown(&detail.body)
+    };
+
+    let body = Paragraph::new(body_lines)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title(" Description (j/k:scroll  Esc:back) "),
+        )
+        .wrap(Wrap { trim: false })
+        .scroll((scroll as u16, 0));
+    frame.render_widget(body, chunks[1]);
+}

--- a/src/ui/pr_view.rs
+++ b/src/ui/pr_view.rs
@@ -7,8 +7,15 @@ use ratatui::{
 };
 
 use crate::app::App;
+use crate::ui::pr_detail;
 
 pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
+    // If a PR detail is loaded, show the detail view instead
+    if let Some(detail) = &app.pr_detail {
+        pr_detail::draw(frame, area, detail, app.pr_detail_scroll);
+        return;
+    }
+
     let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(area);
 
     // Filter bar


### PR DESCRIPTION
## Summary

Complete the PR discovery workflow by adding a detail view. Users can now select a PR from the list and read its full description with basic markdown formatting — the key step before deciding to start a code review.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add PR detail sub-view showing title, author, state, branch, +/- stats, and body
- Implement simple markdown renderer supporting headings (#), bold (**), lists (- /*), and code blocks (```)
- Press `Enter` on PR list to fetch detail via `gh pr view --json` and display it
- Press `Esc`/`Backspace`/`q` in detail view to return to the list (not quit the app)
- Scroll the PR body with `j`/`k`
- Add `PrDetail` type with serde deserialization
- Add 3 unit tests for markdown rendering

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (7 tests: 4 parser + 3 markdown)

## Test Plan

1. `cargo run` → `2` → PR list → select a PR → `Enter`
2. Detail view shows: PR number, title (bold), author, state (colored), branch, +/- stats
3. Body renders with markdown formatting (headings in cyan/bold, lists with bullets, code in green)
4. `j`/`k` scrolls the body
5. `Esc` returns to the PR list
6. `q` in the PR list quits the app