### PR TITLE
fix: use native clipboard commands instead of OSC 52

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -745,7 +745,7 @@ fn copy_via_native_command(text: &str) -> std::io::Result<()> {
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
     {
-        if let Some(stdin) = child.stdin.as_mut() {
+        if let Some(mut stdin) = child.stdin.take() {
             stdin.write_all(text.as_bytes())?;
         }
         let status = child.wait()?;


### PR DESCRIPTION
## Summary

Branch name copy silently fails because OSC 52 escape sequences don't work in many terminal environments (tmux, SSH, terminals without OSC 52 support). This fix uses platform-native clipboard commands as the primary method.

## Related Issues

Closes #114

## Type of Change

- [x] Bug fix

## Changes

- Add `copy_via_native_command()` that uses `pbcopy` on macOS and `xclip`/`xsel` on Linux
- Refactor `copy_to_clipboard()` to try native commands first, fall back to OSC 52
- Extract OSC 52 logic into `copy_via_osc52()` for clarity

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (53 tests)

## Test Plan

1. `cargo test` — all tests pass
2. macOS: copy branch name → paste in terminal → branch name appears
3. Linux with xclip: copy branch name → paste → works
4. Without native commands: falls back to OSC 52 silently