### PR TITLE
feat(branch): add branch list with merged status and batch delete

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,8 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
-use crate::git::types::{Commit, PrDetail, PullRequest, Worktree};
+use std::collections::HashSet;
+
+use crate::git::types::{Branch, Commit, PrDetail, PullRequest, Worktree};
 use crate::ui::confirm_dialog::ConfirmDialog;
 use crate::ui::notification::Notification;
 
@@ -66,6 +68,12 @@ pub struct App {
     pub wt_delete_requested: Option<String>,
     // Worktree creation from PR
     pub wt_create_requested: Option<(String, u64)>, // (head_ref, pr_number)
+    // Branch View
+    pub branches: Vec<Branch>,
+    pub branch_scroll: usize,
+    pub branch_selected: HashSet<String>,
+    pub branches_loaded: bool,
+    pub branch_delete_requested: bool,
     // Notification
     pub notification: Option<Notification>,
 }
@@ -91,6 +99,11 @@ impl App {
             confirm_dialog: None,
             wt_delete_requested: None,
             wt_create_requested: None,
+            branches: Vec::new(),
+            branch_scroll: 0,
+            branch_selected: HashSet::new(),
+            branches_loaded: false,
+            branch_delete_requested: false,
             notification: None,
         }
     }
@@ -130,8 +143,8 @@ impl App {
             _ => match self.active_view {
                 ActiveView::Log => self.handle_log_key(key.code),
                 ActiveView::Pr => self.handle_pr_key(key.code),
+                ActiveView::Branch => self.handle_branch_key(key.code),
                 ActiveView::Worktree => self.handle_wt_key(key.code),
-                _ => {}
             },
         }
     }
@@ -239,12 +252,75 @@ impl App {
         }
     }
 
+    fn handle_branch_key(&mut self, code: KeyCode) {
+        let len = self.branches.len();
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if len > 0 && self.branch_scroll + 1 < len {
+                    self.branch_scroll += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.branch_scroll = self.branch_scroll.saturating_sub(1);
+            }
+            KeyCode::Char(' ') => {
+                if let Some(branch) = self.branches.get(self.branch_scroll) {
+                    // Don't allow selecting current branch or main/master
+                    if branch.is_current || Self::is_protected_branch(&branch.name) {
+                        return;
+                    }
+                    let name = branch.name.clone();
+                    if self.branch_selected.contains(&name) {
+                        self.branch_selected.remove(&name);
+                    } else {
+                        self.branch_selected.insert(name);
+                    }
+                }
+            }
+            KeyCode::Char('a') => {
+                // Select all merged branches (except current and protected)
+                for branch in &self.branches {
+                    if branch.is_merged
+                        && !branch.is_current
+                        && !Self::is_protected_branch(&branch.name)
+                    {
+                        self.branch_selected.insert(branch.name.clone());
+                    }
+                }
+            }
+            KeyCode::Char('d') => {
+                if !self.branch_selected.is_empty() {
+                    let count = self.branch_selected.len();
+                    let names: Vec<&str> =
+                        self.branch_selected.iter().map(|s| s.as_str()).collect();
+                    let preview = if count <= 3 {
+                        names.join(", ")
+                    } else {
+                        format!("{} and {} more", names[..2].join(", "), count - 2)
+                    };
+                    self.confirm_dialog = Some(ConfirmDialog::new(
+                        "Delete Branches",
+                        format!("Delete {count} branch(es)? [{preview}]"),
+                    ));
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn handle_confirm_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('y') => {
-                // Execute the pending delete action
-                if let Some(wt) = self.worktrees.get(self.wt_scroll) {
-                    self.wt_delete_requested = Some(wt.path.clone());
+                match self.active_view {
+                    ActiveView::Worktree => {
+                        if let Some(wt) = self.worktrees.get(self.wt_scroll) {
+                            self.wt_delete_requested = Some(wt.path.clone());
+                        }
+                    }
+                    ActiveView::Branch => {
+                        self.branch_delete_requested = true;
+                    }
+                    _ => {}
                 }
                 self.confirm_dialog = None;
             }
@@ -253,5 +329,9 @@ impl App {
             }
             _ => {}
         }
+    }
+
+    fn is_protected_branch(name: &str) -> bool {
+        matches!(name, "main" | "master")
     }
 }

--- a/src/git/parser.rs
+++ b/src/git/parser.rs
@@ -36,7 +36,6 @@ pub fn parse_log(output: &str) -> Vec<Commit> {
 }
 
 /// Parse output of `git branch -vv`
-#[allow(dead_code)]
 pub fn parse_branches(output: &str, merged_output: &str) -> Vec<Branch> {
     let merged_names: Vec<&str> = merged_output
         .lines()

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -11,7 +11,6 @@ pub struct Commit {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct Branch {
     pub name: String,
     pub is_current: bool,

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crossterm::event::KeyEventKind;
 use crate::app::App;
 use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git};
-use crate::git::parser::{parse_log, parse_worktrees};
+use crate::git::parser::{parse_branches, parse_log, parse_worktrees};
 use crate::git::types::{PrDetail, PullRequest};
 use crate::ui::notification::Notification;
 
@@ -65,6 +65,10 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
         app.worktrees = parse_worktrees(&output);
     }
     app.wt_loaded = true;
+
+    // Load branches
+    load_branches(&mut app).await;
+    app.branches_loaded = true;
 
     loop {
         terminal.draw(|frame| ui::draw(frame, &app))?;
@@ -124,6 +128,20 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
             }
         }
 
+        // Delete selected branches if requested
+        if app.branch_delete_requested {
+            app.branch_delete_requested = false;
+            let selected: Vec<String> = app.branch_selected.drain().collect();
+            for name in &selected {
+                let _ = run_git(&["branch", "-d", name]).await;
+            }
+            // Refresh branch list
+            load_branches(&mut app).await;
+            if app.branch_scroll >= app.branches.len() && app.branch_scroll > 0 {
+                app.branch_scroll = app.branches.len().saturating_sub(1);
+            }
+        }
+
         // Load PR detail if requested
         if let Some(number) = app.pr_detail_requested.take() {
             let num_str = number.to_string();
@@ -147,4 +165,10 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+async fn load_branches(app: &mut App) {
+    let branch_output = run_git(&["branch", "-vv"]).await.unwrap_or_default();
+    let merged_output = run_git(&["branch", "--merged"]).await.unwrap_or_default();
+    app.branches = parse_branches(&branch_output, &merged_output);
 }

--- a/src/ui/branch_view.rs
+++ b/src/ui/branch_view.rs
@@ -1,11 +1,87 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    widgets::{Block, Borders, Paragraph},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState},
 };
 
