### PR TITLE
feat: open action menu directly from search mode on Enter

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -639,6 +639,7 @@ impl App {
             KeyCode::Enter => {
                 self.search_active = false;
                 self.request_details_for_selection();
+                self.open_action_menu();
             }
             KeyCode::Backspace => {
                 self.search_query.pop();


### PR DESCRIPTION
## Summary

Pressing `Enter` during `/` search now confirms the filter AND opens the action menu on the highlighted entry in one step, removing the double-Enter friction.

## Related Issues

Closes #158

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Add `self.open_action_menu()` call in `handle_search_key`'s `Enter` branch, right after `search_active = false`
- `open_action_menu()` already guards against empty selections (returns early if `selected_entry()` is `None`), so filtered-to-zero is safe

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`)
- [x] Tests pass (`cargo test` — 61 passed)

## Test Plan

1. Press `/`, type a query → entries filter in real-time
2. Navigate to target branch with `j`/`k` if needed
3. Press `Enter` → action menu opens immediately on the highlighted entry
4. Press `/`, type a query that matches nothing → press `Enter` → no menu (safe no-op)
5. Press `/`, then `Esc` → search cancelled, no menu (existing behavior unchanged)