### PR TITLE
fix: defer review fetch until gh_user is known

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -82,6 +82,7 @@ pub struct App {
     pub branches: Vec<Branch>,
     pub worktrees: Vec<Worktree>,
     pub gh_user: String,
+    pub gh_user_load_failed: bool,
 
     // Per-view PR caches
     pub local_prs: Vec<PullRequest>,
@@ -152,6 +153,7 @@ impl App {
             branches: Vec::new(),
             worktrees: Vec::new(),
             gh_user: String::new(),
+            gh_user_load_failed: false,
             local_prs: Vec::new(),
             my_prs: Vec::new(),
             review_prs: Vec::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,14 +326,23 @@ async fn run(
                     });
                 }
                 MainFilter::ReviewRequested => {
-                    let show_merged = app.show_merged;
-                    let include_team = app.include_team_reviews;
-                    let gh_user = app.gh_user.clone();
-                    tokio::spawn(async move {
-                        let (prs, errors) =
-                            data::fetch_review_prs(show_merged, include_team, &gh_user).await;
-                        let _ = tx.send(AsyncResult::ReviewPrList(prs, errors));
-                    });
+                    // Defer until gh_user is known — GitHub's `review-requested:@me`
+                    // search expands to team memberships, and the post-fetch filter
+                    // in fetch_review_prs only runs when gh_user is non-empty. Without
+                    // this guard, switching to Review right after startup can show
+                    // team PRs even in me-only mode.
+                    if app.gh_user.is_empty() && !app.include_team_reviews {
+                        app.pr_fetch_requested = Some(MainFilter::ReviewRequested);
+                    } else {
+                        let show_merged = app.show_merged;
+                        let include_team = app.include_team_reviews;
+                        let gh_user = app.gh_user.clone();
+                        tokio::spawn(async move {
+                            let (prs, errors) =
+                                data::fetch_review_prs(show_merged, include_team, &gh_user).await;
+                            let _ = tx.send(AsyncResult::ReviewPrList(prs, errors));
+                        });
+                    }
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -330,8 +330,12 @@ async fn run(
                     // search expands to team memberships, and the post-fetch filter
                     // in fetch_review_prs only runs when gh_user is non-empty. Without
                     // this guard, switching to Review right after startup can show
-                    // team PRs even in me-only mode.
-                    if app.gh_user.is_empty() && !app.include_team_reviews {
+                    // team PRs even in me-only mode. If the user-login fetch failed,
+                    // proceed anyway — no point in spinning forever.
+                    if app.gh_user.is_empty()
+                        && !app.include_team_reviews
+                        && !app.gh_user_load_failed
+                    {
                         app.pr_fetch_requested = Some(MainFilter::ReviewRequested);
                     } else {
                         let show_merged = app.show_merged;
@@ -392,6 +396,7 @@ async fn run(
                     }
                 }
                 AsyncResult::UserLoginError(error_msg) => {
+                    app.gh_user_load_failed = true;
                     if app.verbose && !app.verbose_errors.contains(&error_msg) {
                         app.verbose_errors.push(error_msg);
                     }


### PR DESCRIPTION
## Summary

The Review filter sometimes showed team-requested PRs on initial display even in me-only mode. This was a race: `gh_user` is fetched async at startup, and if the user switched to the Review view before it arrived, `fetch_review_prs` ran with an empty `gh_user`, which silently disabled the post-fetch team-exclusion filter. Because GitHub's `review-requested:@me` search expands to team memberships, team PRs leaked through.

## Related Issues

Closes #142

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- In the `MainFilter::ReviewRequested` branch of the `pr_fetch_requested` handler, detect the race: if `gh_user` is empty and the user is in me-only mode, put the request back on `app.pr_fetch_requested` instead of firing the fetch. The next tick (80 ms) retries until `UserLogin` arrives.

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (\`cargo clippy -- -D warnings\`)
- [x] Tests pass (\`cargo test\` — 57 passed)

## Test Plan

1. Build and launch gct; immediately press the key for Review filter before \`gh_user\` finishes loading
   - Expected: only me-requested PRs shown, no team PRs
2. Start gct, wait a few seconds, then open Review filter
   - Expected: works as before
3. Press \`t\` in Review view to enable team reviews
   - Expected: team PRs appear; toggling off filters them out
4. No automated test — the race is hard to reproduce deterministically and the logic is a single guard