### PR TITLE
feat: add command history view (h) showing session git/gh calls

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,7 @@ pub enum ActiveView {
     #[default]
     Main,
     Log,
+    History,
 }
 
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
@@ -67,6 +68,9 @@ pub struct App {
     // Log View
     pub commits: Vec<Commit>,
     pub log_scroll: usize,
+
+    // History View
+    pub history_scroll: usize,
 
     // Main View — unified entries
     pub entries: Vec<BranchEntry>,
@@ -144,6 +148,7 @@ impl App {
             should_quit: false,
             commits: Vec::new(),
             log_scroll: 0,
+            history_scroll: 0,
             entries: Vec::new(),
             entries_loaded: false,
             main_filter: MainFilter::default(),
@@ -353,13 +358,17 @@ impl App {
                     self.sidebar_scroll = self.search_pre_scroll;
                     self.sidebar_offset = 0;
                     self.request_details_for_selection();
-                } else if self.active_view == ActiveView::Log {
+                } else if matches!(self.active_view, ActiveView::Log | ActiveView::History) {
                     self.active_view = ActiveView::Main;
                 } else {
                     self.should_quit = true;
                 }
             }
             KeyCode::Char('l') => self.active_view = ActiveView::Log,
+            KeyCode::Char('h') => {
+                self.active_view = ActiveView::History;
+                self.history_scroll = 0;
+            }
             KeyCode::Char('1') => {
                 self.main_filter = MainFilter::Local;
                 self.active_view = ActiveView::Main;
@@ -426,10 +435,14 @@ impl App {
                     self.commits_reload_requested = true;
                     self.notification = Some(Notification::success("Refreshing…"));
                 }
+                ActiveView::History => {
+                    // History updates live as commands run — no manual refresh needed.
+                }
             },
             _ => match self.active_view {
                 ActiveView::Main => self.handle_main_key(key.code),
                 ActiveView::Log => self.handle_log_key(key.code),
+                ActiveView::History => self.handle_history_key(key.code),
             },
         }
     }
