### PR TITLE
chore: pin Rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.95.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary

CI and local development currently drift because neither side declares a Rust version: CI uses `dtolnay/rust-toolchain@stable` (always-latest) and local contributors run whatever Homebrew ships. When Rust 1.95 released, its stricter `clippy::collapsible_match` broke `main` immediately after PR #165 merged, and PR #167 cleaned it up. This PR pins the toolchain via `rust-toolchain.toml` so CI and local contributors build on the same version and future bumps are explicit, reviewable PRs.

## Related Issues

Closes #168

## Type of Change

- [x] CI / Build

## Changes

- Added `rust-toolchain.toml` pinning `channel = "1.95.0"` with `rustfmt` and `clippy` components.
- `dtolnay/rust-toolchain@stable` already honors `rust-toolchain.toml`, so no workflow changes are needed — CI will pick the file up automatically.
- Contributors using `rustup` will have 1.95.0 auto-installed on their next `cargo` invocation. Homebrew `rust` does not honor this file; contributors on Homebrew should migrate to rustup.

## Checklist

- [x] `cargo fmt -- --check` passes (on 1.95.0, locally)
- [x] `cargo clippy -- -D warnings` passes (on 1.95.0, locally)
- [x] `cargo test` passes (79 tests on 1.95.0, locally)

## Test Plan

1. CI's Clippy step on this PR runs on 1.95.0 (the pinned version) and is green — confirms the file is picked up.
2. On a fresh clone, `cargo build` should automatically install 1.95.0 via rustup and succeed without manual toolchain configuration.
3. Everyday commands (\`cargo fmt\`, \`cargo clippy\`, \`cargo test\`, \`cargo build\`) all continue to work on the pinned toolchain.