### PR TITLE
fix: replace invalid --review-requested flag with --search qualifier

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -245,34 +245,27 @@ fn parse_graphql_pr(node: &serde_json::Value) -> Option<PullRequest> {
     })
 }
 
-/// Fetch PRs authored by the current user (`--author @me`).
-/// Note: `gh pr list` auto-detects the host from the repo remote; no --hostname needed.
+/// Fetch PRs authored by the current user (`gh pr list --author @me`).
 pub async fn fetch_my_prs(show_merged: bool) -> Vec<PullRequest> {
-    fetch_pr_list("--author", show_merged).await
+    fetch_pr_list(&["--author", "@me"], show_merged).await
 }
 
-/// Fetch PRs with review requested from the current user.
-/// Note: `gh pr list` auto-detects the host from the repo remote; no --hostname needed.
+/// Fetch PRs with review requested from the current user
+/// (`gh pr list --search "review-requested:@me"`).
 pub async fn fetch_review_prs(show_merged: bool) -> Vec<PullRequest> {
-    fetch_pr_list("--review-requested", show_merged).await
+    fetch_pr_list(&["--search", "review-requested:@me"], show_merged).await
 }
 
-/// Common helper for fetching PR lists with a user filter.
-async fn fetch_pr_list(filter_flag: &str, show_merged: bool) -> Vec<PullRequest> {
+/// Common helper for fetching PR lists with a filter.
+/// `filter_args` is passed directly to `gh pr list` (e.g., `["--author", "@me"]`).
+async fn fetch_pr_list(filter_args: &[&str], show_merged: bool) -> Vec<PullRequest> {
     let pr_fields = "number,title,author,state,headRefName,updatedAt,reviewRequests";
     let mut prs = Vec::new();
 
     // Always fetch open PRs
-    let args = vec![
-        "pr",
-        "list",
-        filter_flag,
-        "@me",
-        "--json",
-        pr_fields,
-        "--limit",
-        "100",
-    ];
+    let mut args = vec!["pr", "list"];
+    args.extend_from_slice(filter_args);
+    args.extend_from_slice(&["--json", pr_fields, "--limit", "100"]);
     if let Ok(output) = run_gh(&args).await
         && let Ok(open) = serde_json::from_str::<Vec<PullRequest>>(&output)
     {
@@ -281,18 +274,9 @@ async fn fetch_pr_list(filter_flag: &str, show_merged: bool) -> Vec<PullRequest>
 
     // Optionally fetch merged PRs
     if show_merged {
-        let args = vec![
-            "pr",
-            "list",
-            filter_flag,
-            "@me",
-            "--state",
-            "merged",
-            "--json",
-            pr_fields,
-            "--limit",
-            "50",
-        ];
+        let mut args = vec!["pr", "list"];
+        args.extend_from_slice(filter_args);
+        args.extend_from_slice(&["--state", "merged", "--json", pr_fields, "--limit", "50"]);
         if let Ok(output) = run_gh(&args).await
             && let Ok(merged) = serde_json::from_str::<Vec<PullRequest>>(&output)
         {


### PR DESCRIPTION
## Summary

Fix invalid `--review-requested` flag in `gh pr list` calls that caused Review view to fail on all environments. `--review-requested` does not exist as a `gh pr list` flag. Replaced with `--search "review-requested:@me"` which uses the correct GitHub search qualifier syntax.

Also includes the previous `--hostname` removal from PR #60 (already merged to main).

## Related Issues

Closes #59

## Type of Change

- [x] Bug fix

## Changes

- Replace `--review-requested @me` with `--search "review-requested:@me"` in `fetch_review_prs()`
- Refactor `fetch_pr_list()` to accept `filter_args: &[&str]` slice instead of single flag, allowing different argument structures
- All 22 git/gh command invocations in codebase verified by actual execution

## Full Audit Results

All 14 git commands: ✅ valid
All 8 gh commands: ✅ valid (after this fix)

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (35 tests)
- [x] All CLI commands verified by actual execution

## Test Plan

1. Run `gh pr list --search "review-requested:@me" --json number --limit 1` — verify exit 0
2. Run `gh pr list --search "review-requested:@me" --state merged --json number --limit 1` — verify exit 0
3. Run `cargo run` and switch to Review view (key `3`) — verify PRs load