### PR TITLE
fix: force-delete unmerged branches with warning

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -525,12 +525,13 @@ impl App {
                                 .any(|e| e.name == **name && !e.is_merged() && !e.pr_is_merged())
                         })
                         .count();
+                    let label = if count == 1 { "branch" } else { "branches" };
                     let msg = if unmerged_count > 0 {
                         format!(
-                            "Delete {count} branch(es)? ({unmerged_count} unmerged — will force delete)\n[{preview}]"
+                            "Delete {count} {label}? ({unmerged_count} unmerged — will force delete)\n[{preview}]"
                         )
                     } else {
-                        format!("Delete {count} branch(es)? [{preview}]")
+                        format!("Delete {count} {label}? [{preview}]")
                     };
                     self.confirm_dialog = Some(ConfirmDialog::new("Delete Branches", msg));
                 } else if !self.wt_loading

--- a/src/app.rs
+++ b/src/app.rs
@@ -516,10 +516,23 @@ impl App {
                     } else {
                         format!("{} and {} more", names[..2].join(", "), count - 2)
                     };
-                    self.confirm_dialog = Some(ConfirmDialog::new(
-                        "Delete Branches",
-                        format!("Delete {count} branch(es)? [{preview}]"),
-                    ));
+                    let unmerged_count = self
+                        .branch_selected
+                        .iter()
+                        .filter(|name| {
+                            self.entries
+                                .iter()
+                                .any(|e| e.name == **name && !e.is_merged() && !e.pr_is_merged())
+                        })
+                        .count();
+                    let msg = if unmerged_count > 0 {
+                        format!(
+                            "Delete {count} branch(es)? ({unmerged_count} unmerged — will force delete)\n[{preview}]"
+                        )
+                    } else {
+                        format!("Delete {count} branch(es)? [{preview}]")
+                    };
+                    self.confirm_dialog = Some(ConfirmDialog::new("Delete Branches", msg));
                 } else if !self.wt_loading
                     && let Some(entry) = self.selected_entry().cloned()
                     && let Some(wt_path) = entry.worktree_path()
@@ -761,12 +774,15 @@ impl App {
             }
             ActionItem::DeleteBranch => {
                 let name = entry.name.clone();
+                let is_unmerged = !entry.is_merged() && !entry.pr_is_merged();
                 self.branch_selected.clear();
                 self.branch_selected.insert(name.clone());
-                self.confirm_dialog = Some(ConfirmDialog::new(
-                    "Delete Branch",
-                    format!("Delete branch {name}?"),
-                ));
+                let msg = if is_unmerged {
+                    format!("Delete branch {name}? (unmerged — will force delete)")
+                } else {
+                    format!("Delete branch {name}?")
+                };
+                self.confirm_dialog = Some(ConfirmDialog::new("Delete Branch", msg));
             }
             ActionItem::OpenPrInBrowser => {
                 if let Some(pr) = &entry.pull_request {

--- a/src/main.rs
+++ b/src/main.rs
@@ -620,22 +620,11 @@ async fn run(
         // Delete selected branches if requested
         if app.branch_delete_requested {
             app.branch_delete_requested = false;
-            let selected: Vec<(String, bool)> = app
-                .branch_selected
-                .drain()
-                .map(|name| {
-                    let force = app
-                        .entries
-                        .iter()
-                        .any(|e| e.name == name && (e.is_merged() || e.pr_is_merged()));
-                    (name, force)
-                })
-                .collect();
+            let selected: Vec<String> = app.branch_selected.drain().collect();
             let mut deleted = Vec::new();
             let mut failed = Vec::new();
-            for (name, force) in &selected {
-                let flag = if *force { "-D" } else { "-d" };
-                match run_git(&["branch", flag, name]).await {
+            for name in &selected {
+                match run_git(&["branch", "-D", name]).await {
                     Ok(_) => deleted.push(name.as_str()),
                     Err(e) => failed.push(format!("{name}: {e}")),
                 }


### PR DESCRIPTION
## Summary

Deleting unmerged branches previously failed because the app used `git branch -d`, which git refuses for non-merged branches. This switches to `git branch -D` for all deletions and adds an explicit warning in the confirm dialog when unmerged branches are included.

## Related Issues

Closes #156

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Always use `git branch -D` (force delete) regardless of merge status, removing the per-branch `force` flag and simplifying `Vec<(String, bool)>` to `Vec<String>`
- Batch delete (`d` key): confirm dialog shows "(N unmerged — will force delete)" when unmerged branches are in the selection
- Single delete (action menu → Delete branch): confirm dialog shows "(unmerged — will force delete)" if the branch is unmerged
- No change to the confirm message when all branches are already merged

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`)
- [x] Tests pass (`cargo test` — 61 passed)

## Test Plan

1. Select an unmerged branch → `d` → confirm dialog shows "1 unmerged — will force delete" → `y` → branch deleted
2. Select a merged branch → `d` → confirm dialog shows the standard message without unmerged warning → `y` → branch deleted
3. Select a mix of merged + unmerged → `d` → confirm shows unmerged count
4. Action menu on an unmerged branch → "Delete branch" → confirm shows "(unmerged — will force delete)"
5. Action menu on a merged branch → "Delete branch" → standard message