### PR TITLE
feat(ui): show Draft/Open label for PRs in sidebar and detail pane

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -166,7 +166,7 @@ pub async fn fetch_local_prs(
             let escaped_name = name.replace('\\', "\\\\").replace('"', "\\\"");
             aliases.push_str(&format!(
                 r#"{alias}: pullRequests(first: 2, headRefName: "{escaped_name}", states: [OPEN, MERGED], orderBy: {{field: UPDATED_AT, direction: DESC}}) {{
-  nodes {{ number title state headRefName updatedAt author {{ login }}
+  nodes {{ number title state headRefName updatedAt isDraft author {{ login }}
     reviewRequests(first: 10) {{ nodes {{ requestedReviewer {{ ... on User {{ login }} }} }} }}
   }}
 }}
@@ -231,6 +231,8 @@ fn parse_graphql_pr(node: &serde_json::Value) -> Option<PullRequest> {
         .unwrap_or_default()
         .to_string();
 
+    let is_draft = node["isDraft"].as_bool().unwrap_or(false);
+
     let review_requests = node["reviewRequests"]["nodes"]
         .as_array()
         .map(|arr| {
@@ -251,6 +253,7 @@ fn parse_graphql_pr(node: &serde_json::Value) -> Option<PullRequest> {
         state,
         head_ref,
         updated_at,
+        is_draft,
         review_requests,
         latest_reviews: Vec::new(),
         review_status: None,
@@ -314,7 +317,8 @@ pub async fn fetch_review_prs(
 /// `filter_args` is passed directly to `gh pr list` (e.g., `["--author", "@me"]`).
 /// Returns (prs, errors) where errors contains any fetch/parse failures.
 async fn fetch_pr_list(filter_args: &[&str], show_merged: bool) -> (Vec<PullRequest>, Vec<String>) {
-    let pr_fields = "number,title,author,state,headRefName,updatedAt,reviewRequests,latestReviews";
+    let pr_fields =
+        "number,title,author,state,headRefName,updatedAt,isDraft,reviewRequests,latestReviews";
     let filter_label = filter_args.join(" ");
     let mut prs = Vec::new();
     let mut errors = Vec::new();
@@ -416,6 +420,7 @@ mod tests {
             head_ref: "feature-a".to_string(),
             updated_at: "2024-01-15".to_string(),
             review_requests: vec![],
+            is_draft: false,
             latest_reviews: vec![],
             review_status: None,
         }];
@@ -439,6 +444,7 @@ mod tests {
             head_ref: "remote-branch".to_string(),
             updated_at: "2024-01-15".to_string(),
             review_requests: vec![],
+            is_draft: false,
             latest_reviews: vec![],
             review_status: None,
         }];
@@ -465,6 +471,7 @@ mod tests {
             head_ref: "feature-a".to_string(),
             updated_at: "2024-01-15".to_string(),
             review_requests: vec![],
+            is_draft: false,
             latest_reviews: vec![],
             review_status: None,
         }];
@@ -493,6 +500,7 @@ mod tests {
                 head_ref: "feature-a".to_string(),
                 updated_at: "2024-01-01".to_string(),
                 review_requests: vec![],
+                is_draft: false,
                 latest_reviews: vec![],
                 review_status: None,
             },
@@ -504,6 +512,7 @@ mod tests {
                 head_ref: "feature-a".to_string(),
                 updated_at: "2024-01-15".to_string(),
                 review_requests: vec![],
+                is_draft: false,
                 latest_reviews: vec![],
                 review_status: None,
             },

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -46,6 +46,8 @@ pub struct PullRequest {
     #[serde(rename = "reviewRequests", default)]
     #[allow(dead_code)]
     pub review_requests: Vec<ReviewRequest>,
+    #[serde(rename = "isDraft", default)]
+    pub is_draft: bool,
     #[serde(rename = "latestReviews", default)]
     pub latest_reviews: Vec<LatestReview>,
     #[serde(skip)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1039,6 +1039,7 @@ mod tests {
             head_ref: String::new(),
             updated_at: String::new(),
             review_requests: vec![],
+            is_draft: false,
             latest_reviews: vec![],
             review_status: None,
         };
@@ -1056,6 +1057,7 @@ mod tests {
             head_ref: String::new(),
             updated_at: String::new(),
             review_requests: vec![],
+            is_draft: false,
             latest_reviews: vec![LatestReview {
                 author: "other-user".to_string(),
                 state: "APPROVED".to_string(),
@@ -1079,6 +1081,7 @@ mod tests {
             head_ref: String::new(),
             updated_at: String::new(),
             review_requests: vec![],
+            is_draft: false,
             latest_reviews: vec![LatestReview {
                 author: "katzkb".to_string(),
                 state: "APPROVED".to_string(),
@@ -1099,6 +1102,7 @@ mod tests {
             head_ref: String::new(),
             updated_at: String::new(),
             review_requests: vec![],
+            is_draft: false,
             latest_reviews: vec![LatestReview {
                 author: "katzkb".to_string(),
                 state: "CHANGES_REQUESTED".to_string(),

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -197,17 +197,22 @@ fn draw_pr_section(
     )));
 
     // Author + State
-    let state_color = match pr.state.as_str() {
-        "OPEN" => Color::Green,
-        "CLOSED" => Color::Red,
-        "MERGED" => Color::Magenta,
-        _ => Color::White,
+    let (state_str, state_color) = if pr.is_draft {
+        ("DRAFT".to_string(), Color::DarkGray)
+    } else {
+        let color = match pr.state.as_str() {
+            "OPEN" => Color::Green,
+            "CLOSED" => Color::Red,
+            "MERGED" => Color::Magenta,
+            _ => Color::White,
+        };
+        (pr.state.clone(), color)
     };
     lines.push(Line::from(vec![
         Span::styled("  Author: ", Style::default().fg(Color::DarkGray)),
         Span::styled(pr.author.clone(), Style::default().fg(Color::White)),
         Span::styled("  State: ", Style::default().fg(Color::DarkGray)),
-        Span::styled(pr.state.clone(), Style::default().fg(state_color)),
+        Span::styled(state_str, Style::default().fg(state_color)),
     ]));
 
     // Review status

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -174,6 +174,16 @@ fn format_entry_line(
         ));
     }
 
+    // Draft tag
+    if let Some(pr) = &entry.pull_request
+        && pr.is_draft
+    {
+        spans.push(Span::styled(
+            " [draft]",
+            Style::default().fg(Color::DarkGray),
+        ));
+    }
+
     // Review status tag
     if let Some(pr) = &entry.pull_request
         && let Some(status) = &pr.review_status


### PR DESCRIPTION
## Summary

PRs in the My PR view all showed the same OPEN state with no way to distinguish drafts. This adds `isDraft` support to show a `[draft]` label in the sidebar and DRAFT state in the detail pane.

## Related Issues

Closes #128

## Type of Change

- [x] New feature

## Changes

- Add `is_draft: bool` field to `PullRequest` struct (deserialized from `isDraft`)
- Add `isDraft` to `gh pr list --json` fields and GraphQL query
- Sidebar: show `[draft]` label in gray after PR number for draft PRs
- Detail pane: show "DRAFT" in gray instead of "OPEN" in green for draft PRs

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes
- [x] Tests pass (54 tests)

## Test Plan

1. `cargo test` — all tests pass
2. Have a draft PR open → My PR view shows `[draft]` label, detail pane shows DRAFT
3. Non-draft open PRs show no extra label, detail pane shows OPEN as before