### PR TITLE
fix: detect GHE hostname from remote URL for user login

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -327,12 +327,20 @@ fn extract_gh_hostname(remote_url: &str) -> Option<String> {
             .next()
             .map(|s| s.split(':').next().unwrap_or(s).to_string());
     }
-    // HTTPS: https://hostname/org/repo.git
+    // HTTP(S): https://hostname/org/repo.git or https://user@hostname:port/org/repo.git
     if let Some(rest) = remote_url
         .strip_prefix("https://")
         .or_else(|| remote_url.strip_prefix("http://"))
     {
-        return rest.split('/').next().map(|s| s.to_string());
+        let authority = rest.split('/').next()?;
+        let after_user = authority.split('@').next_back().unwrap_or(authority);
+        return Some(
+            after_user
+                .split(':')
+                .next()
+                .unwrap_or(after_user)
+                .to_string(),
+        );
     }
     None
 }
@@ -374,6 +382,18 @@ mod tests {
         assert_eq!(
             extract_gh_hostname("ssh://git@ghe.company.com:2222/org/repo.git"),
             Some("ghe.company.com".to_string())
+        );
+    }
+
+    #[test]
+    fn test_extract_hostname_https_with_credentials_and_port() {
+        assert_eq!(
+            extract_gh_hostname("https://token@ghe.company.com:8443/org/repo.git"),
+            Some("ghe.company.com".to_string())
+        );
+        assert_eq!(
+            extract_gh_hostname("https://user@github.com/org/repo.git"),
+            Some("github.com".to_string())
         );
     }
 


### PR DESCRIPTION
## Summary

`gh api graphql` does not auto-detect the repository's host, always querying github.com. This causes user identification to fail on GHE, breaking "My PR" and "Review Requested" filters. Now extracts the hostname from `git remote get-url origin` and passes `--hostname` when it differs from github.com.

Closes #46

## Type of Change

- [x] Bug fix

## Changes

- **Host detection**: `extract_gh_hostname()` parses SSH (`git@host:org/repo`) and HTTPS (`https://host/org/repo`) remote URLs
- **Conditional --hostname**: When host is not github.com, `--hostname <host>` is added to `gh api graphql` call
- **3 new tests**: SSH, HTTPS, and unknown format parsing

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (24 tests, 3 new)

## Test Plan

1. In a github.com repo: `cargo run` → My PR filter works (no `--hostname` needed)
2. In a GHE repo: `cargo run` → GHE username detected → My PR and Review filters show correct PRs
3. Verify `git remote get-url origin` returns the expected URL format in both environments