### PR TITLE
fix: remove invalid --hostname flag from gh pr list calls

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -246,26 +246,24 @@ fn parse_graphql_pr(node: &serde_json::Value) -> Option<PullRequest> {
 }
 
 /// Fetch PRs authored by the current user (`--author @me`).
-pub async fn fetch_my_prs(show_merged: bool, hostname: Option<&str>) -> Vec<PullRequest> {
-    fetch_pr_list("--author", show_merged, hostname).await
+/// Note: `gh pr list` auto-detects the host from the repo remote; no --hostname needed.
+pub async fn fetch_my_prs(show_merged: bool) -> Vec<PullRequest> {
+    fetch_pr_list("--author", show_merged).await
 }
 
 /// Fetch PRs with review requested from the current user.
-pub async fn fetch_review_prs(show_merged: bool, hostname: Option<&str>) -> Vec<PullRequest> {
-    fetch_pr_list("--review-requested", show_merged, hostname).await
+/// Note: `gh pr list` auto-detects the host from the repo remote; no --hostname needed.
+pub async fn fetch_review_prs(show_merged: bool) -> Vec<PullRequest> {
+    fetch_pr_list("--review-requested", show_merged).await
 }
 
 /// Common helper for fetching PR lists with a user filter.
-async fn fetch_pr_list(
-    filter_flag: &str,
-    show_merged: bool,
-    hostname: Option<&str>,
-) -> Vec<PullRequest> {
+async fn fetch_pr_list(filter_flag: &str, show_merged: bool) -> Vec<PullRequest> {
     let pr_fields = "number,title,author,state,headRefName,updatedAt,reviewRequests";
     let mut prs = Vec::new();
 
     // Always fetch open PRs
-    let mut args = vec![
+    let args = vec![
         "pr",
         "list",
         filter_flag,
@@ -275,10 +273,6 @@ async fn fetch_pr_list(
         "--limit",
         "100",
     ];
-    if let Some(h) = hostname {
-        args.push("--hostname");
-        args.push(h);
-    }
     if let Ok(output) = run_gh(&args).await
         && let Ok(open) = serde_json::from_str::<Vec<PullRequest>>(&output)
     {
@@ -287,7 +281,7 @@ async fn fetch_pr_list(
 
     // Optionally fetch merged PRs
     if show_merged {
-        let mut args = vec![
+        let args = vec![
             "pr",
             "list",
             filter_flag,
@@ -299,10 +293,6 @@ async fn fetch_pr_list(
             "--limit",
             "50",
         ];
-        if let Some(h) = hostname {
-            args.push("--hostname");
-            args.push(h);
-        }
         if let Ok(output) = run_gh(&args).await
             && let Ok(merged) = serde_json::from_str::<Vec<PullRequest>>(&output)
         {

--- a/src/main.rs
+++ b/src/main.rs
@@ -236,17 +236,15 @@ async fn run(
                 }
                 MainFilter::MyPr => {
                     let show_merged = app.show_merged;
-                    let hostname = gh_hostname.clone();
                     tokio::spawn(async move {
-                        let prs = data::fetch_my_prs(show_merged, hostname.as_deref()).await;
+                        let prs = data::fetch_my_prs(show_merged).await;
                         let _ = tx.send(AsyncResult::MyPrList(prs));
                     });
                 }
                 MainFilter::ReviewRequested => {
                     let show_merged = app.show_merged;
-                    let hostname = gh_hostname.clone();
                     tokio::spawn(async move {
-                        let prs = data::fetch_review_prs(show_merged, hostname.as_deref()).await;
+                        let prs = data::fetch_review_prs(show_merged).await;
                         let _ = tx.send(AsyncResult::ReviewPrList(prs));
                     });
                 }


### PR DESCRIPTION
## Summary

Remove the invalid `--hostname` flag from `gh pr list` calls that caused My PR and Review views to fail on GitHub Enterprise environments. `--hostname` is only valid for `gh api`, not `gh pr` subcommands. `gh pr list` auto-detects the host from the repository's remote URL.

## Related Issues

Closes #59

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Remove `hostname` parameter from `fetch_my_prs()`, `fetch_review_prs()`, and `fetch_pr_list()` in `src/data.rs`
- Remove hostname argument passing from callers in `src/main.rs`
- `fetch_local_prs()` (which uses `gh api graphql --hostname`) is unchanged — `--hostname` is valid for `gh api`

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`)
- [x] Tests pass (35 tests)

## Test Plan

1. Run `cargo run` in a GHE repository
2. Switch to My PR view (key `2`) — verify PRs load without errors
3. Switch to Review view (key `3`) — verify PRs load without errors
4. Verify Local view still works (uses `gh api graphql --hostname`, unaffected)