### PR TITLE
docs: add Homebrew installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,23 @@ A terminal UI tool that acts as a "control tower" for Git/GitHub workflows. Over
 
 ## Installation
 
+### Homebrew (macOS / Linux)
+
 ```bash
-# From source
+brew install katzkb/tap/gct
+```
+
+Upgrade:
+
+```bash
+brew update && brew upgrade gct
+```
+
+Supported platforms: macOS (Apple Silicon / Intel), Linux (x86_64).
+
+### From source
+
+```bash
 git clone https://github.com/katzkb/git-control-tower.git
 cd git-control-tower
 cargo install --path .

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ brew install katzkb/tap/gct
 Upgrade:
 
 ```bash
-brew update && brew upgrade gct
+brew update && brew upgrade katzkb/tap/gct
 ```
 
 Supported platforms: macOS (Apple Silicon / Intel), Linux (x86_64).


### PR DESCRIPTION
## Summary

The release workflow already publishes binaries to the `katzkb/homebrew-tap` tap, but the README only documents the source build. This PR surfaces `brew install katzkb/tap/gct` as the recommended install path so users can discover the prebuilt distribution.

## Related Issues

Closes #151

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Documentation
- [ ] CI / Build

## Changes

- Add a `### Homebrew (macOS / Linux)` subsection with install and upgrade commands
- List supported platforms (macOS Apple Silicon / Intel, Linux x86_64)
- Move the existing source build under a `### From source` subsection

## Checklist

- [x] Code compiles / builds without warnings (no code changes)
- [x] Linter passes (no code changes)
- [x] Tests pass (no code changes)

## Test Plan

- View `README.md` on GitHub and confirm both subsections render correctly
- (Optional) Run `brew install katzkb/tap/gct` on a clean environment after the next release