@@ -562,6 +575,21 @@ impl App {
             }
             KeyCode::Char('k') | KeyCode::Up => {
                 self.log_scroll = self.log_scroll.saturating_sub(1);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_history_key(&mut self, code: KeyCode) {
+        let len = crate::git::command::command_history_snapshot().len();
+        match code {
+            KeyCode::Char('j') | KeyCode::Down => {
+                if len > 0 && self.history_scroll + 1 < len {
+                    self.history_scroll += 1;
+                }
+            }
+            KeyCode::Char('k') | KeyCode::Up => {
+                self.history_scroll = self.history_scroll.saturating_sub(1);
             }
             _ => {}
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -366,8 +366,10 @@ impl App {
             }
             KeyCode::Char('l') => self.active_view = ActiveView::Log,
             KeyCode::Char('h') => {
-                self.active_view = ActiveView::History;
-                self.history_scroll = 0;
+                if self.active_view != ActiveView::History {
+                    self.active_view = ActiveView::History;
+                    self.history_scroll = 0;
+                }
             }
             KeyCode::Char('1') => {
                 self.main_filter = MainFilter::Local;
@@ -581,7 +583,7 @@ impl App {
     }
 
     fn handle_history_key(&mut self, code: KeyCode) {
-        let len = crate::git::command::command_history_snapshot().len();
+        let len = crate::git::command::command_history_len();
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
                 if len > 0 && self.history_scroll + 1 < len {

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -114,6 +114,12 @@ pub fn command_history_snapshot() -> Vec<CommandRecord> {
         .unwrap_or_default()
 }
 
+/// Cheap count of recorded commands — avoids cloning the whole buffer
+/// when only the length is needed (e.g. for scroll-bound checks).
+pub fn command_history_len() -> usize {
+    history().lock().map(|b| b.len()).unwrap_or(0)
+}
+
 // ---- Command execution ----
 
 pub async fn run_git(args: &[&str]) -> Result<String> {

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -89,6 +89,7 @@ pub struct CommandRecord {
     pub args: Vec<String>,
     pub success: bool,
     pub duration: Duration,
+    /// stdout bytes on success, stderr bytes on failure.
     pub output_bytes: usize,
     pub error: Option<String>,
 }

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -1,7 +1,9 @@
+use std::collections::VecDeque;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::PathBuf;
 use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result, bail};
 use tokio::process::Command;
@@ -59,42 +61,123 @@ pub fn debug_log(msg: &str) {
     }
 }
 
-pub async fn run_git(args: &[&str]) -> Result<String> {
-    debug_log(&format!("$ git {}", args.join(" ")));
+// ---- Command history (session-only, in-memory ring buffer) ----
 
-    let output = Command::new("git")
-        .args(args)
-        .output()
-        .await
-        .context("failed to execute git")?;
+const MAX_HISTORY: usize = 1000;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        debug_log(&format!("  → FAIL: {}", stderr.trim()));
-        bail!("git {} failed: {}", args.join(" "), stderr.trim());
+static COMMAND_HISTORY: OnceLock<Mutex<VecDeque<CommandRecord>>> = OnceLock::new();
+
+/// Monotonic start time for the current session — lets the History view
+/// format each record as an offset (e.g. `+1.24s`) instead of wall-clock
+/// time, avoiding the need for a date/time dependency.
+static SESSION_START: OnceLock<Instant> = OnceLock::new();
+
+fn session_start() -> Instant {
+    *SESSION_START.get_or_init(Instant::now)
+}
+
+pub fn session_elapsed_at(timestamp: Instant) -> Duration {
+    timestamp.saturating_duration_since(session_start())
+}
+
+/// Structured record of a single `git`/`gh` invocation.
+/// Lives only in the in-memory ring buffer used by the History view.
+#[derive(Debug, Clone)]
+pub struct CommandRecord {
+    pub started_at: Instant, // monotonic; used for elapsed-since-session-start display
+    pub executable: &'static str, // "git" or "gh"
+    pub args: Vec<String>,
+    pub success: bool,
+    pub duration: Duration,
+    pub output_bytes: usize,
+    pub error: Option<String>,
+}
+
+fn history() -> &'static Mutex<VecDeque<CommandRecord>> {
+    COMMAND_HISTORY.get_or_init(|| Mutex::new(VecDeque::with_capacity(MAX_HISTORY)))
+}
+
+fn push_record(record: CommandRecord) {
+    if let Ok(mut buf) = history().lock() {
+        if buf.len() == MAX_HISTORY {
+            buf.pop_front();
+        }
+        buf.push_back(record);
     }
+}
 
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    debug_log(&format!("  → OK ({} bytes)", stdout.len()));
-    Ok(stdout)
+/// Returns a clone of the current command history, newest first.
+pub fn command_history_snapshot() -> Vec<CommandRecord> {
+    history()
+        .lock()
+        .map(|buf| buf.iter().rev().cloned().collect())
+        .unwrap_or_default()
+}
+
+// ---- Command execution ----
+
+pub async fn run_git(args: &[&str]) -> Result<String> {
+    run_cmd("git", args).await
 }
 
 pub async fn run_gh(args: &[&str]) -> Result<String> {
-    debug_log(&format!("$ gh {}", args.join(" ")));
+    run_cmd("gh", args).await
+}
 
-    let output = Command::new("gh")
-        .args(args)
-        .output()
-        .await
-        .context("failed to execute gh")?;
+/// Shared execution path for `run_git`/`run_gh`:
+/// - logs to the debug file if enabled
+/// - records a `CommandRecord` in the in-memory history buffer
+async fn run_cmd(executable: &'static str, args: &[&str]) -> Result<String> {
+    // Initialize session start lazily; cheap and idempotent.
+    let _ = session_start();
+    debug_log(&format!("$ {executable} {}", args.join(" ")));
+    let started_at = Instant::now();
+    let owned_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+
+    let output = match Command::new(executable).args(args).output().await {
+        Ok(o) => o,
+        Err(e) => {
+            push_record(CommandRecord {
+                started_at,
+                executable,
+                args: owned_args,
+                success: false,
+                duration: started_at.elapsed(),
+                output_bytes: 0,
+                error: Some(format!("spawn failed: {e}")),
+            });
+            return Err(anyhow::Error::new(e))
+                .with_context(|| format!("failed to execute {executable}"));
+        }
+    };
+
+    let duration = started_at.elapsed();
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        debug_log(&format!("  → FAIL: {}", stderr.trim()));
-        bail!("gh {} failed: {}", args.join(" "), stderr.trim());
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        debug_log(&format!("  → FAIL: {stderr}"));
+        push_record(CommandRecord {
+            started_at,
+            executable,
+            args: owned_args.clone(),
+            success: false,
+            duration,
+            output_bytes: output.stderr.len(),
+            error: Some(stderr.clone()),
+        });
+        bail!("{executable} {} failed: {stderr}", owned_args.join(" "));
     }
 
     let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
     debug_log(&format!("  → OK ({} bytes)", stdout.len()));
+    push_record(CommandRecord {
+        started_at,
+        executable,
+        args: owned_args,
+        success: true,
+        duration,
+        output_bytes: stdout.len(),
+        error: None,
+    });
     Ok(stdout)
 }

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 pub fn draw(frame: &mut Frame) {
-    let area = centered_rect(60, 27, frame.area());
+    let area = centered_rect(60, 31, frame.area());
     frame.render_widget(Clear, area);
 
     let lines = vec![
@@ -23,6 +23,7 @@ pub fn draw(frame: &mut Frame) {
         key_line("2", "Filter: My PR"),
         key_line("3", "Filter: Review"),
         key_line("l", "Log View"),
+        key_line("h", "History View"),
         key_line("r", "Refresh current view"),
         key_line("?", "Toggle this help"),
         key_line("q", "Quit"),
@@ -41,6 +42,10 @@ pub fn draw(frame: &mut Frame) {
         Line::from(""),
         section("Log View"),
         key_line("j/k ↑/↓", "Navigate commits"),
+        key_line("Esc", "Back to Main"),
+        Line::from(""),
+        section("History View"),
+        key_line("j/k ↑/↓", "Navigate commands"),
         key_line("Esc", "Back to Main"),
         Line::from(""),
         Line::from(Span::styled(

--- a/src/ui/history_view.rs
+++ b/src/ui/history_view.rs
@@ -66,7 +66,7 @@ fn format_record(record: &CommandRecord) -> ListItem<'static> {
         Span::styled(format!("{} ", record.executable), exec_style),
         Span::raw(record.args.join(" ")),
         Span::raw("  "),
-        Span::styled(status.to_string(), status_style),
+        Span::styled(status, status_style),
         Span::styled(format!("  {size:>7}  {duration:>6}"), meta_style),
     ];
 

--- a/src/ui/history_view.rs
+++ b/src/ui/history_view.rs
@@ -35,7 +35,8 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     let mut state = ListState::default();
     if app.history_scroll < records.len() {
         state.select(Some(app.history_scroll));
-    } else if !records.is_empty() {
+    } else {
+        // records is guaranteed non-empty here by the early return above
         state.select(Some(records.len() - 1));
     }
 

--- a/src/ui/history_view.rs
+++ b/src/ui/history_view.rs
@@ -1,0 +1,101 @@
+use std::time::Duration;
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, ListState},
+};
+
+use crate::app::App;
+use crate::git::command::{CommandRecord, command_history_snapshot, session_elapsed_at};
+
+pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
+    let block = Block::default().borders(Borders::ALL).title(" History ");
+
+    let records = command_history_snapshot();
+
+    if records.is_empty() {
+        let placeholder = List::new(vec![ListItem::new(Span::styled(
+            "No commands recorded yet.",
+            Style::default().fg(Color::DarkGray),
+        ))])
+        .block(block);
+        frame.render_widget(placeholder, area);
+        return;
+    }
+
+    let items: Vec<ListItem> = records.iter().map(format_record).collect();
+
+    let list = List::new(items)
+        .block(block)
+        .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+
+    let mut state = ListState::default();
+    if app.history_scroll < records.len() {
+        state.select(Some(app.history_scroll));
+    } else if !records.is_empty() {
+        state.select(Some(records.len() - 1));
+    }
+
+    frame.render_stateful_widget(list, area, &mut state);
+}
+
+fn format_record(record: &CommandRecord) -> ListItem<'static> {
+    let offset_style = Style::default().fg(Color::DarkGray);
+    let exec_style = Style::default().fg(Color::Cyan);
+    let status_style = if record.success {
+        Style::default().fg(Color::Green)
+    } else {
+        Style::default().fg(Color::Red)
+    };
+    let meta_style = Style::default().fg(Color::DarkGray);
+
+    let status = if record.success { "OK " } else { "ERR" };
+    let duration = format_duration(record.duration);
+    let size = format_bytes(record.output_bytes);
+    let offset = format!(
+        "+{}",
+        format_duration(session_elapsed_at(record.started_at))
+    );
+
+    let mut spans = vec![
+        Span::styled(format!("{offset:>8}"), offset_style),
+        Span::raw("  "),
+        Span::styled(format!("{} ", record.executable), exec_style),
+        Span::raw(record.args.join(" ")),
+        Span::raw("  "),
+        Span::styled(status.to_string(), status_style),
+        Span::styled(format!("  {size:>7}  {duration:>6}"), meta_style),
+    ];
+
+    if let Some(err) = &record.error {
+        spans.push(Span::raw("  "));
+        spans.push(Span::styled(
+            err.lines().next().unwrap_or("").to_string(),
+            Style::default().fg(Color::Red),
+        ));
+    }
+
+    ListItem::new(Line::from(spans))
+}
+
+fn format_duration(d: Duration) -> String {
+    let ms = d.as_millis();
+    if ms < 1000 {
+        format!("{ms}ms")
+    } else {
+        format!("{:.2}s", d.as_secs_f64())
+    }
+}
+
+fn format_bytes(n: usize) -> String {
+    if n < 1024 {
+        format!("{n}B")
+    } else if n < 1024 * 1024 {
+        format!("{:.1}KB", n as f64 / 1024.0)
+    } else {
+        format!("{:.1}MB", n as f64 / (1024.0 * 1024.0))
+    }
+}

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,6 +1,7 @@
 pub mod confirm_dialog;
 mod detail_pane;
 mod help_overlay;
+mod history_view;
 mod log_view;
 mod main_view;
 pub mod markdown;
@@ -22,6 +23,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     match app.active_view {
         ActiveView::Main => main_view::draw(frame, chunks[0], app),
         ActiveView::Log => log_view::draw(frame, chunks[0], app),
+        ActiveView::History => history_view::draw(frame, chunks[0], app),
     }
 
     // Status bar
@@ -46,6 +48,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
             )
         }
         ActiveView::Log => " [Log]  1:Local  2:My PR  3:Review  l:Log  ?:Help  q:Quit".to_string(),
+        ActiveView::History => " [History]  j/k:Scroll  Esc:Back  ?:Help  q:Quit".to_string(),
     };
     let status =
         Paragraph::new(status_text).style(Style::default().fg(Color::White).bg(Color::DarkGray));

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -43,11 +43,13 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
                 ""
             };
             format!(
-                " [{}]  1:Local  2:My PR  3:Review  Enter:Actions  /:Search{merged_hint}{team_hint}  l:Log  ?:Help  q:Quit",
+                " [{}]  1:Local  2:My PR  3:Review  Enter:Actions  /:Search{merged_hint}{team_hint}  l:Log  h:History  ?:Help  q:Quit",
                 app.main_filter.label()
             )
         }