-pub fn draw(frame: &mut Frame, area: Rect) {
-    let block = Block::default().borders(Borders::ALL).title(" Branch ");
-    let content = Paragraph::new("Branch View").block(block);
-    frame.render_widget(content, area);
+use crate::app::App;
+use crate::ui::confirm_dialog;
+
+pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Branch (Space:select  a:select-merged  d:delete  j/k:navigate) ");
+
+    if !app.branches_loaded {
+        let loading = List::new(vec![ListItem::new("Loading...")]).block(block);
+        frame.render_widget(loading, area);
+        return;
+    }
+
+    if app.branches.is_empty() {
+        let empty = List::new(vec![ListItem::new("No branches found")]).block(block);
+        frame.render_widget(empty, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = app
+        .branches
+        .iter()
+        .map(|branch| {
+            let checkbox = if app.branch_selected.contains(&branch.name) {
+                "[x] "
+            } else {
+                "[ ] "
+            };
+
+            let current_marker = if branch.is_current { "* " } else { "  " };
+
+            let name_style = if branch.is_merged && !branch.is_current {
+                Style::default().fg(Color::Yellow)
+            } else if branch.is_current {
+                Style::default()
+                    .fg(Color::Green)
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(Color::White)
+            };
+
+            let merged_tag = if branch.is_merged {
+                Span::styled(" [merged]", Style::default().fg(Color::Yellow))
+            } else {
+                Span::raw("")
+            };
+
+            let upstream_info = branch
+                .upstream
+                .as_ref()
+                .map(|u| Span::styled(format!(" → {u}"), Style::default().fg(Color::DarkGray)))
+                .unwrap_or_else(|| Span::raw(""));
+
+            let line = Line::from(vec![
+                Span::styled(checkbox, Style::default().fg(Color::Cyan)),
+                Span::raw(current_marker),
+                Span::styled(&branch.name, name_style),
+                merged_tag,
+                upstream_info,
+            ]);
+            ListItem::new(line)
+        })
+        .collect();
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+
+    let mut state = ListState::default();
+    state.select(Some(app.branch_scroll));
+
+    frame.render_stateful_widget(list, area, &mut state);
+
+    // Draw confirm dialog on top if active
+    if let Some(dialog) = &app.confirm_dialog {
+        confirm_dialog::draw(frame, dialog);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -22,7 +22,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
     match app.active_view {
         ActiveView::Log => log_view::draw(frame, chunks[0], app),
         ActiveView::Pr => pr_view::draw(frame, chunks[0], app),
-        ActiveView::Branch => branch_view::draw(frame, chunks[0]),
+        ActiveView::Branch => branch_view::draw(frame, chunks[0], app),
         ActiveView::Worktree => worktree_view::draw(frame, chunks[0], app),
     }
 


### PR DESCRIPTION
## Summary

Complete the branch cleanup workflow by implementing the Branch View. Users can now visualize which local branches are already merged and clean them up with checkbox multi-select and batch deletion — the final piece of the spec's "Ground Control" feature.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Display local branches in a scrollable list with checkbox, current marker (*), name, [merged] tag, and upstream tracking info
- Merged branches highlighted in yellow for easy identification
- `Space` toggles checkbox selection (current/main/master protected)
- `a` selects all merged branches at once
- `d` opens confirmation dialog listing selected branches, `y` executes `git branch -d` for each
- Branch list refreshes after deletion with scroll position adjustment
- Reuses `ConfirmDialog` from PR 7, extended `handle_confirm_key` to dispatch by active view
- Removed all remaining `#[allow(dead_code)]` from `Branch` type and `parse_branches` parser

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (7 existing tests)

## Test Plan

1. `cargo run` → `3` to switch to Branch View
2. Verify branch list shows with current branch marked `*` in green, merged branches in yellow with `[merged]` tag
3. `j`/`k` — navigate the list
4. `Space` on a non-protected branch — checkbox toggles `[x]`/`[ ]`
5. `Space` on main/master or current branch — nothing happens (protected)
6. `a` — all merged branches get selected
7. `d` with selections — confirmation dialog shows branch count and names
8. `n` — cancels, `y` — deletes branches, list refreshes
9. Other views and `q` work normally