### PR TITLE
chore: add README and prepare v0.0.1 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "git-control-tower"
-version = "0.1.0"
+version = "0.0.1"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "git-control-tower"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "A terminal UI tool for overseeing Git/GitHub workflows"
+repository = "https://github.com/katzkb/git-control-tower"
+keywords = ["git", "github", "tui", "terminal", "worktree"]
+categories = ["command-line-utilities", "development-tools"]
 
 [dependencies]
 ratatui = "0.29"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Git Control Tower (gct)
+
+A terminal UI tool that acts as a "control tower" for Git/GitHub workflows. Oversee your repository, start PR reviews, and clean up branches — all from the terminal.
+
+## Features
+
+- **Branch-centric 2-pane view** — Left sidebar lists branches with PR and worktree indicators. Right pane shows git status, worktree path, and PR details with markdown rendering.
+- **Filter modes** — Switch between Local branches (`1`), your PRs (`2`), and review-requested PRs (`3`).
+- **Worktree management** — Create worktrees from PRs with `w` for instant code review. Delete with `d`.
+- **Branch cleanup** — Multi-select branches with `Space`, select all merged with `a`, batch delete with `d`.
+- **Commit log** — View commit history with `l`.
+
+## Requirements
+
+- [git](https://git-scm.com/) CLI
+- [gh](https://cli.github.com/) CLI (authenticated)
+- A terminal with 256-color support
+
+## Installation
+
+```bash
+# From source
+git clone https://github.com/katzkb/git-control-tower.git
+cd git-control-tower
+cargo install --path .
+```
+
+## Usage
+
+```bash
+# Run inside a git repository
+gct
+```
+
+## Keybindings
+
+### Global
+
+| Key | Action |
+|-----|--------|
+| `1` | Filter: Local branches |
+| `2` | Filter: My PRs |
+| `3` | Filter: Review requested |
+| `l` | Log view |
+| `?` | Help |
+| `q` | Quit |
+
+### Main View
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Navigate sidebar |
+| `Space` | Toggle branch selection |
+| `a` | Select all merged branches |
+| `d` | Delete selected branches / worktree |
+| `w` | Create worktree from PR |
+
+### Log View
+
+| Key | Action |
+|-----|--------|
+| `j` / `k` | Navigate commits |
+| `Esc` | Back to main view |
+
+## License
+
+Licensed under either of
+
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE))
+- MIT License ([LICENSE-MIT](LICENSE-MIT))
+
+at your option.


### PR DESCRIPTION
## Summary

Prepare the project for its first release (v0.0.1). Adds a README with feature overview, installation instructions, keybinding reference, and license info. Updates Cargo.toml with release metadata.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] CI / Build

## Changes

- **README.md**: Feature overview, requirements (git/gh CLI), installation from source, full keybinding table, dual license info
- **Cargo.toml**: Version set to 0.0.1, added `description`, `repository`, `keywords`, `categories`

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (12 tests)

## Test Plan

1. Verify README renders correctly on GitHub
2. `cargo install --path .` succeeds and `gct` command works