### PR TITLE
ci: add release workflow for cross-platform binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+          - target: x86_64-apple-darwin
+            os: macos-latest
+          - target: aarch64-apple-darwin
+            os: macos-latest
+          - target: x86_64-pc-windows-msvc
+            os: windows-latest
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          tar czf ../../../gct-${{ github.ref_name }}-${{ matrix.target }}.tar.gz gct
+          cd ../../..
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cd target/${{ matrix.target }}/release
+          7z a ../../../gct-${{ github.ref_name }}-${{ matrix.target }}.zip gct.exe
+          cd ../../..
+
+      - name: Upload to Release
+        run: gh release upload ${{ github.ref_name }} gct-${{ github.ref_name }}-${{ matrix.target }}.*
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically builds and uploads binaries to GitHub Releases when a version tag (`v*`) is pushed.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] CI / Build

## Changes

- **New workflow** `.github/workflows/release.yml`:
  - Triggers on `v*` tag push
  - Builds for 4 targets: Linux x86_64, macOS x86_64, macOS arm64 (Apple Silicon), Windows x86_64
  - Packages as `.tar.gz` (Unix) / `.zip` (Windows)
  - Uploads to the GitHub Release via `gh release upload`
  - Archive naming: `gct-v{version}-{target}.tar.gz`

## Checklist

- [x] YAML syntax valid
- [x] Existing CI workflow unchanged

## Test Plan

1. Merge this PR
2. Create a test release: `gh release create v0.0.2-rc.1 --prerelease --title "test"`
3. Push tag: `git tag v0.0.2-rc.1 && git push origin v0.0.2-rc.1`
4. Verify 4 binary archives appear on the release page
5. Download and test one binary runs correctly