### PR TITLE
fix: use GraphQL viewer query for GitHub Enterprise support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,8 +70,17 @@ async fn run(
         app.commits = parse_log(&output);
     }
 
-    // Load GitHub user
-    if let Ok(user) = run_gh(&["api", "user", "--jq", ".login"]).await {
+    // Load GitHub user (uses graphql viewer query which respects GHE host)
+    if let Ok(user) = run_gh(&[
+        "api",
+        "graphql",
+        "-f",
+        "query={viewer{login}}",
+        "--jq",
+        ".data.viewer.login",
+    ])
+    .await
+    {
         app.gh_user = user.trim().to_string();
     }
 


### PR DESCRIPTION
## Summary

Fixes user identification on GitHub Enterprise. `gh api user` always queries github.com regardless of the repo's remote host, causing "My PR" and "Review Requested" filters to fail when the GHE username differs.

Closes #31

## Type of Change

- [x] Bug fix

## Changes

- Replace `gh api user --jq .login` with `gh api graphql -f query={viewer{login}} --jq .data.viewer.login`
- The GraphQL `viewer` query automatically respects the repository's remote host, working on both github.com and GitHub Enterprise

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (21 tests)

## Test Plan

1. In a github.com repo: `cargo run` → "My PR" filter shows authored PRs
2. In a GHE repo: `cargo run` → "My PR" filter shows authored PRs (previously empty)
3. Verify `gh api graphql -f 'query={viewer{login}}' --jq '.data.viewer.login'` returns correct username for both hosts