### PR TITLE
feat(log): display commit graph topology in log view

### DIFF
--- a/src/git/parser.rs
+++ b/src/git/parser.rs
@@ -139,8 +139,28 @@ mod tests {
         assert_eq!(commits[0].message, "fix bug");
         assert_eq!(commits[0].author, "Alice");
         assert_eq!(commits[0].date, "2024-01-15");
+        assert_eq!(commits[0].graph, "* ");
         assert_eq!(commits[1].hash, "def5678");
         assert_eq!(commits[1].message, "add feature");
+        assert_eq!(commits[1].graph, "* ");
+    }
+
+    #[test]
+    fn test_parse_log_with_graph_branches() {
+        let output = "* abc1234\x00merge branch\x00Alice\x002024-01-15\n\
+                       |\\ \n\
+                       | * def5678\x00feature work\x00Bob\x002024-01-14\n\
+                       |/ \n\
+                       * ghi9012\x00initial commit\x00Alice\x002024-01-13\n";
+        let commits = parse_log(output);
+        // Graph-only lines (|\ and |/) are skipped, only commit lines are parsed
+        assert_eq!(commits.len(), 3);
+        assert_eq!(commits[0].graph, "* ");
+        assert_eq!(commits[0].hash, "abc1234");
+        assert_eq!(commits[1].graph, "| * ");
+        assert_eq!(commits[1].hash, "def5678");
+        assert_eq!(commits[2].graph, "* ");
+        assert_eq!(commits[2].hash, "ghi9012");
     }
 
     #[test]

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -6,7 +6,6 @@ pub struct Commit {
     pub message: String,
     pub author: String,
     pub date: String,
-    #[allow(dead_code)]
     pub graph: String,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,6 +53,7 @@ async fn run(terminal: &mut ratatui::DefaultTerminal) -> anyhow::Result<()> {
     // Load commit history
     if let Ok(output) = run_git(&[
         "log",
+        "--graph",
         "--format=%h%x00%s%x00%an%x00%ad",
         "--date=short",
         "-n",

--- a/src/ui/log_view.rs
+++ b/src/ui/log_view.rs
@@ -21,17 +21,23 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
         .commits
         .iter()
         .map(|commit| {
-            let line = Line::from(vec![
-                Span::styled(
-                    format!("{} ", commit.hash),
-                    Style::default().fg(Color::Yellow),
-                ),
-                Span::raw(&commit.message),
-                Span::styled(
-                    format!("  ({}, {})", commit.author, commit.date),
-                    Style::default().fg(Color::DarkGray),
-                ),
-            ]);
+            let mut spans = Vec::new();
+            if !commit.graph.is_empty() {
+                spans.push(Span::styled(
+                    &commit.graph,
+                    Style::default().fg(Color::Magenta),
+                ));
+            }
+            spans.push(Span::styled(
+                format!("{} ", commit.hash),
+                Style::default().fg(Color::Yellow),
+            ));
+            spans.push(Span::raw(&commit.message));
+            spans.push(Span::styled(
+                format!("  ({}, {})", commit.author, commit.date),
+                Style::default().fg(Color::DarkGray),
+            ));
+            let line = Line::from(spans);
             ListItem::new(line)
         })
         .collect();


### PR DESCRIPTION
## Summary

Add commit graph visualization to the Log View, showing branch/merge topology alongside commit history. This makes it easy to see how branches diverge and merge at a glance.

## Related Issues

Closes #12

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add `--graph` flag to the `git log` command to produce graph characters
- Render graph prefix (`*`, `|`, `/`, `\`) in magenta at the start of each commit line
- Remove `#[allow(dead_code)]` from `Commit.graph` (now rendered in UI)
- Add test case for parsing graph output with branch/merge topology

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (8 tests: 5 parser + 3 markdown)

## Test Plan

1. `cargo run` — Log View shows graph characters in magenta to the left of each commit
2. In a repo with branches/merges, topology is visible (`*` for commits, `|` for ongoing branches, `\`/`/` for merges)
3. `j`/`k` scrolling still works as before