### PR TITLE
feat: add r key to refresh the current view

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -413,7 +413,9 @@ impl App {
                             self.review_prs_loaded = false;
                         }
                     }
-                    // Stale PR detail bodies should also reload
+                    // Clear PR detail cache for ALL filters, not just the current
+                    // one — stale detail bodies are risky after a refresh, and the
+                    // detail pane will refetch on the next selection.
                     self.pr_detail_cache.clear();
                     // Signal branches/worktrees reload + PR fetch
                     self.branches_reload_requested = true;

--- a/src/app.rs
+++ b/src/app.rs
@@ -127,6 +127,8 @@ pub struct App {
     pub branch_delete_requested: bool,
     pub open_pr_requested: Option<u64>,
     pub copy_branch_requested: Option<String>,
+    pub branches_reload_requested: bool,
+    pub commits_reload_requested: bool,
 
     // Spinner animation
     spinner_tick: usize,
@@ -184,6 +186,8 @@ impl App {
             branch_delete_requested: false,
             open_pr_requested: None,
             copy_branch_requested: None,
+            branches_reload_requested: false,
+            commits_reload_requested: false,
             spinner_tick: 0,
             config,
         }
@@ -392,6 +396,35 @@ impl App {
                 }
                 self.request_details_for_selection();
             }
+            KeyCode::Char('r') => match self.active_view {
+                ActiveView::Main => {
+                    // Invalidate current filter's PR cache so the fetch is forced
+                    match self.main_filter {
+                        MainFilter::Local => {
+                            self.local_prs.clear();
+                            self.local_prs_loaded = false;
+                        }
+                        MainFilter::MyPr => {
+                            self.my_prs.clear();
+                            self.my_prs_loaded = false;
+                        }
+                        MainFilter::ReviewRequested => {
+                            self.review_prs.clear();
+                            self.review_prs_loaded = false;
+                        }
+                    }
+                    // Stale PR detail bodies should also reload
+                    self.pr_detail_cache.clear();
+                    // Signal branches/worktrees reload + PR fetch
+                    self.branches_reload_requested = true;
+                    self.pr_fetch_requested = Some(self.main_filter);
+                    self.notification = Some(Notification::success("Refreshing…"));
+                }
+                ActiveView::Log => {
+                    self.commits_reload_requested = true;
+                    self.notification = Some(Notification::success("Refreshing…"));
+                }
+            },
             _ => match self.active_view {
                 ActiveView::Main => self.handle_main_key(key.code),
                 ActiveView::Log => self.handle_log_key(key.code),

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,6 +286,28 @@ async fn run(
             });
         }
 
+        // Reload branches/worktrees on `r` refresh from Main view
+        if app.branches_reload_requested {
+            app.branches_reload_requested = false;
+            refresh_entries(&mut app).await;
+        }
+
+        // Reload commits on `r` refresh from Log view
+        if app.commits_reload_requested {
+            app.commits_reload_requested = false;
+            if let Ok(output) = run_git(&[
+                "log",
+                "--format=%h%x00%s%x00%an%x00%ad",
+                "--date=short",
+                "-n",
+                "200",
+            ])
+            .await
+            {
+                app.commits = parse_log(&output);
+            }
+        }
+
         // Spawn git status load in background (non-blocking, deduplicated)
         if let Some(wt_path) = app.git_status_requested.take()
             && !status_inflight.contains(&wt_path)

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,6 +29,15 @@ use crate::git::parser::{parse_branches, parse_log, parse_worktrees};
 use crate::git::types::{GitStatus, PrDetail, PullRequest, ReviewStatus};
 use crate::ui::notification::Notification;
 
+/// Args used for fetching commits in the Log view (startup + `r` refresh).
+const LOG_ARGS: &[&str] = &[
+    "log",
+    "--format=%h%x00%s%x00%an%x00%ad",
+    "--date=short",
+    "-n",
+    "200",
+];
+
 struct RepoInfo {
     owner: String,
     repo: String,
@@ -161,15 +170,7 @@ async fn run(
     let mut status_inflight: HashSet<String> = HashSet::new();
 
     // Phase 1: Fast local loads (blocking, ~170ms)
-    if let Ok(output) = run_git(&[
-        "log",
-        "--format=%h%x00%s%x00%an%x00%ad",
-        "--date=short",
-        "-n",
-        "200",
-    ])
-    .await
-    {
+    if let Ok(output) = run_git(LOG_ARGS).await {
         app.commits = parse_log(&output);
     }
     if let Ok(output) = run_git(&["worktree", "list", "--porcelain"]).await {
@@ -295,15 +296,7 @@ async fn run(
         // Reload commits on `r` refresh from Log view
         if app.commits_reload_requested {
             app.commits_reload_requested = false;
-            if let Ok(output) = run_git(&[
-                "log",
-                "--format=%h%x00%s%x00%an%x00%ad",
-                "--date=short",
-                "-n",
-                "200",
-            ])
-            .await
-            {
+            if let Ok(output) = run_git(LOG_ARGS).await {
                 app.commits = parse_log(&output);
             }
         }

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 pub fn draw(frame: &mut Frame) {
-    let area = centered_rect(60, 26, frame.area());
+    let area = centered_rect(60, 27, frame.area());
     frame.render_widget(Clear, area);
 
     let lines = vec![
@@ -23,6 +23,7 @@ pub fn draw(frame: &mut Frame) {
         key_line("2", "Filter: My PR"),
         key_line("3", "Filter: Review"),
         key_line("l", "Log View"),
+        key_line("r", "Refresh current view"),
         key_line("?", "Toggle this help"),
         key_line("q", "Quit"),
         Line::from(""),


### PR DESCRIPTION
## Summary

gct's data only loaded at startup, so users had to quit and relaunch to see new branches, PR updates, or fresh commits. Add a `r` key that re-fetches the data behind the currently visible view — branches/worktrees/PRs in Main, commits in Log — reusing the existing async fetch machinery so the keypress is cheap.

## Related Issues

Closes #146

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add two new request flags on `App`: `branches_reload_requested` and `commits_reload_requested`
- Wire `r` into the global key dispatch:
  - **Main view**: invalidate the current filter's PR cache and the PR detail cache, set `branches_reload_requested = true`, and re-request a PR fetch via `pr_fetch_requested = Some(self.main_filter)`. Other filters' caches stay warm so a quick `1`/`2`/`3` switch is still instant.
  - **Log view**: set `commits_reload_requested = true`.
  - Both paths show a brief "Refreshing…" notification (auto-dismiss 3s).
- In `main::run`, consume the new flags next to the existing async request handlers — `refresh_entries(&mut app).await` for the Main path and a `git log` fetch for the Log path
- Document the binding in the help overlay (`?`) under the **Global** section, and bump the overlay height by one line

Scroll position is preserved across the refresh (unlike `1`/`2`/`3` which jump to a new filter).

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (\`cargo clippy -- -D warnings\`)
- [x] Tests pass (\`cargo test\` — 57 passed)

## Test Plan

1. Launch \`gct\` in a repo
2. Externally run \`git branch test-r\`, press \`r\` in Main view → the new branch appears (no quit)
3. Externally make a commit, switch to Log view (\`l\`), press \`r\` → the new commit appears at the top
4. Sidebar/log scroll position is unchanged after refresh
5. The \"Refreshing…\" notification appears and auto-dismisses
6. Press \`r\` rapidly → no crash, the existing dedup machinery handles it
7. Open help overlay with \`?\` → \`r — Refresh current view\` is listed in Global