### PR TITLE
feat: make protected branches configurable and hide [merged] label

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,20 @@ type = "command"
 command = "npm ci"
 ```
 
+### Protected Branches
+
+Protected branches are excluded from the `[merged]` label, yellow name color, and all deletion actions (`space`, `a`, action menu). Default: `["main", "master", "develop"]`.
+
+```toml
+# Override the default list — useful if your team uses `staging`, `release`, etc.
+protected_branches = ["main", "develop", "staging"]
+
+# Or disable protection entirely
+# protected_branches = []
+```
+
+Branch names are matched case-sensitively.
+
 ## License
 
 Licensed under either of

--- a/src/app.rs
+++ b/src/app.rs
@@ -129,10 +129,13 @@ pub struct App {
 
     // Spinner animation
     spinner_tick: usize,
+
+    // Loaded TOML config (protected_branches, worktree, …)
+    pub config: crate::config::Config,
 }
 
 impl App {
-    pub fn new() -> Self {
+    pub fn new(config: crate::config::Config) -> Self {
         Self {
             active_view: ActiveView::default(),
             should_quit: false,
@@ -180,6 +183,7 @@ impl App {
             open_pr_requested: None,
             copy_branch_requested: None,
             spinner_tick: 0,
+            config,
         }
     }
 
@@ -409,22 +413,23 @@ impl App {
                 }
             }
             KeyCode::Char(' ') => {
-                if let Some(entry) = self.selected_entry() {
-                    let name = entry.name.clone();
-                    if !entry.is_current() && !Self::is_protected_branch(&name) {
-                        if self.branch_selected.contains(&name) {
-                            self.branch_selected.remove(&name);
-                        } else {
-                            self.branch_selected.insert(name);
-                        }
+                if let Some(entry) = self.selected_entry().cloned()
+                    && !entry.is_current()
+                    && !self.is_protected_branch(&entry.name)
+                {
+                    if self.branch_selected.contains(&entry.name) {
+                        self.branch_selected.remove(&entry.name);
+                    } else {
+                        self.branch_selected.insert(entry.name);
                     }
                 }
             }
             KeyCode::Char('a') => {
+                let protected = &self.config.protected_branches;
                 for entry in &self.entries {
                     if (entry.is_merged() || entry.pr_is_merged())
                         && !entry.is_current()
-                        && !Self::is_protected_branch(&entry.name)
+                        && !protected.iter().any(|b| b == &entry.name)
                     {
                         self.branch_selected.insert(entry.name.clone());
                     }
@@ -590,7 +595,7 @@ impl App {
         }
         if entry.local_branch.is_some()
             && !entry.is_current()
-            && !Self::is_protected_branch(&entry.name)
+            && !self.is_protected_branch(&entry.name)
         {
             items.push(ActionItem::DeleteBranch);
         }
@@ -701,7 +706,7 @@ impl App {
         }
     }
 
-    pub fn is_protected_branch(name: &str) -> bool {
-        matches!(name, "main" | "master")
+    pub fn is_protected_branch(&self, name: &str) -> bool {
+        self.config.protected_branches.iter().any(|b| b == name)
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -425,15 +425,17 @@ impl App {
                 }
             }
             KeyCode::Char('a') => {
-                let protected = &self.config.protected_branches;
-                for entry in &self.entries {
-                    if (entry.is_merged() || entry.pr_is_merged())
-                        && !entry.is_current()
-                        && !protected.iter().any(|b| b == &entry.name)
-                    {
-                        self.branch_selected.insert(entry.name.clone());
-                    }
-                }
+                let to_select: Vec<String> = self
+                    .entries
+                    .iter()
+                    .filter(|e| {
+                        (e.is_merged() || e.pr_is_merged())
+                            && !e.is_current()
+                            && !self.is_protected_branch(&e.name)
+                    })
+                    .map(|e| e.name.clone())
+                    .collect();
+                self.branch_selected.extend(to_select);
             }
             KeyCode::Char('d') => {
                 if !self.branch_selected.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,10 +4,25 @@ use std::path::{Path, PathBuf};
 
 const DEFAULT_WORKTREE_DIR: &str = "..";
 
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize)]
 pub struct Config {
     #[serde(default)]
     pub worktree: WorktreeConfig,
+    #[serde(default = "default_protected_branches")]
+    pub protected_branches: Vec<String>,
+}
+
+fn default_protected_branches() -> Vec<String> {
+    vec!["main".into(), "master".into(), "develop".into()]
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            worktree: WorktreeConfig::default(),
+            protected_branches: default_protected_branches(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -259,6 +274,7 @@ mod tests {
                 dir: "../wt".to_string(),
                 ..Default::default()
             },
+            ..Default::default()
         };
         let expected = Path::new("../wt").join("feature/auth");
         assert_eq!(
@@ -312,8 +328,51 @@ dir = "../wt"
                 dir: "  ".to_string(),
                 ..Default::default()
             },
+            ..Default::default()
         };
         assert_eq!(config.worktree_path("feature/auth"), "../feature/auth");
+    }
+
+    #[test]
+    fn test_default_protected_branches() {
+        let config = Config::default();
+        assert_eq!(
+            config.protected_branches,
+            vec![
+                "main".to_string(),
+                "master".to_string(),
+                "develop".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_protected_branches() {
+        let toml_str = r#"
+protected_branches = ["main", "develop", "staging"]
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(
+            config.protected_branches,
+            vec![
+                "main".to_string(),
+                "develop".to_string(),
+                "staging".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_config_uses_default_protected() {
+        let config: Config = toml::from_str("").unwrap();
+        assert_eq!(
+            config.protected_branches,
+            vec![
+                "main".to_string(),
+                "master".to_string(),
+                "develop".to_string()
+            ]
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 
 const DEFAULT_WORKTREE_DIR: &str = "..";
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     #[serde(default)]
     pub worktree: WorktreeConfig,
@@ -36,7 +36,7 @@ pub enum PostCreateAction {
     Command { command: String },
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 pub struct WorktreeConfig {
     #[serde(default = "default_worktree_dir")]
     pub dir: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ async fn main() -> anyhow::Result<()> {
     let backend = CrosstermBackend::new(tty);
     let mut terminal = Terminal::new(backend)?;
 
-    let (result, cd_path) = run(&mut terminal, &config, verbose).await;
+    let (result, cd_path) = run(&mut terminal, config, verbose).await;
 
     // Restore terminal — always disable raw mode even if LeaveAlternateScreen fails
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
@@ -144,10 +144,10 @@ async fn check_prerequisites() {
 
 async fn run(
     terminal: &mut Terminal<CrosstermBackend<std::fs::File>>,
-    config: &config::Config,
+    config: config::Config,
     verbose: bool,
 ) -> (anyhow::Result<()>, Option<String>) {
-    let mut app = App::new();
+    let mut app = App::new(config);
     app.verbose = verbose;
     let mut events = EventHandler::new(Duration::from_millis(80));
     let (tx, mut rx) = mpsc::unbounded_channel::<AsyncResult>();
@@ -544,12 +544,12 @@ async fn run(
         // Create worktree if requested (async, non-blocking)
         if let Some(branch_name) = app.wt_create_requested.take() {
             app.wt_loading = true;
-            let wt_path = config.worktree_path(&branch_name);
+            let wt_path = app.config.worktree_path(&branch_name);
             if let Some(parent) = std::path::Path::new(&wt_path).parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
             let has_local = app.branches.iter().any(|b| b.name == branch_name);
-            let post_create = config.worktree.post_create.clone();
+            let post_create = app.config.worktree.post_create.clone();
             let tx = tx.clone();
             tokio::spawn(async move {
                 let result = if has_local {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -94,10 +94,12 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                 .iter()
                 .map(|entry| {
                     let is_selected = app.branch_selected.contains(&entry.name);
+                    let is_protected = app.is_protected_branch(&entry.name);
                     ListItem::new(format_entry_line(
                         entry,
                         show_checkboxes,
                         is_selected,
+                        is_protected,
                         search_query,
                     ))
                 })
@@ -131,6 +133,7 @@ fn format_entry_line(
     entry: &BranchEntry,
     show_checkboxes: bool,
     is_selected: bool,
+    is_protected: bool,
     search_query: &str,
 ) -> Line<'static> {
     let mut spans: Vec<Span> = Vec::new();
@@ -149,7 +152,7 @@ fn format_entry_line(
         Style::default()
             .fg(Color::Green)
             .add_modifier(Modifier::BOLD)
-    } else if entry.is_merged() || entry.pr_is_merged() {
+    } else if (entry.is_merged() || entry.pr_is_merged()) && !is_protected {
         Style::default().fg(Color::Yellow)
     } else {
         Style::default().fg(Color::White)
@@ -206,7 +209,7 @@ fn format_entry_line(
     }
 
     // Merged tag
-    if (entry.is_merged() || entry.pr_is_merged()) && !entry.is_current() {
+    if (entry.is_merged() || entry.pr_is_merged()) && !entry.is_current() && !is_protected {
         spans.push(Span::styled(
             " [merged]",
             Style::default().fg(Color::Yellow),


### PR DESCRIPTION
## Summary

Make the list of protected branches configurable via `.gct.toml` (default `["main", "master", "develop"]`), and hide the `[merged]` label and yellow branch-name color for protected branches in the sidebar. Previously `develop` was shown as `[merged]` in teams that merge it into `main`, which misled users who read that label as "safe to delete".

## Related Issues

Closes #140

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add `protected_branches: Vec<String>` to `Config` with a serde default of `["main", "master", "develop"]` and a custom `impl Default`
- Store the loaded `Config` on `App`; convert `is_protected_branch` from a static helper to a `&self` method reading from `self.config.protected_branches`
- Update the three call sites (`space`, `a`, action menu). The `a` handler uses a disjoint borrow of `self.config.protected_branches` to keep the borrow checker happy alongside `&self.entries` and `&mut self.branch_selected`
- Thread `Config` by value through `main::run` → `App::new`, switching the two worktree-creation call sites to `app.config.…`
- `format_entry_line` now takes an `is_protected: bool` flag computed per entry by `draw_entry_list`; both the yellow name color and the `[merged]` label are suppressed when the branch is protected

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (\`cargo clippy -- -D warnings\`)
- [x] Tests pass (\`cargo test\` — 57 passed, 3 new)

## Test Plan

1. Run \`cargo fmt -- --check && cargo clippy -- -D warnings && cargo test\`
2. Build and open gct in a repo where \`develop\` has been merged into \`main\`:
   - \`develop\` shows in default (white) color with no \`[merged]\` label
   - Other actually-merged feature branches still show yellow \`[merged]\`
   - Pressing \`a\` does not select \`develop\`; \`space\` on \`develop\` is a no-op
   - Action menu on \`develop\` (\`Enter\`) does not show "Delete branch"
3. Create \`.gct.toml\` with \`protected_branches = ["main", "develop", "staging"]\` and verify \`staging\` is also excluded from \`[merged]\` / selection / action menu
4. Set \`protected_branches = []\` and verify \`main\` becomes selectable again