### PR TITLE
fix(ci): handle existing release branch on retry

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -12,6 +12,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: create-release-pr
+  cancel-in-progress: false
+
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
@@ -60,11 +64,17 @@ jobs:
             exit 1
           fi
           # Delete remote branch if it exists (leftover from a failed run)
-          if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
             echo "Deleting existing remote branch $BRANCH"
             git push origin --delete "$BRANCH"
           else
-            echo "No existing remote branch $BRANCH to delete"
+            status=$?
+            if [ "$status" -eq 2 ]; then
+              echo "No existing remote branch $BRANCH to delete"
+            else
+              echo "::error::Failed to query remote for branch '$BRANCH' (exit code $status)"
+              exit "$status"
+            fi
           fi
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes release PR workflow failing on retry when a previous run left a remote branch behind.

## Changes

- Deletes existing `release/*` remote branch before creating a new one
- Prevents `non-fast-forward` push rejection on retry

## Test Plan

1. Merge this PR
2. Re-run "Create Release PR" workflow from Actions UI
3. Should succeed even with leftover `release/v0.0.2` branch