### PR TITLE
feat: allow worktree creation for local branches without PRs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -554,8 +554,7 @@ impl App {
         match action {
             ActionItem::CreateWorktree => {
                 self.wt_create_requested = Some(entry.name.clone());
-                self.notification =
-                    Some(Notification::success("Creating worktree...".to_string()));
+                self.notification = Some(Notification::success("Creating worktree...".to_string()));
             }
             ActionItem::CdIntoWorktree => {
                 if let Some(path) = entry.worktree_path() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -356,8 +356,9 @@ async fn run(
             };
             match result {
                 Ok(_) => {
-                    app.notification =
-                        Some(Notification::success(format!("Worktree created: {wt_path}")));
+                    app.notification = Some(Notification::success(format!(
+                        "Worktree created: {wt_path}"
+                    )));
                 }
                 Err(e) => {
                     app.notification = Some(Notification::error(format!(


### PR DESCRIPTION
## Summary

Enable worktree creation for any local branch, not just branches with associated PRs. For local branches, skip `git fetch` and directly create the worktree. For remote-only branches (from PR data), fetch first as before.

## Type of Change

- [ ] Bug fix
- [x] New feature

## Changes

- Relax `CreateWorktree` condition from `pull_request.is_some()` to `local_branch.is_some() || pull_request.is_some()`
- Simplify `wt_create_requested` type from `Option<(String, u64)>` to `Option<String>` (PR number was unused)
- Skip `git fetch` for local branches (already available locally)
- Add `!is_current()` guard to prevent creating worktree for the current branch

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (36 tests)

## Test Plan

1. Select a local branch without a PR (e.g., `test`) → press `w` or Enter → "Create worktree" appears
2. Worktree is created without `git fetch`
3. PR branch still works as before (fetch + worktree add)