### PR TITLE
fix: set binary name to gct in Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "git-control-tower"
-version = "0.0.1"
+version = "0.0.2"
 dependencies = [
  "anyhow",
  "crossterm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ repository = "https://github.com/katzkb/git-control-tower"
 keywords = ["git", "github", "tui", "terminal", "worktree"]
 categories = ["command-line-utilities", "development-tools"]
 
+[[bin]]
+name = "gct"
+path = "src/main.rs"
+
 [dependencies]
 ratatui = "0.29"
 crossterm = "0.28"


### PR DESCRIPTION
## Summary

The release workflow failed because it looked for a binary named `gct` but cargo built `git-control-tower`. Adds a `[[bin]]` section to produce `gct` as the binary name.

## Changes

- Added `[[bin]]` section with `name = "gct"` to Cargo.toml
- `cargo install --path .` now installs as `gct` command

## Test Plan

1. `cargo build --release` → `target/release/gct` exists
2. Merge → run "Create Release PR" workflow → merge release PR → binaries should build successfully