### PR TITLE
feat(search): keep filter active after Enter and highlight matches

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -213,7 +213,7 @@ impl App {
     }
 
     pub fn filtered_entries(&self) -> Vec<&BranchEntry> {
-        let search_query = if self.search_active && !self.search_query.is_empty() {
+        let search_query = if !self.search_query.is_empty() {
             Some(self.search_query.to_lowercase())
         } else {
             None
@@ -302,7 +302,13 @@ impl App {
             KeyCode::Char('?') => self.show_help = true,
             KeyCode::Char('q') => self.should_quit = true,
             KeyCode::Esc => {
-                if self.active_view == ActiveView::Log {
+                if !self.search_query.is_empty() {
+                    // Clear search filter and restore scroll
+                    self.search_query.clear();
+                    self.sidebar_scroll = self.search_pre_scroll;
+                    self.sidebar_offset = 0;
+                    self.request_details_for_selection();
+                } else if self.active_view == ActiveView::Log {
                     self.active_view = ActiveView::Main;
                 } else {
                     self.should_quit = true;
@@ -312,6 +318,7 @@ impl App {
             KeyCode::Char('1') => {
                 self.main_filter = MainFilter::Local;
                 self.active_view = ActiveView::Main;
+                self.search_query.clear();
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
@@ -323,6 +330,7 @@ impl App {
             KeyCode::Char('2') => {
                 self.main_filter = MainFilter::MyPr;
                 self.active_view = ActiveView::Main;
+                self.search_query.clear();
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
@@ -334,6 +342,7 @@ impl App {
             KeyCode::Char('3') => {
                 self.main_filter = MainFilter::ReviewRequested;
                 self.active_view = ActiveView::Main;
+                self.search_query.clear();
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
@@ -486,19 +495,7 @@ impl App {
                 self.request_details_for_selection();
             }
             KeyCode::Enter => {
-                let selected_name = self.selected_entry().map(|e| e.name.clone());
                 self.search_active = false;
-                self.search_query.clear();
-                if let Some(name) = selected_name {
-                    let new_idx = self
-                        .filtered_entries()
-                        .iter()
-                        .position(|e| e.name == name)
-                        .unwrap_or(0);
-                    self.sidebar_scroll = new_idx;
-                } else {
-                    self.sidebar_scroll = self.search_pre_scroll;
-                }
                 self.request_details_for_selection();
             }
             KeyCode::Backspace => {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -50,6 +50,13 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
                 Style::default().fg(Color::Yellow),
             ));
         }
+        // Show active search filter
+        if !app.search_query.is_empty() {
+            spans.push(Span::styled(
+                format!(" /{}", app.search_query),
+                Style::default().fg(Color::Cyan),
+            ));
+        }
         // Show team toggle indicator for Review view
         if app.main_filter == MainFilter::ReviewRequested {
             let team_label = if app.include_team_reviews {
@@ -81,11 +88,17 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                 Style::default().fg(Color::DarkGray),
             )))]
         } else {
+            let search_query = &app.search_query;
             filtered
                 .iter()
                 .map(|entry| {
                     let is_selected = app.branch_selected.contains(&entry.name);
-                    ListItem::new(format_entry_line(entry, show_checkboxes, is_selected))
+                    ListItem::new(format_entry_line(
+                        entry,
+                        show_checkboxes,
+                        is_selected,
+                        search_query,
+                    ))
                 })
                 .collect()
         };
@@ -117,6 +130,7 @@ fn format_entry_line(
     entry: &BranchEntry,
     show_checkboxes: bool,
     is_selected: bool,
+    search_query: &str,
 ) -> Line<'static> {
     let mut spans: Vec<Span> = Vec::new();
 
@@ -129,7 +143,7 @@ fn format_entry_line(
         }
     }
 
-    // Branch name
+    // Branch name (with search highlight)
     let name_style = if entry.is_current() {
         Style::default()
             .fg(Color::Green)
@@ -139,7 +153,7 @@ fn format_entry_line(
     } else {
         Style::default().fg(Color::White)
     };
-    spans.push(Span::styled(format!(" {}", entry.name), name_style));
+    spans.extend(format_branch_name(&entry.name, search_query, name_style));
 
     // Current marker
     if entry.is_current() {
@@ -189,4 +203,25 @@ fn format_entry_line(
     }
 
     Line::from(spans)
+}
+
+fn format_branch_name(name: &str, search_query: &str, base_style: Style) -> Vec<Span<'static>> {
+    if search_query.is_empty() {
+        return vec![Span::styled(format!(" {name}"), base_style)];
+    }
+    let lower_name = name.to_lowercase();
+    let lower_query = search_query.to_lowercase();
+    if let Some(start) = lower_name.find(&lower_query) {
+        let end = start + lower_query.len();
+        let highlight_style = base_style
+            .add_modifier(Modifier::UNDERLINED)
+            .fg(Color::Cyan);
+        vec![
+            Span::styled(format!(" {}", &name[..start]), base_style),
+            Span::styled(name[start..end].to_string(), highlight_style),
+            Span::styled(name[end..].to_string(), base_style),
+        ]
+    } else {
+        vec![Span::styled(format!(" {name}"), base_style)]
+    }
 }


### PR DESCRIPTION
## Summary

Improve the search experience so pressing Enter exits input mode while keeping the filter active. Matched text is highlighted in branch names, and normal operations (j/k, Enter, d, w) work on the filtered list.

## Related Issues

Closes #90

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Enter exits search input mode without clearing `search_query` — filter stays active
- `filtered_entries()` applies search filter regardless of `search_active` state
- Matched substring highlighted with underlined cyan in sidebar branch names
- Filter bar shows `/query` indicator when filter is active outside input mode
- Esc in normal mode clears the search filter and restores the original scroll position
- View switch (1/2/3) clears `search_query` to reset the filter

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Formatter passes
- [ ] Tests pass (verify manually)

## Test Plan

1. Press `/` and type `feat` — list filters to branches containing "feat", matched text is underlined cyan
2. Press Enter — input mode exits, filter stays active, filter bar shows `/feat`
3. Use j/k to navigate, Enter for action menu — normal operations work
4. Press Esc — filter clears, full list restores
5. Press `/feat` + Enter, then press `2` (My PR) — search query clears