### PR TITLE
fix: use force delete for squash-merged branches

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -442,11 +442,22 @@ async fn run(
         // Delete selected branches if requested
         if app.branch_delete_requested {
             app.branch_delete_requested = false;
-            let selected: Vec<String> = app.branch_selected.drain().collect();
+            let selected: Vec<(String, bool)> = app
+                .branch_selected
+                .drain()
+                .map(|name| {
+                    let force = app
+                        .entries
+                        .iter()
+                        .any(|e| e.name == name && (e.is_merged() || e.pr_is_merged()));
+                    (name, force)
+                })
+                .collect();
             let mut deleted = Vec::new();
             let mut failed = Vec::new();
-            for name in &selected {
-                match run_git(&["branch", "-d", name]).await {
+            for (name, force) in &selected {
+                let flag = if *force { "-D" } else { "-d" };
+                match run_git(&["branch", flag, name]).await {
                     Ok(_) => deleted.push(name.as_str()),
                     Err(e) => failed.push(format!("{name}: {e}")),
                 }


### PR DESCRIPTION
## Summary

Squash-merged branches fail to delete with `git branch -d` because the original commit hashes don't match the squash commit. Use `-D` (force delete) when the branch is confirmed merged by either `git branch --merged` or GitHub PR state, while keeping `-d` for unconfirmed branches.

## Related Issues

Closes #86

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Check `is_merged()` (git) or `pr_is_merged()` (GitHub PR state MERGED) for each selected branch before deletion
- Use `git branch -D` for confirmed-merged branches, `-d` for others
- Collect merge status alongside branch names before draining the selection set

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Formatter passes
- [ ] Tests pass (verify manually)

## Test Plan

1. On GHE work PC, select a squash-merged branch → delete → verify it succeeds (no error notification)
2. Select a branch that hasn't been merged → delete → verify `-d` is used (git safety check preserved)
3. Select mixed branches (some merged, some not) → verify merged ones use `-D`, others use `-d`