### PR TITLE
feat(worktree): add symlink type to post_create hooks

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -117,12 +117,8 @@ fn copy_dir_recursive(src: &Path, dst: &Path) -> std::io::Result<()> {
 }
 
 fn create_symlink(src: &Path, dst: &Path) -> std::io::Result<()> {
-    // Resolve to absolute path so the symlink target is valid from the new worktree
-    let abs_src = if src.is_absolute() {
-        src.to_path_buf()
-    } else {
-        std::env::current_dir()?.join(src)
-    };
+    // Resolve to absolute canonical path so the symlink target is valid from the new worktree
+    let abs_src = fs::canonicalize(src)?;
     if let Some(parent) = dst.parent() {
         fs::create_dir_all(parent)?;
     }


### PR DESCRIPTION
## Summary

Adds a `symlink` type to worktree `post_create` hooks, allowing users to create symbolic links from the main worktree into new worktrees. Useful for sharing large directories (e.g. `.bin/`, `node_modules/`) without duplicating disk space.

## Related Issues

Closes #107

## Type of Change

- [x] New feature

## Changes

- Add `Symlink` variant to `PostCreateAction` enum
- Implement `create_symlink()` that resolves the source to an absolute path and creates the symlink
- Cross-platform support: `std::os::unix::fs::symlink` on Unix, `symlink_dir`/`symlink_file` on Windows
- Add 3 new tests: TOML parsing, file symlink, directory symlink

## Config Example

```toml
[[worktree.post_create]]
type = "symlink"
from = ".bin"
to = ".bin"
```

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (50 tests, 3 new)

## Test Plan

1. `cargo test` — all 50 tests pass
2. Add symlink config → create worktree → verify symlink exists and points to correct target
3. Mixed config (copy + symlink) → both operations succeed