### PR TITLE
feat(worktree): add command type to post_create hooks

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -151,7 +151,15 @@ fn run_command(command: &str, work_dir: &Path) -> std::io::Result<()> {
         .output()?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(std::io::Error::other(stderr.trim().to_string()));
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let msg = if !stderr.trim().is_empty() {
+            stderr.trim().to_string()
+        } else if !stdout.trim().is_empty() {
+            stdout.trim().to_string()
+        } else {
+            format!("exited with {}", output.status)
+        };
+        return Err(std::io::Error::other(msg));
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds a `command` type to worktree `post_create` hooks, allowing users to run arbitrary shell commands in the new worktree after creation. This completes the post_create hook system alongside `copy` (#104) and `symlink` (#107).

## Related Issues

Closes #110

## Type of Change

- [x] New feature

## Changes

- Add `Command` variant to `PostCreateAction` enum with a `command` string field
- Implement `run_command()` that executes via `sh -c` with the worktree as working directory
- Command failures are non-fatal — errors are collected and reported through the existing system
- Add 3 new tests: TOML parsing, command success, command failure

## Config Example

```toml
[[worktree.post_create]]
type = "command"
command = "npm ci"

[[worktree.post_create]]
type = "command"
command = "make bootstrap"
```

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (53 tests, 3 new)

## Test Plan

1. `cargo test` — all 53 tests pass
2. Add command config → create worktree → verify command runs in worktree directory
3. Add failing command → verify error shown in verbose mode
4. No command config → works as before