### PR TITLE
feat: support cursor movement in branch-create name input

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -66,6 +66,7 @@ pub struct ActionMenu {
 pub struct BranchCreateInput {
     pub source: String,
     pub name: String,
+    pub cursor: usize,
 }
 
 pub struct App {
@@ -760,6 +761,7 @@ impl App {
                 self.branch_create_input = Some(BranchCreateInput {
                     source: entry.name.clone(),
                     name: String::new(),
+                    cursor: 0,
                 });
             }
             ActionItem::DeleteBranch => {
@@ -791,6 +793,8 @@ impl App {
             Some(i) => i,
             None => return,
         };
+        let char_len = input.name.chars().count();
+        input.cursor = input.cursor.min(char_len);
         match code {
             KeyCode::Esc => {
                 self.branch_create_input = None;
@@ -801,11 +805,34 @@ impl App {
                 self.branch_create_input = None;
                 self.branch_create_requested = Some((source, name));
             }
+            KeyCode::Left => {
+                input.cursor = input.cursor.saturating_sub(1);
+            }
+            KeyCode::Right => {
+                if input.cursor < char_len {
+                    input.cursor += 1;
+                }
+            }
+            KeyCode::Home => {
+                input.cursor = 0;
+            }
+            KeyCode::End => {
+                input.cursor = char_len;
+            }
             KeyCode::Backspace => {
-                input.name.pop();
+                if input.cursor > 0 {
+                    remove_char_at(&mut input.name, input.cursor - 1);
+                    input.cursor -= 1;
+                }
+            }
+            KeyCode::Delete => {
+                if input.cursor < char_len {
+                    remove_char_at(&mut input.name, input.cursor);
+                }
             }
             KeyCode::Char(c) => {
-                input.name.push(c);
+                insert_char_at(&mut input.name, input.cursor, c);
+                input.cursor += 1;
             }
             _ => {}
         }
@@ -834,5 +861,85 @@ impl App {
 
     pub fn is_protected_branch(&self, name: &str) -> bool {
         self.config.protected_branches.iter().any(|b| b == name)
+    }
+}
+
+fn insert_char_at(s: &mut String, char_idx: usize, c: char) {
+    let byte_idx = char_to_byte_idx(s, char_idx);
+    s.insert(byte_idx, c);
+}
+
+fn remove_char_at(s: &mut String, char_idx: usize) {
+    let byte_idx = char_to_byte_idx(s, char_idx);
+    if byte_idx < s.len() {
+        s.remove(byte_idx);
+    }
+}
+
+fn char_to_byte_idx(s: &str, char_idx: usize) -> usize {
+    s.char_indices()
+        .nth(char_idx)
+        .map(|(b, _)| b)
+        .unwrap_or(s.len())
+}
+
+#[cfg(test)]
+mod text_edit_tests {
+    use super::*;
+
+    #[test]
+    fn insert_at_start() {
+        let mut s = String::from("bc");
+        insert_char_at(&mut s, 0, 'a');
+        assert_eq!(s, "abc");
+    }
+
+    #[test]
+    fn insert_at_middle() {
+        let mut s = String::from("ac");
+        insert_char_at(&mut s, 1, 'b');
+        assert_eq!(s, "abc");
+    }
+
+    #[test]
+    fn insert_at_end() {
+        let mut s = String::from("ab");
+        insert_char_at(&mut s, 2, 'c');
+        assert_eq!(s, "abc");
+    }
+
+    #[test]
+    fn insert_unicode() {
+        let mut s = String::from("αγ");
+        insert_char_at(&mut s, 1, 'β');
+        assert_eq!(s, "αβγ");
+    }
+
+    #[test]
+    fn remove_at_start() {
+        let mut s = String::from("abc");
+        remove_char_at(&mut s, 0);
+        assert_eq!(s, "bc");
+    }
+
+    #[test]
+    fn remove_at_middle() {
+        let mut s = String::from("abc");
+        remove_char_at(&mut s, 1);
+        assert_eq!(s, "ac");
+    }
+
+    #[test]
+    fn remove_at_end_is_noop() {
+        let mut s = String::from("abc");
+        remove_char_at(&mut s, 3);
+        assert_eq!(s, "abc");
+    }
+
+    #[test]
+    fn remove_unicode() {
+        let mut s = String::from("αβγ");
+        remove_char_at(&mut s, 1);
+        assert_eq!(s, "αγ");
     }
 }

--- a/src/ui/branch_create_input.rs
+++ b/src/ui/branch_create_input.rs
@@ -14,8 +14,6 @@ pub fn draw(frame: &mut Frame, input: &BranchCreateInput) {
 
     // Available width for the value portion of each row: modal inner width
     // minus the "  Name: " prefix (8) minus 1 column for the cursor on Name.
-    // When the value is wider than this, we keep the trailing portion
-    // visible (the typing position) and mark the hidden head with "…".
     let inner = area.width.saturating_sub(2) as usize;
     let from_prefix = "  From: ".len();
     let name_prefix = "  Name: ".len();
@@ -23,24 +21,31 @@ pub fn draw(frame: &mut Frame, input: &BranchCreateInput) {
     let name_max = inner.saturating_sub(name_prefix + 1);
 
     let source_display = truncate_head(&input.source, from_max);
-    let name_display = truncate_head(&input.name, name_max);
+    let window = window_around_cursor(&input.name, input.cursor, name_max);
+
+    let white = Style::default().fg(Color::White);
+    let gray = Style::default().fg(Color::DarkGray);
+    let cyan = Style::default().fg(Color::Cyan);
+
+    let mut name_spans: Vec<Span> = Vec::with_capacity(6);
+    name_spans.push(Span::styled("  Name: ", gray));
+    if window.left_ellipsis {
+        name_spans.push(Span::styled("…", gray));
+    }
+    name_spans.push(Span::styled(window.before, white));
+    name_spans.push(Span::styled("_", cyan));
+    name_spans.push(Span::styled(window.after, white));
+    if window.right_ellipsis {
+        name_spans.push(Span::styled("…", gray));
+    }
 
     let lines = vec![
         Line::from(""),
         Line::from(vec![
-            Span::styled("  From: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(
-                source_display,
-                Style::default()
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD),
-            ),
+            Span::styled("  From: ", gray),
+            Span::styled(source_display, white.add_modifier(Modifier::BOLD)),
         ]),
-        Line::from(vec![
-            Span::styled("  Name: ", Style::default().fg(Color::DarkGray)),
-            Span::styled(name_display, Style::default().fg(Color::White)),
-            Span::styled("_", Style::default().fg(Color::Cyan)),
-        ]),
+        Line::from(name_spans),
         Line::from(""),
         Line::from(vec![
             Span::styled(
@@ -86,6 +91,67 @@ fn truncate_head(s: &str, max: usize) -> String {
     out
 }
 
+#[derive(Debug, PartialEq, Eq)]
+struct CursorWindow {
+    before: String,
+    after: String,
+    left_ellipsis: bool,
+    right_ellipsis: bool,
+}
+
+/// Compute the visible portion of `s` around `cursor` that fits within `max` columns.
+///
+/// The returned `before` + cursor (1 col) + `after` spans at most `max` columns.
+/// `left_ellipsis` / `right_ellipsis` indicate whether a `…` marker should be drawn
+/// on the clipped side (ellipsis columns are not included in `max`).
+fn window_around_cursor(s: &str, cursor: usize, max: usize) -> CursorWindow {
+    let chars: Vec<char> = s.chars().collect();
+    let len = chars.len();
+    let cursor = cursor.min(len);
+
+    // Content budget excludes the 1 column reserved for the cursor itself.
+    let content_budget = max.saturating_sub(1);
+    if content_budget == 0 || len == 0 {
+        return CursorWindow {
+            before: String::new(),
+            after: String::new(),
+            left_ellipsis: false,
+            right_ellipsis: false,
+        };
+    }
+
+    if len <= content_budget {
+        return CursorWindow {
+            before: chars[..cursor].iter().collect(),
+            after: chars[cursor..].iter().collect(),
+            left_ellipsis: false,
+            right_ellipsis: false,
+        };
+    }
+
+    // Text doesn't fit. Pick a window [start, end) of size `content_budget`
+    // that contains the cursor and keeps it roughly centered.
+    let half = content_budget / 2;
+    let mut start = cursor.saturating_sub(half);
+    let mut end = start + content_budget;
+    if end > len {
+        end = len;
+        start = end - content_budget;
+    }
+
+    let left_ellipsis = start > 0;
+    let right_ellipsis = end < len;
+    let before: String = chars[start..cursor].iter().collect();
+    let after: String = chars[cursor..end].iter().collect();
+
+    CursorWindow {
+        before,
+        after,
+        left_ellipsis,
+        right_ellipsis,
+    }
+}
+
 fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
     let vertical = Layout::vertical([Constraint::Length(height)])
         .flex(Flex::Center)
@@ -118,5 +184,88 @@ mod tests {
     #[test]
     fn truncate_head_unicode() {
         assert_eq!(truncate_head("αβγδε", 4), "…γδε");
+    }
+
+    fn w(before: &str, after: &str, l: bool, r: bool) -> CursorWindow {
+        CursorWindow {
+            before: before.to_string(),
+            after: after.to_string(),
+            left_ellipsis: l,
+            right_ellipsis: r,
+        }
+    }
+
+    #[test]
+    fn window_fits_no_ellipsis() {
+        assert_eq!(
+            window_around_cursor("abc", 1, 10),
+            w("a", "bc", false, false)
+        );
+    }
+
+    #[test]
+    fn window_cursor_at_start() {
+        assert_eq!(
+            window_around_cursor("abc", 0, 10),
+            w("", "abc", false, false)
+        );
+    }
+
+    #[test]
+    fn window_cursor_at_end() {
+        assert_eq!(
+            window_around_cursor("abc", 3, 10),
+            w("abc", "", false, false)
+        );
+    }
+
+    #[test]
+    fn window_clipped_right_when_cursor_near_start() {
+        // "abcdefghij", cursor=1, max=5 -> content budget 4
+        // half=2, start=max(0,1-2)=0, end=0+4=4 -> "abcd" with right ellipsis
+        assert_eq!(
+            window_around_cursor("abcdefghij", 1, 5),
+            w("a", "bcd", false, true)
+        );
+    }
+
+    #[test]
+    fn window_clipped_left_when_cursor_near_end() {
+        // "abcdefghij", cursor=10, max=5 -> content budget 4
+        // half=2, start=8, end=12 -> clamp end=10, start=6 -> "ghij" with left ellipsis
+        assert_eq!(
+            window_around_cursor("abcdefghij", 10, 5),
+            w("ghij", "", true, false)
+        );
+    }
+
+    #[test]
+    fn window_clipped_both_when_cursor_middle() {
+        // "abcdefghij", cursor=5, max=5 -> content budget 4
+        // half=2, start=3, end=7 -> "de" + "fg", both ellipses
+        assert_eq!(
+            window_around_cursor("abcdefghij", 5, 5),
+            w("de", "fg", true, true)
+        );
+    }
+
+    #[test]
+    fn window_unicode() {
+        // 5 multi-byte chars, cursor middle, max=4 -> content budget 3
+        // half=1, start=1, end=4 -> "β" + "γδ", both ellipses
+        assert_eq!(
+            window_around_cursor("αβγδε", 2, 4),
+            w("β", "γδ", true, true)
+        );
+    }
+
+    #[test]
+    fn window_zero_max() {
+        assert_eq!(window_around_cursor("abc", 1, 0), w("", "", false, false));
+    }
+
+    #[test]
+    fn window_empty_string() {
+        assert_eq!(window_around_cursor("", 0, 10), w("", "", false, false));
     }
 }

--- a/src/ui/branch_create_input.rs
+++ b/src/ui/branch_create_input.rs
@@ -13,12 +13,13 @@ pub fn draw(frame: &mut Frame, input: &BranchCreateInput) {
     frame.render_widget(Clear, area);
 
     // Available width for the value portion of each row: modal inner width
-    // minus the "  Name: " prefix (8) minus 1 column for the cursor on Name.
+    // minus the prefix. `window_around_cursor` / `truncate_head` each treat their
+    // `max` as the full budget (content + cursor + ellipses), so no extra reservation.
     let inner = area.width.saturating_sub(2) as usize;
     let from_prefix = "  From: ".len();
     let name_prefix = "  Name: ".len();
     let from_max = inner.saturating_sub(from_prefix);
-    let name_max = inner.saturating_sub(name_prefix + 1);
+    let name_max = inner.saturating_sub(name_prefix);
 
     let source_display = truncate_head(&input.source, from_max);
     let window = window_around_cursor(&input.name, input.cursor, name_max);
@@ -101,26 +102,33 @@ struct CursorWindow {
 
 /// Compute the visible portion of `s` around `cursor` that fits within `max` columns.
 ///
-/// The returned `before` + cursor (1 col) + `after` spans at most `max` columns.
-/// `left_ellipsis` / `right_ellipsis` indicate whether a `…` marker should be drawn
-/// on the clipped side (ellipsis columns are not included in `max`).
+/// `max` is the total budget for the rendered cell, covering the 1-column cursor
+/// indicator, any visible content, and up to two `…` markers. The returned
+/// `before` + cursor + `after` + ellipses together span at most `max` columns.
 fn window_around_cursor(s: &str, cursor: usize, max: usize) -> CursorWindow {
+    let empty = CursorWindow {
+        before: String::new(),
+        after: String::new(),
+        left_ellipsis: false,
+        right_ellipsis: false,
+    };
     let chars: Vec<char> = s.chars().collect();
     let len = chars.len();
     let cursor = cursor.min(len);
 
-    // Content budget excludes the 1 column reserved for the cursor itself.
-    let content_budget = max.saturating_sub(1);
-    if content_budget == 0 || len == 0 {
-        return CursorWindow {
-            before: String::new(),
-            after: String::new(),
-            left_ellipsis: false,
-            right_ellipsis: false,
-        };
+    if max == 0 || len == 0 {
+        return empty;
     }
 
-    if len <= content_budget {
+    // 1 col goes to the cursor indicator; the rest is for content plus ellipses.
+    let visible = max - 1;
+    if visible == 0 {
+        // Only room for the cursor indicator itself — hide content and ellipses.
+        return empty;
+    }
+
+    // Fast path: the whole string fits alongside the cursor; no ellipses needed.
+    if len <= visible {
         return CursorWindow {
             before: chars[..cursor].iter().collect(),
             after: chars[cursor..].iter().collect(),
@@ -129,26 +137,45 @@ fn window_around_cursor(s: &str, cursor: usize, max: usize) -> CursorWindow {
         };
     }
 
-    // Text doesn't fit. Pick a window [start, end) of size `content_budget`
-    // that contains the cursor and keeps it roughly centered.
-    let half = content_budget / 2;
-    let mut start = cursor.saturating_sub(half);
-    let mut end = start + content_budget;
-    if end > len {
-        end = len;
-        start = end - content_budget;
+    // String is wider than the visible area — at least one ellipsis is required.
+    // A one-sided clip uses a content window of size `visible - 1`.
+    let one_ell = visible.saturating_sub(1);
+
+    // Cursor close to the start: clip only on the right.
+    if cursor <= one_ell {
+        let end = one_ell;
+        return CursorWindow {
+            before: chars[..cursor].iter().collect(),
+            after: chars[cursor..end].iter().collect(),
+            left_ellipsis: false,
+            right_ellipsis: true,
+        };
     }
 
-    let left_ellipsis = start > 0;
-    let right_ellipsis = end < len;
-    let before: String = chars[start..cursor].iter().collect();
-    let after: String = chars[cursor..end].iter().collect();
+    // Cursor close to the end: clip only on the left.
+    if cursor >= len - one_ell {
+        let start = len - one_ell;
+        return CursorWindow {
+            before: chars[start..cursor].iter().collect(),
+            after: chars[cursor..].iter().collect(),
+            left_ellipsis: true,
+            right_ellipsis: false,
+        };
+    }
 
+    // Cursor in the middle: clip on both sides. Budget shrinks by 2 for ellipses.
+    if visible < 2 {
+        return empty;
+    }
+    let window_size = visible - 2;
+    let half = window_size / 2;
+    let start = cursor - half;
+    let end = start + window_size;
     CursorWindow {
-        before,
-        after,
-        left_ellipsis,
-        right_ellipsis,
+        before: chars[start..cursor].iter().collect(),
+        after: chars[cursor..end].iter().collect(),
+        left_ellipsis: true,
+        right_ellipsis: true,
     }
 }
 
@@ -221,41 +248,33 @@ mod tests {
 
     #[test]
     fn window_clipped_right_when_cursor_near_start() {
-        // "abcdefghij", cursor=1, max=5 -> content budget 4
-        // half=2, start=max(0,1-2)=0, end=0+4=4 -> "abcd" with right ellipsis
         assert_eq!(
             window_around_cursor("abcdefghij", 1, 5),
-            w("a", "bcd", false, true)
+            w("a", "bc", false, true)
         );
     }
 
     #[test]
     fn window_clipped_left_when_cursor_near_end() {
-        // "abcdefghij", cursor=10, max=5 -> content budget 4
-        // half=2, start=8, end=12 -> clamp end=10, start=6 -> "ghij" with left ellipsis
         assert_eq!(
             window_around_cursor("abcdefghij", 10, 5),
-            w("ghij", "", true, false)
+            w("hij", "", true, false)
         );
     }
 
     #[test]
     fn window_clipped_both_when_cursor_middle() {
-        // "abcdefghij", cursor=5, max=5 -> content budget 4
-        // half=2, start=3, end=7 -> "de" + "fg", both ellipses
         assert_eq!(
             window_around_cursor("abcdefghij", 5, 5),
-            w("de", "fg", true, true)
+            w("e", "f", true, true)
         );
     }
 
     #[test]
     fn window_unicode() {
-        // 5 multi-byte chars, cursor middle, max=4 -> content budget 3
-        // half=1, start=1, end=4 -> "β" + "γδ", both ellipses
         assert_eq!(
             window_around_cursor("αβγδε", 2, 4),
-            w("β", "γδ", true, true)
+            w("αβ", "", false, true)
         );
     }
 
@@ -267,5 +286,25 @@ mod tests {
     #[test]
     fn window_empty_string() {
         assert_eq!(window_around_cursor("", 0, 10), w("", "", false, false));
+    }
+
+    /// Rendered cell width must never exceed `max` regardless of cursor position.
+    #[test]
+    fn window_never_exceeds_max() {
+        let s = "abcdefghij";
+        for cursor in 0..=s.chars().count() {
+            for max in 0..=12 {
+                let out = window_around_cursor(s, cursor, max);
+                let width = out.before.chars().count()
+                    + out.after.chars().count()
+                    + 1 // cursor indicator
+                    + usize::from(out.left_ellipsis)
+                    + usize::from(out.right_ellipsis);
+                assert!(
+                    width <= max.max(1),
+                    "cursor={cursor} max={max} width={width} out={out:?}"
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Make the branch-creation modal's `Name` field behave like a normal single-line text input. Previously, `Left` / `Right` / `Home` / `End` / `Delete` were all no-ops and `Backspace` only popped from the end, so fixing a typo in the middle of a branch name meant deleting everything back to the error and retyping it.

## Related Issues

Closes #164

## Type of Change

- [x] New feature

## Changes

- Added `cursor: usize` (character index) to `BranchCreateInput` and initialize it at the construction site.
- Extended `handle_branch_create_input_key` to handle `Left`, `Right`, `Home`, `End`, and `Delete` in addition to the existing keys; `Backspace` and `Char` now act at the cursor position rather than always at the end.
- Added small `insert_char_at` / `remove_char_at` helpers in `app.rs` that convert char indices to byte indices so multi-byte UTF-8 input works correctly.
- Rewrote the modal renderer to show the cursor at its true position: the `Name` line is now split into `[left …] [before] [_] [after] [right …]` spans.
- Replaced the head-only `truncate_head` with a new `window_around_cursor` helper for the `Name` line — the visible window now scrolls so the cursor stays on screen, with `…` markers on whichever side is clipped. `From:` still uses `truncate_head` (it's read-only).
- Added unit tests covering the splice helpers and the windowing logic (fits / clipped-left / clipped-right / clipped-both / unicode / boundary cases).

## Checklist

- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo test` passes (78 tests)

## Test Plan

1. `cargo test` — all unit tests pass, including new windowing and splice tests.
2. `cargo run` — open the action menu on any branch, pick **Create Branch**, then:
   - Type `feature/foo`, press `Left` several times, insert a char in the middle, press `Home`, press `End`, use `Delete`, and `Backspace` after moving the cursor — the visible `_` tracks the cursor and the resulting branch name on `Enter` matches what the cursor suggests.
   - Type a long name (wider than the modal), arrow-left into the hidden portion — the window should scroll so the cursor stays visible, with `…` on whichever side is clipped.
   - Enter still creates the branch, `Esc` still cancels.