### PR TITLE
fix: exclude branches at HEAD from merged detection

### DIFF
--- a/src/git/parser.rs
+++ b/src/git/parser.rs
@@ -36,7 +36,8 @@ pub fn parse_log(output: &str) -> Vec<Commit> {
 }
 
 /// Parse output of `git branch -vv`
-pub fn parse_branches(output: &str, merged_output: &str, head_hash: &str) -> Vec<Branch> {
+/// `base_hash` is the full commit hash of the repository's default branch (e.g., main).
+pub fn parse_branches(output: &str, merged_output: &str, base_hash: &str) -> Vec<Branch> {
     let merged_names: Vec<&str> = merged_output
         .lines()
         .map(|l| l.trim().trim_start_matches("* "))
@@ -71,11 +72,12 @@ pub fn parse_branches(output: &str, merged_output: &str, head_hash: &str) -> Vec
             });
 
             // A branch is merged if it's in --merged output AND its commit differs
-            // from HEAD. Branches pointing to HEAD (e.g., newly created branches)
-            // are just "at the same commit", not truly merged.
+            // from the default branch. Branches at the same commit as the default
+            // branch (e.g., newly created branches) are not truly merged.
             let commit_hash = rest.split_whitespace().nth(1).unwrap_or_default();
-            let is_merged =
-                merged_names.contains(&name.as_str()) && !head_hash.starts_with(commit_hash);
+            let is_merged = merged_names.contains(&name.as_str())
+                && !commit_hash.is_empty()
+                && !base_hash.starts_with(commit_hash);
 
             Some(Branch {
                 name,
@@ -150,13 +152,13 @@ mod tests {
 
     #[test]
     fn test_parse_branches() {
-        // head_hash is full (40 chars), branch -vv shows abbreviated (7 chars)
+        // base_hash is full (40 chars), branch -vv shows abbreviated (7 chars)
         let output = "* main       abc1234 [origin/main] latest commit\n\
                          feature-a  def5678 [origin/feature-a: ahead 1] wip\n\
                          old-branch ghi9012 some old work\n";
         let merged = "  old-branch\n";
-        let head_hash = "abc1234567890abcdef1234567890abcdef12345678";
-        let branches = parse_branches(output, merged, head_hash);
+        let base_hash = "abc1234567890abcdef1234567890abcdef12345678";
+        let branches = parse_branches(output, merged, base_hash);
 
         assert_eq!(branches.len(), 3);
 
@@ -176,17 +178,17 @@ mod tests {
     }
 
     #[test]
-    fn test_branch_at_head_not_marked_merged() {
-        // head_hash is full, branch hashes are abbreviated but match HEAD prefix
+    fn test_branch_at_default_not_marked_merged() {
+        // base_hash is full, branch hashes are abbreviated but match default branch prefix
         let output = "* main       abc1234 [origin/main] latest commit\n\
                          new-branch abc1234 starting work\n";
         let merged = "* main\n  new-branch\n";
-        let head_hash = "abc1234567890abcdef1234567890abcdef12345678";
-        let branches = parse_branches(output, merged, head_hash);
+        let base_hash = "abc1234567890abcdef1234567890abcdef12345678";
+        let branches = parse_branches(output, merged, base_hash);
 
         assert_eq!(branches.len(), 2);
-        assert!(!branches[0].is_merged); // main (same hash prefix as HEAD)
-        assert!(!branches[1].is_merged); // new-branch (same hash prefix as HEAD)
+        assert!(!branches[0].is_merged); // main (same commit as default branch)
+        assert!(!branches[1].is_merged); // new-branch (same commit as default branch)
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,15 +412,20 @@ async fn load_branches(app: &mut App) {
 }
 
 async fn detect_default_branch() -> String {
+    // Try remote HEAD symbolic ref (most reliable)
     if let Ok(output) = run_git(&["symbolic-ref", "refs/remotes/origin/HEAD"]).await
         && let Some(name) = output.trim().strip_prefix("refs/remotes/origin/")
     {
         return name.to_string();
     }
+    // Fallback: try main, then master, then HEAD
     if run_git(&["rev-parse", "--verify", "main"]).await.is_ok() {
         return "main".to_string();
     }
-    "master".to_string()
+    if run_git(&["rev-parse", "--verify", "master"]).await.is_ok() {
+        return "master".to_string();
+    }
+    "HEAD".to_string()
 }
 
 /// Extract owner, repo, and hostname from a git remote URL.


### PR DESCRIPTION
## Summary

Branches created from the current HEAD (e.g., `git checkout -b test`) were incorrectly displayed as "merged" because `git branch --merged` includes any branch whose tip is reachable from HEAD. Now the merged detection compares each branch's commit hash with HEAD and excludes branches at the same commit.

## Related Issues

Closes #64

## Type of Change

- [x] Bug fix

## Changes

- Add `head_hash` parameter to `parse_branches()` in `src/git/parser.rs`
- Compare branch commit hash with HEAD — only mark as merged if they differ
- Fetch HEAD hash via `git rev-parse HEAD` in `load_branches()` 
- Add test case verifying branches at HEAD are not marked merged

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (36 tests)

## Test Plan

1. `git checkout -b test-new` from main
2. Run `cargo run` — verify `test-new` does NOT show `[merged]` tag
3. Verify actually merged branches (e.g., `fix/ghe-user-detection`) still show `[merged]`