### PR TITLE
fix: split OR-combined search into separate queries for GHE compatibility

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -288,6 +288,9 @@ pub async fn fetch_review_prs(
         }
     }
 
+    // Sort by updated_at descending for consistent ordering
+    all_prs.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+
     (all_prs, all_errors)
 }
 


### PR DESCRIPTION
## Summary

The `OR` operator in GitHub search is not supported on some GHE versions, causing the Review view's combined query (`review-requested:@me OR reviewed-by:@me`) to return 0 results even though each qualifier works individually. Split into separate queries and merge results with PR number deduplication.

## Related Issues

Closes #82

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Replace single OR-combined search with a loop over individual queries (`review-requested:@me`, `reviewed-by:@me`, optionally `team-review-requested:@me`)
- Merge results using `HashSet<u64>` for PR number deduplication
- Each query reuses the existing `fetch_pr_list` helper unchanged

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Formatter passes
- [ ] Tests pass (verify manually)

## Test Plan

1. On GHE work PC, run `gct` and switch to Review view (key `3`)
2. Verify both pending review requests AND already-reviewed PRs appear
3. Press `t` to toggle team mode — verify team-assigned PRs also appear
4. Verify no duplicate entries in the list