### PR TITLE
ci: use RELEASE_PAT for release PR creation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PAT }}
 
       - name: Determine version
         id: version
@@ -80,7 +81,7 @@ jobs:
             fi
           fi
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}
 
       - name: Create release branch and push
         run: |
@@ -117,4 +118,4 @@ jobs:
           BODY
           )"
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PAT }}


### PR DESCRIPTION
## Summary

Release PRs opened by `create-release-pr.yml` were stuck in `mergeStateStatus: BLOCKED` because the required `check` status from `ci.yml` never ran. GitHub Actions does not fire `pull_request` events for PRs authored by the default `GITHUB_TOKEN`, so the CI workflow was never triggered. Switching to the fine-grained `RELEASE_PAT` secret restores normal CI behavior for release PRs.

## Related Issues

Closes #173

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] CI / Build

## Changes

- Authenticate `actions/checkout@v4` with `secrets.RELEASE_PAT` so the subsequent `git push` runs under the PAT identity.
- Swap `env.GH_TOKEN` in the branch-cleanup step to `secrets.RELEASE_PAT` to keep auth consistent with the push.
- Swap `env.GH_TOKEN` in the `gh pr create` step to `secrets.RELEASE_PAT` — the critical change that makes the release PR trigger `ci.yml`.

No changes to `ci.yml`, `release.yml`, or any source code. The `RELEASE_PAT` secret is already configured on the repository (fine-grained PAT with `contents:write` + `pull-requests:write`).

## Checklist

- [x] Code compiles / builds without warnings (no Rust changes)
- [x] Linter passes (no Rust changes)
- [ ] Tests pass (will be verified by CI on this PR)

## Test Plan

- This PR itself exercises \`ci.yml\` on a normal feature branch — confirms the workflow YAML is still valid and the \`check\` status reports as usual.
- Post-merge: manually dispatch the \`Create Release PR\` workflow and confirm the generated release PR has the \`check\` status reported and is no longer \`BLOCKED\`.