### PR TITLE
perf: defer GitHub API calls to show branch list immediately on startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,8 @@ enum AsyncResult {
     PrDetailError(u64),
     GitStatus { wt_path: String, status: GitStatus },
     GitStatusError(String),
+    UserLogin(String),
+    PrList(Vec<PullRequest>),
 }
 
 #[tokio::main]
@@ -69,7 +71,7 @@ async fn run(
     let mut pr_inflight: HashSet<u64> = HashSet::new();
     let mut status_inflight: HashSet<String> = HashSet::new();
 
-    // Load commit history
+    // Phase 1: Fast local loads (blocking, ~170ms)
     if let Ok(output) = run_git(&[
         "log",
         "--format=%h%x00%s%x00%an%x00%ad",
@@ -81,51 +83,52 @@ async fn run(
     {
         app.commits = parse_log(&output);
     }
-
-    // Load GitHub user (uses graphql viewer query which respects GHE host)
-    if let Ok(user) = run_gh(&[
-        "api",
-        "graphql",
-        "-f",
-        "query={viewer{login}}",
-        "--jq",
-        ".data.viewer.login",
-    ])
-    .await
-    {
-        app.gh_user = user.trim().to_string();
-    }
-
-    // Load PR list (open + merged)
-    let pr_fields = "number,title,author,state,headRefName,updatedAt,reviewRequests";
-    if let Ok(output) = run_gh(&["pr", "list", "--json", pr_fields, "--limit", "50"]).await
-        && let Ok(prs) = serde_json::from_str::<Vec<PullRequest>>(&output)
-    {
-        app.pull_requests = prs;
-    }
-    if let Ok(output) = run_gh(&[
-        "pr", "list", "--state", "merged", "--json", pr_fields, "--limit", "50",
-    ])
-    .await
-        && let Ok(prs) = serde_json::from_str::<Vec<PullRequest>>(&output)
-    {
-        app.pull_requests.extend(prs);
-    }
-
-    // Load worktrees
     if let Ok(output) = run_git(&["worktree", "list", "--porcelain"]).await {
         app.worktrees = parse_worktrees(&output);
     }
-
-    // Load branches
     load_branches(&mut app).await;
-
-    // Build merged entries
-    app.entries = merge_entries(&app.branches, &app.worktrees, &app.pull_requests);
+    app.entries = merge_entries(&app.branches, &app.worktrees, &[]);
     app.entries_loaded = true;
-
-    // Request details for the initial selection (lazy-loads git status and PR detail)
     app.request_details_for_selection();
+
+    // Phase 2: Slow network loads (background, non-blocking)
+    let tx_user = tx.clone();
+    tokio::spawn(async move {
+        if let Ok(user) = run_gh(&[
+            "api",
+            "graphql",
+            "-f",
+            "query={viewer{login}}",
+            "--jq",
+            ".data.viewer.login",
+        ])
+        .await
+        {
+            let _ = tx_user.send(AsyncResult::UserLogin(user.trim().to_string()));
+        }
+    });
+
+    let tx_prs = tx.clone();
+    tokio::spawn(async move {
+        let pr_fields = "number,title,author,state,headRefName,updatedAt,reviewRequests";
+        let mut prs = Vec::new();
+        if let Ok(output) = run_gh(&["pr", "list", "--json", pr_fields, "--limit", "50"]).await
+            && let Ok(open) = serde_json::from_str::<Vec<PullRequest>>(&output)
+        {
+            prs.extend(open);
+        }
+        if let Ok(output) = run_gh(&[
+            "pr", "list", "--state", "merged", "--json", pr_fields, "--limit", "50",
+        ])
+        .await
+            && let Ok(merged) = serde_json::from_str::<Vec<PullRequest>>(&output)
+        {
+            prs.extend(merged);
+        }
+        if !prs.is_empty() {
+            let _ = tx_prs.send(AsyncResult::PrList(prs));
+        }
+    });
 
     loop {
         terminal.draw(|frame| ui::draw(frame, &app))?;
@@ -204,6 +207,18 @@ async fn run(
                 }
                 AsyncResult::GitStatusError(wt_path) => {
                     status_inflight.remove(&wt_path);
+                }
+                AsyncResult::UserLogin(user) => {
+                    app.gh_user = user;
+                }
+                AsyncResult::PrList(prs) => {
+                    app.pull_requests = prs;
+                    app.entries = merge_entries(&app.branches, &app.worktrees, &app.pull_requests);
+                    let filtered_len = app.filtered_entries().len();
+                    if app.sidebar_scroll >= filtered_len && filtered_len > 0 {
+                        app.sidebar_scroll = filtered_len - 1;
+                    }
+                    app.request_details_for_selection();
                 }
             }
         }


### PR DESCRIPTION
## Summary

Startup was slow because GitHub API calls (user login, PR list) blocked the first render. Now only fast local git commands run synchronously (~170ms), and network calls run in the background via tokio::spawn.

Closes #43

## Type of Change

- [x] New feature

## Changes

- **Phase 1 (blocking, ~170ms)**: `git log`, `git worktree list`, `git branch -vv/--merged`, `merge_entries` with empty PRs → branch list renders immediately
- **Phase 2 (background)**: `gh api graphql viewer` and `gh pr list` (open + merged) spawned as async tasks
- **On PR data arrival**: `merge_entries` rebuilt with PR data, sidebar updates with PR numbers
- Reuses existing `AsyncResult` + `mpsc` channel pattern with new `UserLogin` and `PrList` variants

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (21 tests)

## Test Plan

1. `cargo run` → branch list appears within milliseconds (no PR numbers yet)
2. After 1-3s, PR numbers appear next to branches
3. Filter modes (2:My PR, 3:Review) work after gh_user loads
4. `j`/`k` navigation works immediately from startup
5. Detail pane shows "Loading..." for PR info until data arrives