### PR TITLE
fix: exclude team review PRs from me-only Review filter

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -268,6 +268,7 @@ pub async fn fetch_my_prs(show_merged: bool) -> (Vec<PullRequest>, Vec<String>) 
 pub async fn fetch_review_prs(
     show_merged: bool,
     include_team: bool,
+    gh_user: &str,
 ) -> (Vec<PullRequest>, Vec<String>) {
     let mut queries = vec!["review-requested:@me", "reviewed-by:@me"];
     if include_team {
@@ -277,15 +278,30 @@ pub async fn fetch_review_prs(
     let mut all_prs = Vec::new();
     let mut all_errors = Vec::new();
     let mut seen: HashSet<u64> = HashSet::new();
+    let mut reviewed_numbers: HashSet<u64> = HashSet::new();
 
-    for query in queries {
+    for query in &queries {
         let (prs, errors) = fetch_pr_list(&["--search", query], show_merged).await;
         all_errors.extend(errors);
         for pr in prs {
+            if *query == "reviewed-by:@me" {
+                reviewed_numbers.insert(pr.number);
+            }
             if seen.insert(pr.number) {
                 all_prs.push(pr);
             }
         }
+    }
+
+    // When me-only, exclude PRs that only have team review requests
+    if !include_team && !gh_user.is_empty() {
+        all_prs.retain(|pr| {
+            reviewed_numbers.contains(&pr.number)
+                || pr
+                    .review_requests
+                    .iter()
+                    .any(|r| r.login.as_deref() == Some(gh_user))
+        });
     }
 
     // Sort by updated_at descending for consistent ordering

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,8 +311,10 @@ async fn run(
                 MainFilter::ReviewRequested => {
                     let show_merged = app.show_merged;
                     let include_team = app.include_team_reviews;
+                    let gh_user = app.gh_user.clone();
                     tokio::spawn(async move {
-                        let (prs, errors) = data::fetch_review_prs(show_merged, include_team).await;
+                        let (prs, errors) =
+                            data::fetch_review_prs(show_merged, include_team, &gh_user).await;
                         let _ = tx.send(AsyncResult::ReviewPrList(prs, errors));
                     });
                 }


### PR DESCRIPTION
## Summary

The Review view's me-only mode (team toggle off) was showing PRs assigned to teams the user belongs to. The `review-requested:@me` GitHub search query can include team review requests. This fix filters results after fetching to exclude team-only PRs.

## Related Issues

Closes #118

## Type of Change

- [x] Bug fix

## Changes

- Add `gh_user` parameter to `fetch_review_prs()` for post-fetch filtering
- Track which PRs came from `reviewed-by:@me` query (always kept)
- When `include_team` is false, retain only PRs where the user is directly listed as a reviewer or has already reviewed
- Pass `app.gh_user` from the async spawn in main.rs

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (53 tests)

## Test Plan

1. `cargo test` — all tests pass
2. Review view (me only): only PRs with direct user review assignment appear
3. Toggle `t` (team): team review PRs now included
4. `reviewed-by:@me` PRs always appear regardless of toggle