### PR TITLE
chore: reorder action menu items by usage priority

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -506,14 +506,17 @@ impl App {
         };
         let mut items = Vec::new();
 
+        if entry.pull_request.is_some() {
+            items.push(ActionItem::OpenPrInBrowser);
+        }
+        if entry.worktree.is_some() {
+            items.push(ActionItem::CdIntoWorktree);
+        }
         if entry.worktree.is_none()
             && !entry.is_current()
             && (entry.local_branch.is_some() || entry.pull_request.is_some())
         {
             items.push(ActionItem::CreateWorktree);
-        }
-        if entry.worktree.is_some() {
-            items.push(ActionItem::CdIntoWorktree);
         }
         if entry.worktree.is_some() && !entry.is_current() {
             items.push(ActionItem::DeleteWorktree);
@@ -523,9 +526,6 @@ impl App {
             && !Self::is_protected_branch(&entry.name)
         {
             items.push(ActionItem::DeleteBranch);
-        }
-        if entry.pull_request.is_some() {
-            items.push(ActionItem::OpenPrInBrowser);
         }
 
         if !items.is_empty() {


### PR DESCRIPTION
## Summary

Reorder the action menu (Enter key) items so frequently used actions appear first: Open PR → cd → Create worktree → Delete worktree → Delete branch.

## Related Issues

Closes #79

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactoring

## Changes

- Reorder `items.push()` calls in `open_action_menu()` — no logic changes

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (42 tests)