### PR TITLE
fix: render TUI to /dev/tty instead of stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod event;
 mod git;
 mod ui;
 
+use anyhow::Context;
 use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::process;
@@ -75,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
         .read(true)
         .write(true)
         .open("/dev/tty")
-        .expect("failed to open /dev/tty");
+        .context("failed to open /dev/tty — is a controlling terminal available?")?;
     enable_raw_mode()?;
     execute!(tty, EnterAlternateScreen)?;
 
@@ -83,7 +84,9 @@ async fn main() -> anyhow::Result<()> {
     let original_hook = std::panic::take_hook();
     std::panic::set_hook(Box::new(move |info| {
         let _ = disable_raw_mode();
-        let _ = crossterm::execute!(std::io::stderr(), LeaveAlternateScreen);
+        if let Ok(mut panic_tty) = OpenOptions::new().write(true).open("/dev/tty") {
+            let _ = crossterm::execute!(panic_tty, LeaveAlternateScreen);
+        }
         original_hook(info);
     }));
 
@@ -92,8 +95,8 @@ async fn main() -> anyhow::Result<()> {
 
     let (result, cd_path) = run(&mut terminal, &config, verbose).await;
 
-    // Restore terminal
-    execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
+    // Restore terminal — always disable raw mode even if LeaveAlternateScreen fails
+    let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
     disable_raw_mode()?;
 
     if let Some(path) = cd_path {


### PR DESCRIPTION
## Summary

The shell-init wrapper (`eval "$(gct shell-init zsh)"`) captures stdout to detect worktree cd paths, which inadvertently swallows the TUI rendering. This fix renders the TUI directly to `/dev/tty`, keeping stdout reserved exclusively for cd path output.

## Related Issues

Closes #101

## Type of Change

- [x] Bug fix

## Changes

- Replace `ratatui::init()` (stdout-based) with manual `/dev/tty` backend initialization
- Use `CrosstermBackend<File>` instead of `CrosstermBackend<Stdout>`
- Replace `ratatui::restore()` with manual `LeaveAlternateScreen` + `disable_raw_mode`
- Add panic hook to restore terminal state on unexpected exit

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass

## Test Plan

1. Run `cargo test` — all tests pass
2. Without shell wrapper: run `gct` directly — TUI renders normally
3. With shell wrapper: `eval "$(cargo run -- shell-init zsh)"` then `gct` — TUI renders correctly
4. Select a worktree and press Enter — shell `cd`s to the worktree directory