### PR TITLE
feat(sidebar): show placeholder when branch list is empty

### DIFF
--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -88,6 +88,20 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                 format!("  {spinner} Loading"),
                 Style::default().fg(Color::DarkGray),
             )))]
+        } else if filtered.is_empty() {
+            let msg = if !app.search_query.is_empty() {
+                "  No branches match the search"
+            } else {
+                match app.main_filter {
+                    MainFilter::Local => "  No local branches",
+                    MainFilter::MyPr => "  No branches with your PRs",
+                    MainFilter::ReviewRequested => "  No branches awaiting review",
+                }
+            };
+            vec![ListItem::new(Line::from(Span::styled(
+                msg,
+                Style::default().fg(Color::DarkGray),
+            )))]
         } else {
             let search_query = &app.search_query;
             filtered


### PR DESCRIPTION
## Summary

The left-pane branch list previously rendered as blank space when the filtered entry list was empty and the view had finished loading. Users couldn't tell whether the app was stuck, their filter/search excluded everything, or the repo simply had no matching branches. This PR renders a context-aware placeholder in that state, matching the existing "Loading" styling.

## Related Issues

Closes #170

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- In `src/ui/sidebar.rs::draw_entry_list`, added a branch for the `filtered.is_empty() && !is_loading` case that renders a single dark-gray `ListItem`.
- Placeholder text is context-aware:
  - Active search with no matches → "No branches match the search"
  - `Local` filter → "No local branches"
  - `My PR` filter → "No branches with your PRs"
  - `Review` filter → "No branches awaiting review"
- `item_count` continues to reflect `filtered.len()`, so the placeholder row is non-selectable (the existing `if item_count > 0` guard around `state.select` handles this).

## Checklist

- [x] Code compiles / builds without warnings (`cargo build`)
- [x] Linter passes (`cargo clippy -- -D warnings`, `cargo fmt --check`)
- [ ] Tests pass (no new tests; no snapshot tests exist for the sidebar)

## Test Plan

1. Run `cargo run` in a repo.
2. Type a search query that matches nothing in the sidebar → expect "No branches match the search".
3. Switch to the **My PR** filter in a repo where the user has no authored PRs → expect "No branches with your PRs".
4. Switch to the **Review** filter with no review requests → expect "No branches awaiting review".
5. Run in a fresh/empty repo with no local branches (Local filter) → expect "No local branches".
6. Confirm the "Loading" spinner still appears on first open until the async PR load completes, and that selection/navigation (`j`/`k`) do not land on the placeholder row.