### PR TITLE
feat: add --version / -v flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,12 @@ enum AsyncResult {
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    // Handle --version / -v before anything else
+    if std::env::args().any(|a| a == "--version" || a == "-v") {
+        println!("gct v{}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
     // Initialize debug logging (GCT_DEBUG=1 enables it)
     crate::git::command::init_debug_log();
 


### PR DESCRIPTION
## Summary

Adds `--version` and `-v` CLI flags that print the version and exit immediately, without requiring git repo or gh CLI.

Closes #53

## Type of Change

- [x] New feature

## Changes

- Check `std::env::args` at the very start of `main()`, before any initialization
- Print `gct v{CARGO_PKG_VERSION}` and return

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (26 tests)

## Test Plan

1. `gct --version` → `gct v0.0.8`
2. `gct -v` → `gct v0.0.8`
3. `gct` → TUI launches normally