### PR TITLE
feat: add "Copy branch name" to action menu

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +159,7 @@ name = "git-control-tower"
 version = "0.0.18"
 dependencies = [
  "anyhow",
+ "base64",
  "crossterm",
  "ratatui",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
+base64 = "0.22.1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -38,6 +38,7 @@ pub enum ActionItem {
     DeleteWorktree,
     DeleteBranch,
     OpenPrInBrowser,
+    CopyBranchName,
 }
 
 impl ActionItem {
@@ -48,6 +49,7 @@ impl ActionItem {
             Self::DeleteWorktree => "Delete worktree",
             Self::DeleteBranch => "Delete branch",
             Self::OpenPrInBrowser => "Open PR in browser",
+            Self::CopyBranchName => "Copy branch name",
         }
     }
 }
@@ -120,6 +122,7 @@ pub struct App {
     pub branch_selected: HashSet<String>,
     pub branch_delete_requested: bool,
     pub open_pr_requested: Option<u64>,
+    pub copy_branch_requested: Option<String>,
 }
 
 impl App {
@@ -166,6 +169,7 @@ impl App {
             branch_selected: HashSet::new(),
             branch_delete_requested: false,
             open_pr_requested: None,
+            copy_branch_requested: None,
         }
     }
 
@@ -537,6 +541,7 @@ impl App {
         if entry.pull_request.is_some() {
             items.push(ActionItem::OpenPrInBrowser);
         }
+        items.push(ActionItem::CopyBranchName);
         if entry.worktree.is_some() {
             items.push(ActionItem::CdIntoWorktree);
         }
@@ -633,6 +638,10 @@ impl App {
                 if let Some(pr) = &entry.pull_request {
                     self.open_pr_requested = Some(pr.number);
                 }
+            }
+            ActionItem::CopyBranchName => {
+                self.copy_branch_requested = Some(entry.name.clone());
+                self.notification = Some(Notification::success(format!("Copied: {}", entry.name)));
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -492,6 +492,11 @@ async fn run(
             let _ = run_gh(&["pr", "view", &pr_number.to_string(), "--web"]).await;
         }
 
+        // Copy branch name to clipboard if requested
+        if let Some(name) = app.copy_branch_requested.take() {
+            copy_to_clipboard(&name);
+        }
+
         if app.should_quit {
             break;
         }
@@ -577,6 +582,14 @@ async fn detect_default_branch() -> String {
         return "master".to_string();
     }
     "HEAD".to_string()
+}
+
+fn copy_to_clipboard(text: &str) {
+    use base64::Engine;
+    use std::io::Write;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(text);
+    let _ = std::io::stdout().write_all(format!("\x1b]52;c;{encoded}\x07").as_bytes());
+    let _ = std::io::stdout().flush();
 }
 
 fn compute_review_status(pr: &PullRequest, gh_user: &str) -> ReviewStatus {


### PR DESCRIPTION
## Summary

Add a "Copy branch name" option to the action menu that copies the selected branch name to the system clipboard via OSC 52 escape sequence, enabling quick pasting into terminal commands or PR descriptions.

## Related Issues

Closes #92

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add `CopyBranchName` variant to `ActionItem` enum
- Available for all branches (no conditions), positioned after "Open PR in browser"
- Uses OSC 52 escape sequence for clipboard access (works across macOS/Linux/Windows terminals)
- Shows "Copied: <branch>" success notification
- Add `base64` crate dependency for OSC 52 encoding

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Formatter passes
- [ ] Tests pass (verify manually)

## Test Plan

1. Select any branch → press Enter → "Copy branch name" appears as second item
2. Select it → "Copied: <branch>" notification appears
3. Cmd+V / Ctrl+V in terminal → branch name is pasted