### PR TITLE
feat(pr): create worktree from PR detail for review

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -2,6 +2,7 @@ use crossterm::event::{KeyCode, KeyEvent};
 
 use crate::git::types::{Commit, PrDetail, PullRequest, Worktree};
 use crate::ui::confirm_dialog::ConfirmDialog;
+use crate::ui::notification::Notification;
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub enum ActiveView {
@@ -63,6 +64,10 @@ pub struct App {
     pub wt_loaded: bool,
     pub confirm_dialog: Option<ConfirmDialog>,
     pub wt_delete_requested: Option<String>,
+    // Worktree creation from PR
+    pub wt_create_requested: Option<(String, u64)>, // (head_ref, pr_number)
+    // Notification
+    pub notification: Option<Notification>,
 }
 
 impl App {
@@ -85,6 +90,8 @@ impl App {
             wt_loaded: false,
             confirm_dialog: None,
             wt_delete_requested: None,
+            wt_create_requested: None,
+            notification: None,
         }
     }
 
@@ -182,6 +189,9 @@ impl App {
     }
 
     fn handle_pr_detail_key(&mut self, code: KeyCode) {
+        // Clear notification on any key press
+        self.notification = None;
+
         match code {
             KeyCode::Esc | KeyCode::Backspace | KeyCode::Char('q') => {
                 self.pr_detail = None;
@@ -192,6 +202,11 @@ impl App {
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.pr_detail_scroll = self.pr_detail_scroll.saturating_sub(1);
+            }
+            KeyCode::Char('w') => {
+                if let Some(detail) = &self.pr_detail {
+                    self.wt_create_requested = Some((detail.head_ref.clone(), detail.number));
+                }
             }
             _ => {}
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git};
 use crate::git::parser::{parse_log, parse_worktrees};
 use crate::git::types::{PrDetail, PullRequest};
+use crate::ui::notification::Notification;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -86,6 +87,39 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
                 app.worktrees = parse_worktrees(&output);
                 if app.wt_scroll >= app.worktrees.len() && app.wt_scroll > 0 {
                     app.wt_scroll -= 1;
+                }
+            }
+        }
+
+        // Create worktree from PR if requested
+        if let Some((head_ref, pr_number)) = app.wt_create_requested.take() {
+            let remote_ref = format!("origin/{head_ref}");
+            let wt_path = format!("../gct-review-{pr_number}");
+
+            // Fetch the branch first
+            match run_git(&["fetch", "origin", &head_ref]).await {
+                Ok(_) => {
+                    // Create the worktree
+                    match run_git(&["worktree", "add", &wt_path, &remote_ref]).await {
+                        Ok(_) => {
+                            app.notification = Some(Notification::success(format!(
+                                "Worktree created: {wt_path}"
+                            )));
+                            // Refresh worktree list
+                            if let Ok(output) = run_git(&["worktree", "list", "--porcelain"]).await
+                            {
+                                app.worktrees = parse_worktrees(&output);
+                            }
+                        }
+                        Err(e) => {
+                            app.notification = Some(Notification::error(format!(
+                                "Failed to create worktree: {e}"
+                            )));
+                        }
+                    }
+                }
+                Err(e) => {
+                    app.notification = Some(Notification::error(format!("Failed to fetch: {e}")));
                 }
             }
         }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -2,6 +2,7 @@ mod branch_view;
 pub mod confirm_dialog;
 mod log_view;
 pub mod markdown;
+pub mod notification;
 mod pr_detail;
 mod pr_view;
 mod worktree_view;
@@ -31,4 +32,9 @@ pub fn draw(frame: &mut Frame, app: &App) {
     ))
     .style(Style::default().fg(Color::White).bg(Color::DarkGray));
     frame.render_widget(status, chunks[1]);
+
+    // Notification overlay
+    if let Some(notif) = &app.notification {
+        notification::draw(frame, notif);
+    }
 }

--- a/src/ui/notification.rs
+++ b/src/ui/notification.rs
@@ -1,0 +1,59 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Color, Style},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
+
+#[derive(Debug, Clone)]
+pub struct Notification {
+    pub message: String,
+    pub is_error: bool,
+}
+
+impl Notification {
+    pub fn success(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            is_error: false,
+        }
+    }
+
+    pub fn error(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            is_error: true,
+        }
+    }
+}
+
+pub fn draw(frame: &mut Frame, notification: &Notification) {
+    let area = bottom_rect(80, 3, frame.area());
+
+    frame.render_widget(Clear, area);
+
+    let color = if notification.is_error {
+        Color::Red
+    } else {
+        Color::Green
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(color));
+
+    let paragraph = Paragraph::new(notification.message.as_str())
+        .block(block)
+        .style(Style::default().fg(color))
+        .wrap(Wrap { trim: false });
+
+    frame.render_widget(paragraph, area);
+}
+
+fn bottom_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Min(0), Constraint::Length(height)]).split(area);
+    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
+        .flex(Flex::Center)
+        .split(vertical[1]);
+    horizontal[0]
+}

--- a/src/ui/pr_detail.rs
+++ b/src/ui/pr_detail.rs
@@ -73,7 +73,7 @@ pub fn draw(frame: &mut Frame, area: Rect, detail: &PrDetail, scroll: usize) {
         .block(
             Block::default()
                 .borders(Borders::ALL)
-                .title(" Description (j/k:scroll  Esc:back) "),
+                .title(" Description (j/k:scroll  w:worktree  Esc:back) "),
         )
         .wrap(Wrap { trim: false })
         .scroll((scroll as u16, 0));


### PR DESCRIPTION
## Summary

Complete the core review workflow by enabling one-key worktree creation from the PR detail view. Users can now go from browsing PRs to having a checkout ready for code review in a single keypress.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Press `w` in PR detail view to `git fetch origin <branch>` then `git worktree add ../gct-review-<number> origin/<branch>`
- Add `Notification` component for transient success/error messages at the bottom of the screen
- Notifications dismiss on the next key press in the detail view
- Worktree list auto-refreshes after successful creation
- Error messages shown when fetch fails or worktree already exists

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (7 existing tests)

## Test Plan

1. `cargo run` → `2` → select a PR → `Enter` → detail view
2. Press `w` — green notification shows the created worktree path
3. Press `4` to switch to Worktree View — new worktree appears in the list
4. Go back to PR detail → `w` again — red error notification (already exists)
5. Notification clears on next key press