### PR TITLE
feat: add --help / -h flag with usage output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,12 @@ async fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
+    // Handle --help / -h before any prerequisite checks so it works outside a git repo
+    if std::env::args().any(|a| a == "--help" || a == "-h") {
+        print_help();
+        return Ok(());
+    }
+
     // Handle shell-init subcommand
     let args: Vec<String> = std::env::args().collect();
     if args.get(1).map(|s| s.as_str()) == Some("shell-init") {
@@ -739,6 +745,34 @@ async fn detect_default_branch() -> String {
         return "master".to_string();
     }
     "HEAD".to_string()
+}
+
+fn print_help() {
+    print!(
+        "gct — Git Control Tower
+A terminal TUI for Git/GitHub branch, PR, and worktree management.
+
+USAGE:
+    gct [OPTIONS]
+    gct shell-init <SHELL>
+
+OPTIONS:
+    -h, --help        Print this help message and exit
+    -v, --version     Print version and exit
+        --verbose     Surface silenced errors for troubleshooting
+
+SUBCOMMANDS:
+    shell-init <SHELL>
+        Print shell wrapper code for `cd into worktree` support.
+        SHELL is one of: zsh, bash, fish (default: zsh).
+        Example: eval \"$(gct shell-init zsh)\"
+
+Run `gct` with no arguments inside a git repository to launch the TUI.
+
+CONFIG:
+    .gct.toml (repo root) → ~/.config/gct/config.toml → ~/.gct.toml
+"
+    );
 }
 
 fn print_shell_init(shell: &str) {


### PR DESCRIPTION
## Summary

`gct --help` previously fell through to `check_prerequisites()` and died with `Error: not a git repository` when run outside a git repo. Add an early-exit `--help` / `-h` handler symmetric to the existing `--version` handler so usage is discoverable from any directory.

## Related Issues

Closes #144

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add `--help` / `-h` early-exit branch in `main()` immediately after the `--version` branch — runs before `check_prerequisites()`, so it works outside a git repository
- Add `print_help()` helper next to `print_shell_init` that prints usage covering `--version`, `--help`, `--verbose`, the `shell-init` subcommand, and a note about the TUI launch and config file lookup order

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (\`cargo clippy -- -D warnings\`)
- [x] Tests pass (\`cargo test\` — 57 passed)

## Test Plan

1. \`cargo run -- --help\` and \`cargo run -- -h\` → both print usage and exit 0
2. After \`cargo install --path .\`:
   - \`cd /tmp && gct --help\` → prints usage, exits 0 (no "not a git repository")
   - \`cd /tmp && gct --version\` → still works (regression check)
   - \`gct\` from a git repo → still launches the TUI