### PR TITLE
fix(ci): sync Cargo.lock on release version bump

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -45,6 +45,8 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Releasing: ${VERSION}"
 
+      - uses: dtolnay/rust-toolchain@stable
+
       - name: Update Cargo.toml version
         run: |
           VERSION="${{ steps.version.outputs.version }}"


### PR DESCRIPTION
## Summary

The release PR workflow updates Cargo.toml version via sed but doesn't regenerate Cargo.lock, causing a version mismatch. Adds `cargo generate-lockfile` after the sed replacement.

## Type of Change

- [x] Bug fix

## Changes

- Run `cargo generate-lockfile` after updating Cargo.toml version in create-release-pr workflow

## Test Plan

1. Merge this PR
2. Run "Create Release PR" workflow
3. Verify the release PR includes both Cargo.toml and Cargo.lock with matching versions