### PR TITLE
fix(release): honor rust-toolchain.toml when adding build targets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,9 +58,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: ${{ matrix.target }}
+      - name: Install Rust toolchain
+        run: |
+          rustup show
+          rustup target add ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary

The `build` matrix in `release.yml` has been failing on every non-Linux target (macOS x2, Windows) since the Rust toolchain was pinned via `rust-toolchain.toml` in #169. `dtolnay/rust-toolchain@stable` installs stable and adds the target to it, but `cargo build` runs under 1.95.0 from `rust-toolchain.toml`, which lacks that target — so `E0463: can't find crate for 'core'` aborts the build. As a result, v0.0.31 and v0.0.32 are missing macOS/Windows release assets.

## Related Issues

Closes #176

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [x] CI / Build

## Changes

- Replace `dtolnay/rust-toolchain@stable` + `targets:` with a `rustup show && rustup target add` step in the `build` job. `rustup show` installs the toolchain declared in `rust-toolchain.toml`, and the subsequent `rustup target add` attaches the matrix target to that same toolchain — the one `cargo build` actually uses.
- Rust version stays in `rust-toolchain.toml` alone; no duplication in CI.

## Checklist

- [x] Code compiles / builds without warnings (no Rust changes)
- [x] Linter passes (no Rust changes)
- [ ] Tests pass (not applicable — release.yml is not triggered by this PR)

## Test Plan

- `release.yml` runs only on merged `release/*` PRs, so this PR does not exercise the changed workflow directly.
- Post-merge verification: trigger the next release cycle (`Create Release PR` → merge → `Release` workflow). Expect all four matrix entries (`x86_64-unknown-linux-gnu`, `x86_64-apple-darwin`, `aarch64-apple-darwin`, `x86_64-pc-windows-msvc`) to produce archives uploaded to the GitHub Release, and `update-homebrew` to succeed.
- Failure mode to watch: `rustup show` failing to resolve 1.95.0 on a specific runner — would be visible immediately in the workflow log.