-        ActiveView::Log => " [Log]  1:Local  2:My PR  3:Review  l:Log  ?:Help  q:Quit".to_string(),
+        ActiveView::Log => {
+            " [Log]  1:Local  2:My PR  3:Review  l:Log  h:History  ?:Help  q:Quit".to_string()
+        }
         ActiveView::History => " [History]  j/k:Scroll  Esc:Back  ?:Help  q:Quit".to_string(),
     };
     let status =


### PR DESCRIPTION
## Summary

gct delegates every operation to `git` and `gh`, but it was opaque which commands actually ran behind each keypress. Add a **History** view (`h`) that lists every `git`/`gh` invocation made during the current session — timestamp (offset from session start), executable + args, OK/ERR status, output size, and wall-clock duration. The buffer lives entirely in memory and is wiped on exit.

## Related Issues

Closes #148

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- **Capture**: `src/git/command.rs` gets a `CommandRecord` struct and a `OnceLock<Mutex<VecDeque<_>>>` ring buffer (1000 entries, mirrors the existing `DEBUG_LOG` pattern). `run_git` and `run_gh` now funnel through a shared `run_cmd(executable, args)` helper that records each call regardless of success/failure. Exposed via `command_history_snapshot()`.
- **Time handling**: Records store `Instant` (monotonic). A `SESSION_START` `OnceLock<Instant>` is initialized on first command, and `session_elapsed_at()` computes the offset for display. No date/time dependency added.
- **View**: New `ActiveView::History` variant plus `history_scroll: usize` on `App`. Global `h` key opens the view, `Esc` returns to Main, `j`/`k`/`↑`/`↓` scroll. `r` is a no-op in History (buffer updates live as commands run).
- **Rendering**: New `src/ui/history_view.rs` renders the snapshot newest-first with columns for session offset, executable + args, colored `OK`/`ERR` status, output size (`B`/`KB`/`MB`), and duration (`ms`/`s`). Error messages trail failed entries.
- **UI plumbing**: `src/ui/mod.rs` dispatches the new view and adds a status-bar label. `src/ui/help_overlay.rs` documents `h` in the Global section and adds a new History View section (overlay bumped by 4 lines).

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (\`cargo clippy -- -D warnings\`)
- [x] Tests pass (\`cargo test\` — 57 passed)

## Test Plan

1. Launch gct → press \`h\` immediately. History view shows the startup fetches (\`git branch -vv\`, \`git worktree list --porcelain\`, \`git log …\`, \`gh api graphql viewer.login\`, etc.) with their durations.
2. Scroll with \`j\`/\`k\`; press \`Esc\` to return to Main.
3. Press \`r\` in Main to trigger a refresh, then \`h\` again — the new commands appear at the top of the list.
4. Cause a failure (e.g. press \`d\` on a worktree with untracked files before approving the force-delete) — the failing \`git worktree remove\` entry shows \`ERR\` in red with its stderr trailing.
5. \`?\` → help overlay lists \`h — History View\` under Global and a dedicated History View section.
6. Quit and relaunch gct → history contains only commands from the new session (no persistence).