### PR TITLE
ci: fix clippy collapsible_match on Rust 1.95

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -808,10 +808,8 @@ impl App {
             KeyCode::Left => {
                 input.cursor = input.cursor.saturating_sub(1);
             }
-            KeyCode::Right => {
-                if input.cursor < char_len {
-                    input.cursor += 1;
-                }
+            KeyCode::Right if input.cursor < char_len => {
+                input.cursor += 1;
             }
             KeyCode::Home => {
                 input.cursor = 0;
@@ -819,16 +817,12 @@ impl App {
             KeyCode::End => {
                 input.cursor = char_len;
             }
-            KeyCode::Backspace => {
-                if input.cursor > 0 {
-                    remove_char_at(&mut input.name, input.cursor - 1);
-                    input.cursor -= 1;
-                }
+            KeyCode::Backspace if input.cursor > 0 => {
+                remove_char_at(&mut input.name, input.cursor - 1);
+                input.cursor -= 1;
             }
-            KeyCode::Delete => {
-                if input.cursor < char_len {
-                    remove_char_at(&mut input.name, input.cursor);
-                }
+            KeyCode::Delete if input.cursor < char_len => {
+                remove_char_at(&mut input.name, input.cursor);
             }
             KeyCode::Char(c) => {
                 insert_char_at(&mut input.name, input.cursor, c);


### PR DESCRIPTION
## Summary

After #165 merged, CI's Clippy step fails on Rust 1.95 because `handle_branch_create_input_key` has three match arms whose body is a nested `if` — the exact pattern `clippy::collapsible_match` flags. Converting each nested `if` into a match-arm guard silences the lint without changing behavior. This mirrors the earlier fix in #162 for other handlers.

## Related Issues

Closes #166

## Type of Change

- [x] CI / Build

## Changes

- `KeyCode::Right`, `KeyCode::Backspace`, `KeyCode::Delete` arms now use match guards (`if input.cursor < char_len` / `if input.cursor > 0`) instead of wrapping their body in a nested `if`. The `_ => {}` fallback still covers the negative-guard cases (e.g., `Right` when `cursor == char_len`).

## Checklist

- [x] `cargo fmt -- --check` passes (local)
- [x] `cargo clippy -- -D warnings` passes (local — 1.94; CI will verify 1.95)
- [x] `cargo test` passes (79 tests)

## Test Plan

1. CI Clippy job on Rust 1.95 passes (this is what the PR fixes).
2. `cargo test` — full suite still green; no behavior change.
3. Manual: open branch-create modal, verify Right/Backspace/Delete still respect bounds (Right doesn't move past end, Backspace is no-op at position 0, Delete is no-op at end).