### PR TITLE
feat: add startup checks and keyboard help overlay

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -76,6 +76,8 @@ pub struct App {
     pub branch_delete_requested: bool,
     // Notification
     pub notification: Option<Notification>,
+    // Help
+    pub show_help: bool,
 }
 
 impl App {
@@ -105,6 +107,7 @@ impl App {
             branches_loaded: false,
             branch_delete_requested: false,
             notification: None,
+            show_help: false,
         }
     }
 
@@ -122,6 +125,17 @@ impl App {
     }
 
     pub fn handle_key(&mut self, key: KeyEvent) {
+        // Help overlay takes priority
+        if self.show_help {
+            match key.code {
+                KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
+                    self.show_help = false;
+                }
+                _ => {}
+            }
+            return;
+        }
+
         // Confirm dialog takes priority
         if self.confirm_dialog.is_some() {
             self.handle_confirm_key(key.code);
@@ -135,6 +149,7 @@ impl App {
         }
 
         match key.code {
+            KeyCode::Char('?') => self.show_help = true,
             KeyCode::Char('q') | KeyCode::Esc => self.should_quit = true,
             KeyCode::Char('1') => self.active_view = ActiveView::Log,
             KeyCode::Char('2') => self.active_view = ActiveView::Pr,

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod event;
 mod git;
 mod ui;
 
+use std::process;
 use std::time::Duration;
 
 use crossterm::event::KeyEventKind;
@@ -16,10 +17,33 @@ use crate::ui::notification::Notification;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Startup checks before initializing TUI
+    check_prerequisites().await;
+
     let mut terminal = ratatui::init();
     let result = run(&mut terminal).await;
     ratatui::restore();
     result
+}
+
+async fn check_prerequisites() {
+    if run_git(&["--version"]).await.is_err() {
+        eprintln!("Error: git is not installed or not in PATH.");
+        eprintln!("Please install git: https://git-scm.com/");
+        process::exit(1);
+    }
+
+    if run_gh(&["--version"]).await.is_err() {
+        eprintln!("Error: gh (GitHub CLI) is not installed or not in PATH.");
+        eprintln!("Please install gh: https://cli.github.com/");
+        process::exit(1);
+    }
+
+    if run_git(&["rev-parse", "--git-dir"]).await.is_err() {
+        eprintln!("Error: not a git repository.");
+        eprintln!("Please run gct from inside a git repository.");
+        process::exit(1);
+    }
 }
 
 async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -1,0 +1,89 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+pub fn draw(frame: &mut Frame) {
+    let area = centered_rect(60, 24, frame.area());
+    frame.render_widget(Clear, area);
+
+    let lines = vec![
+        Line::from(Span::styled(
+            "Git Control Tower — Keyboard Shortcuts",
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(""),
+        section("Global"),
+        key_line("1", "Log View"),
+        key_line("2", "PR View"),
+        key_line("3", "Branch View"),
+        key_line("4", "Worktree View"),
+        key_line("?", "Toggle this help"),
+        key_line("q / Esc", "Quit"),
+        Line::from(""),
+        section("Log View"),
+        key_line("j/k ↑/↓", "Navigate commits"),
+        Line::from(""),
+        section("PR View"),
+        key_line("j/k ↑/↓", "Navigate PRs"),
+        key_line("a", "Filter: authored by me"),
+        key_line("r", "Filter: review requested"),
+        key_line("Enter", "View PR detail"),
+        key_line("w", "Create worktree (in detail)"),
+        key_line("Esc", "Back to list (in detail)"),
+        Line::from(""),
+        section("Branch View"),
+        key_line("j/k ↑/↓", "Navigate branches"),
+        key_line("Space", "Toggle selection"),
+        key_line("a", "Select all merged"),
+        key_line("d", "Delete selected"),
+        Line::from(""),
+        section("Worktree View"),
+        key_line("j/k ↑/↓", "Navigate worktrees"),
+        key_line("d", "Delete worktree"),
+        Line::from(""),
+        Line::from(Span::styled(
+            "Press ? or Esc to close",
+            Style::default().fg(Color::DarkGray),
+        )),
+    ];
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Help ")
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn section(name: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("  {name}"),
+        Style::default()
+            .fg(Color::Yellow)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn key_line(key: &str, desc: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("    {key:<14}"), Style::default().fg(Color::Green)),
+        Span::raw(desc.to_string()),
+    ])
+}
+
+fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .split(area);
+    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
+        .flex(Flex::Center)
+        .split(vertical[0]);
+    horizontal[0]
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,5 +1,6 @@
 mod branch_view;
 pub mod confirm_dialog;
+mod help_overlay;
 mod log_view;
 pub mod markdown;
 pub mod notification;
@@ -27,7 +28,7 @@ pub fn draw(frame: &mut Frame, app: &App) {
     }
 
     let status = Paragraph::new(format!(
-        " [{}]  1:Log  2:PR  3:Branch  4:Worktree  q:Quit",
+        " [{}]  1:Log  2:PR  3:Branch  4:Worktree  ?:Help  q:Quit",
         app.active_view.label()
     ))
     .style(Style::default().fg(Color::White).bg(Color::DarkGray));
@@ -36,5 +37,10 @@ pub fn draw(frame: &mut Frame, app: &App) {
     // Notification overlay
     if let Some(notif) = &app.notification {
         notification::draw(frame, notif);
+    }
+
+    // Help overlay
+    if app.show_help {
+        help_overlay::draw(frame);
     }
 }


### PR DESCRIPTION
## Summary

Final polish for the initial release. Validates that required tools are available before launching the TUI, and provides an in-app keyboard shortcut reference for discoverability.

## Related Issues

None

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add startup checks: verify `git`, `gh`, and git repository before TUI init, with clear error messages and exit
- Add `?` keybinding (from any view) to toggle a help overlay showing all keyboard shortcuts organized by view
- Help overlay dismisses with `Esc`, `q`, or `?`
- While help is shown, all other key input is ignored
- Status bar now shows `?:Help` hint

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (7 existing tests)

## Test Plan

1. `cargo run` in a git repo with git and gh installed — app starts normally
2. Press `?` — help overlay shows all keybindings for all views
3. Press `Esc` or `?` — help closes, back to normal view
4. While help is showing, other keys (1-4, j/k) are ignored
5. Run outside a git repo — "Error: not a git repository" message and clean exit