### PR TITLE
feat(worktree): add worktree list with delete and confirmation dialog

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
-use crate::git::types::{Commit, PrDetail, PullRequest};
+use crate::git::types::{Commit, PrDetail, PullRequest, Worktree};
+use crate::ui::confirm_dialog::ConfirmDialog;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ActiveView {
@@ -56,6 +57,12 @@ pub struct App {
     pub pr_detail: Option<PrDetail>,
     pub pr_detail_scroll: usize,
     pub pr_detail_requested: Option<u64>,
+    // Worktree View
+    pub worktrees: Vec<Worktree>,
+    pub wt_scroll: usize,
+    pub wt_loaded: bool,
+    pub confirm_dialog: Option<ConfirmDialog>,
+    pub wt_delete_requested: Option<String>,
 }
 
 impl App {
@@ -73,6 +80,11 @@ impl App {
             pr_detail: None,
             pr_detail_scroll: 0,
             pr_detail_requested: None,
+            worktrees: Vec::new(),
+            wt_scroll: 0,
+            wt_loaded: false,
+            confirm_dialog: None,
+            wt_delete_requested: None,
         }
     }
 
@@ -90,6 +102,12 @@ impl App {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) {
+        // Confirm dialog takes priority
+        if self.confirm_dialog.is_some() {
+            self.handle_confirm_key(key.code);
+            return;
+        }
+
         // PR detail: Esc/Backspace goes back to list instead of quitting
         if self.active_view == ActiveView::Pr && self.pr_detail.is_some() {
             self.handle_pr_detail_key(key.code);
@@ -105,6 +123,7 @@ impl App {
             _ => match self.active_view {
                 ActiveView::Log => self.handle_log_key(key.code),
                 ActiveView::Pr => self.handle_pr_key(key.code),
+                ActiveView::Worktree => self.handle_wt_key(key.code),
                 _ => {}
             },
         }
@@ -173,6 +192,49 @@ impl App {
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.pr_detail_scroll = self.pr_detail_scroll.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_wt_key(&mut self, code: KeyCode) {
+        let len = self.worktrees.len();
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if len > 0 && self.wt_scroll + 1 < len {
+                    self.wt_scroll += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.wt_scroll = self.wt_scroll.saturating_sub(1);
+            }
+            KeyCode::Char('d') => {
+                if let Some(wt) = self.worktrees.get(self.wt_scroll) {
+                    // Don't allow deleting the main worktree (first one)
+                    if self.wt_scroll == 0 {
+                        return;
+                    }
+                    self.confirm_dialog = Some(ConfirmDialog::new(
+                        "Delete Worktree",
+                        format!("Remove worktree at {}?", wt.path),
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_confirm_key(&mut self, code: KeyCode) {
+        match code {
+            KeyCode::Char('y') => {
+                // Execute the pending delete action
+                if let Some(wt) = self.worktrees.get(self.wt_scroll) {
+                    self.wt_delete_requested = Some(wt.path.clone());
+                }
+                self.confirm_dialog = None;
+            }
+            KeyCode::Char('n') | KeyCode::Esc => {
+                self.confirm_dialog = None;
             }
             _ => {}
         }

--- a/src/git/parser.rs
+++ b/src/git/parser.rs
@@ -84,7 +84,6 @@ pub fn parse_branches(output: &str, merged_output: &str) -> Vec<Branch> {
 }
 
 /// Parse output of `git worktree list --porcelain`
-#[allow(dead_code)]
 pub fn parse_worktrees(output: &str) -> Vec<Worktree> {
     let mut worktrees = Vec::new();
     let mut path = String::new();

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -71,7 +71,6 @@ pub struct PrDetail {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Worktree {
     pub path: String,
     pub head: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crossterm::event::KeyEventKind;
 use crate::app::App;
 use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git};
-use crate::git::parser::parse_log;
+use crate::git::parser::{parse_log, parse_worktrees};
 use crate::git::types::{PrDetail, PullRequest};
 
 #[tokio::main]
@@ -59,6 +59,12 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
     }
     app.prs_loaded = true;
 
+    // Load worktrees
+    if let Ok(output) = run_git(&["worktree", "list", "--porcelain"]).await {
+        app.worktrees = parse_worktrees(&output);
+    }
+    app.wt_loaded = true;
+
     loop {
         terminal.draw(|frame| ui::draw(frame, &app))?;
 
@@ -70,6 +76,18 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
             Some(Event::Tick) => {}
             Some(Event::Key(_)) => {}
             None => break,
+        }
+
+        // Delete worktree if requested
+        if let Some(path) = app.wt_delete_requested.take() {
+            let _ = run_git(&["worktree", "remove", &path]).await;
+            // Refresh worktree list
+            if let Ok(output) = run_git(&["worktree", "list", "--porcelain"]).await {
+                app.worktrees = parse_worktrees(&output);
+                if app.wt_scroll >= app.worktrees.len() && app.wt_scroll > 0 {
+                    app.wt_scroll -= 1;
+                }
+            }
         }
 
         // Load PR detail if requested

--- a/src/ui/confirm_dialog.rs
+++ b/src/ui/confirm_dialog.rs
@@ -1,0 +1,70 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+#[derive(Debug, Clone)]
+pub struct ConfirmDialog {
+    pub title: String,
+    pub message: String,
+}
+
+impl ConfirmDialog {
+    pub fn new(title: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            message: message.into(),
+        }
+    }
+}
+
+pub fn draw(frame: &mut Frame, dialog: &ConfirmDialog) {
+    let area = centered_rect(50, 7, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::raw(&dialog.message)),
+        Line::from(""),
+        Line::from(vec![
+            Span::styled(
+                " y ",
+                Style::default()
+                    .fg(Color::White)
+                    .bg(Color::Red)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" Yes  "),
+            Span::styled(
+                " n ",
+                Style::default()
+                    .fg(Color::White)
+                    .bg(Color::DarkGray)
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::raw(" No"),
+        ]),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" {} ", dialog.title))
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .split(area);
+    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
+        .flex(Flex::Center)
+        .split(vertical[0]);
+    horizontal[0]
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,4 +1,5 @@
 mod branch_view;
+pub mod confirm_dialog;
 mod log_view;
 pub mod markdown;
 mod pr_detail;
@@ -21,7 +22,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
         ActiveView::Log => log_view::draw(frame, chunks[0], app),
         ActiveView::Pr => pr_view::draw(frame, chunks[0], app),
         ActiveView::Branch => branch_view::draw(frame, chunks[0]),
-        ActiveView::Worktree => worktree_view::draw(frame, chunks[0]),
+        ActiveView::Worktree => worktree_view::draw(frame, chunks[0], app),
     }
 
     let status = Paragraph::new(format!(

--- a/src/ui/worktree_view.rs
+++ b/src/ui/worktree_view.rs
@@ -1,11 +1,65 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    widgets::{Block, Borders, Paragraph},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState},
 };
 
-pub fn draw(frame: &mut Frame, area: Rect) {
-    let block = Block::default().borders(Borders::ALL).title(" Worktree ");
-    let content = Paragraph::new("Worktree View").block(block);
-    frame.render_widget(content, area);
+use crate::app::App;
+use crate::ui::confirm_dialog;
+
+pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Worktree (d:delete  j/k:navigate) ");
+
+    if !app.wt_loaded {
+        let loading = List::new(vec![ListItem::new("Loading...")]).block(block);
+        frame.render_widget(loading, area);
+        return;
+    }
+
+    if app.worktrees.is_empty() {
+        let empty = List::new(vec![ListItem::new("No worktrees found")]).block(block);
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = app
+        .worktrees
+        .iter()
+        .map(|wt| {
+            let branch_str =
+                wt.branch
+                    .as_deref()
+                    .unwrap_or(if wt.is_bare { "(bare)" } else { "(detached)" });
+            let line = Line::from(vec![
+                Span::styled(
+                    format!("{:<20} ", branch_str),
+                    Style::default().fg(Color::Cyan),
+                ),
+                Span::styled(
+                    format!("{} ", &wt.head[..wt.head.len().min(8)]),
+                    Style::default().fg(Color::Yellow),
+                ),
+                Span::styled(&wt.path, Style::default().fg(Color::White)),
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+
+    let mut state = ListState::default();
+    state.select(Some(app.wt_scroll));
+
+    frame.render_stateful_widget(list, area, &mut state);
+
+    // Draw confirm dialog on top if active
+    if let Some(dialog) = &app.confirm_dialog {
+        confirm_dialog::draw(frame, dialog);
+    }
 }


### PR DESCRIPTION
## Summary

Implement the Worktree View for managing git worktrees, and introduce a reusable confirmation dialog component for destructive operations. Users can now browse, inspect, and safely delete worktrees.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Display worktrees in a scrollable list showing branch name, HEAD (short hash), and filesystem path
- Add `d` key to trigger deletion with a centered y/n confirmation dialog overlay
- Protect the main worktree (index 0) from deletion
- Refresh the worktree list after successful deletion, adjusting scroll position
- Add reusable `ConfirmDialog` component (`src/ui/confirm_dialog.rs`) for use by Branch View (PR 9)
- Remove `#[allow(dead_code)]` from `Worktree` type and `parse_worktrees` parser (now in use)

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (7 existing tests)

## Test Plan

1. `cargo run` → `4` to switch to Worktree View
2. Verify worktree list shows at least the main worktree with branch, HEAD hash, and path
3. `j`/`k` — navigate the list
4. Select a non-main worktree → `d` — confirmation dialog appears
5. `n` or `Esc` — dialog dismisses, no deletion
6. `d` again → `y` — worktree is deleted, list refreshes
7. Attempting `d` on the main worktree (first entry) does nothing
8. `1`/`2`/`3` — switch to other views, `q` to quit