### PR TITLE
ci: auto-update Homebrew formula on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,7 @@ jobs:
         with:
           repository: katzkb/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          ref: main
 
       - name: Update formula
         env:
@@ -145,4 +146,4 @@ jobs:
           git add Formula/gct.rb
           git diff --cached --quiet && echo "Formula already up to date" && exit 0
           git commit -m "chore: update gct to ${VERSION}"
-          git push
+          git push origin main


### PR DESCRIPTION
## Summary

Automates Homebrew formula updates as part of the release workflow. After binaries are built and uploaded, a new job updates `katzkb/homebrew-tap` with the correct version and SHA256 hashes.

Closes #33

## Type of Change

- [x] CI / Build

## Changes

- **New job `update-homebrew`** in `release.yml` (runs after `build` completes):
  1. Downloads macOS arm64, macOS x86_64, and Linux x86_64 archives from the release
  2. Computes SHA256 hashes
  3. Updates `Formula/gct.rb` version and all three SHA256 values via sed
  4. Commits and pushes to `katzkb/homebrew-tap`

## Checklist

- [x] YAML syntax valid
- [x] Existing workflow jobs unchanged

## Test Plan

1. Merge this PR
2. Trigger a release via "Create Release PR" workflow
3. After release completes, verify `homebrew-tap/Formula/gct.rb` has updated version and hashes
4. `brew upgrade gct` installs the new version