### PR TITLE
fix(worktree): gate inflight worktree ops per-path so unrelated entries stay actionable

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -135,7 +135,9 @@ pub struct App {
     pub wt_force_delete_requested: Option<String>,
     pub wt_force_delete_pending_path: Option<String>,
     pub wt_create_requested: Option<String>,
-    pub wt_loading: bool,
+    /// Worktree paths with an in-flight create/delete, gated per-path so unrelated
+    /// worktrees stay actionable in the UI while one is still running.
+    pub wt_inflight: HashSet<String>,
     pub branch_selected: HashSet<String>,
     pub branch_delete_requested: bool,
     pub open_pr_requested: Option<u64>,
@@ -197,7 +199,7 @@ impl App {
             wt_force_delete_requested: None,
             wt_force_delete_pending_path: None,
             wt_create_requested: None,
-            wt_loading: false,
+            wt_inflight: HashSet::new(),
             branch_selected: HashSet::new(),
             branch_delete_requested: false,
             open_pr_requested: None,
@@ -224,7 +226,7 @@ impl App {
     pub fn tick(&mut self) {
         self.spinner_tick = self.spinner_tick.wrapping_add(1);
         // Don't auto-dismiss while a worktree operation is in progress
-        if !self.wt_loading
+        if self.wt_inflight.is_empty()
             && let Some(ref mut n) = self.notification
         {
             if n.ticks_remaining > 0 {
@@ -533,10 +535,10 @@ impl App {
                         format!("Delete {count} {label}? [{preview}]")
                     };
                     self.confirm_dialog = Some(ConfirmDialog::new("Delete Branches", msg));
-                } else if !self.wt_loading
-                    && let Some(entry) = self.selected_entry().cloned()
+                } else if let Some(entry) = self.selected_entry().cloned()
                     && let Some(wt_path) = entry.worktree_path()
                     && !entry.is_current()
+                    && !self.wt_inflight.contains(wt_path)
                 {
                     let path = wt_path.to_string();
                     self.confirm_dialog = Some(ConfirmDialog::new(
@@ -547,11 +549,13 @@ impl App {
                 }
             }
             KeyCode::Char('w') => {
-                if !self.wt_loading
-                    && let Some(entry) = self.selected_entry()
+                if let Some(entry) = self.selected_entry()
                     && entry.worktree.is_none()
                     && !entry.is_current()
                     && (entry.local_branch.is_some() || entry.pull_request.is_some())
+                    && !self
+                        .wt_inflight
+                        .contains(&self.config.worktree_path(&entry.name))
                 {
                     self.wt_create_requested = Some(entry.name.clone());
                     self.notification =
@@ -675,14 +679,19 @@ impl App {
         if entry.worktree.is_some() {
             items.push(ActionItem::CdIntoWorktree);
         }
-        if !self.wt_loading
-            && entry.worktree.is_none()
+        if entry.worktree.is_none()
             && !entry.is_current()
             && (entry.local_branch.is_some() || entry.pull_request.is_some())
+            && !self
+                .wt_inflight
+                .contains(&self.config.worktree_path(&entry.name))
         {
             items.push(ActionItem::CreateWorktree);
         }
-        if !self.wt_loading && entry.worktree.is_some() && !entry.is_current() {
+        if let Some(wt_path) = entry.worktree_path()
+            && !entry.is_current()
+            && !self.wt_inflight.contains(wt_path)
+        {
             items.push(ActionItem::DeleteWorktree);
         }
         if entry.local_branch.is_some() {
@@ -846,7 +855,11 @@ impl App {
             }
             KeyCode::Char('n') | KeyCode::Esc => {
                 self.wt_delete_pending_path = None;
-                self.wt_force_delete_pending_path = None;
+                // Declining force-delete ends the op — release the path so its
+                // action items reappear.
+                if let Some(path) = self.wt_force_delete_pending_path.take() {
+                    self.wt_inflight.remove(&path);
+                }
                 self.confirm_dialog = None;
             }
             _ => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,14 +61,20 @@ enum AsyncResult {
         wt_path: String,
         copy_errors: Vec<String>,
     },
-    WtCreateError(String),
+    WtCreateError {
+        wt_path: String,
+        message: String,
+    },
     WtRemoved(String),
     WtRemoveError {
         path: String,
         reason: String,
     },
     WtForceRemoved(String),
-    WtForceRemoveError(String),
+    WtForceRemoveError {
+        path: String,
+        message: String,
+    },
 }
 
 #[tokio::main]
@@ -489,7 +495,7 @@ async fn run(
                     wt_path,
                     copy_errors,
                 } => {
-                    app.wt_loading = false;
+                    app.wt_inflight.remove(&wt_path);
                     if copy_errors.is_empty() {
                         app.notification = Some(Notification::success(format!(
                             "Worktree created: {wt_path}"
@@ -505,18 +511,18 @@ async fn run(
                     }
                     refresh_entries(&mut app).await;
                 }
-                AsyncResult::WtCreateError(msg) => {
-                    app.wt_loading = false;
-                    app.notification = Some(Notification::error(msg));
+                AsyncResult::WtCreateError { wt_path, message } => {
+                    app.wt_inflight.remove(&wt_path);
+                    app.notification = Some(Notification::error(message));
                 }
                 AsyncResult::WtRemoved(path) => {
-                    app.wt_loading = false;
+                    app.wt_inflight.remove(&path);
                     app.notification =
                         Some(Notification::success(format!("Worktree removed: {path}")));
                     refresh_entries(&mut app).await;
                 }
                 AsyncResult::WtRemoveError { path, reason } => {
-                    app.wt_loading = false;
+                    // Keep path in wt_inflight until the force-delete decision resolves.
                     app.confirm_dialog = Some(crate::ui::confirm_dialog::ConfirmDialog::new(
                         "Force Delete Worktree",
                         format!("{reason}\nForce remove {path}?"),
@@ -524,22 +530,22 @@ async fn run(
                     app.wt_force_delete_pending_path = Some(path);
                 }
                 AsyncResult::WtForceRemoved(path) => {
-                    app.wt_loading = false;
+                    app.wt_inflight.remove(&path);
                     app.notification = Some(Notification::success(format!(
                         "Worktree force removed: {path}"
                     )));
                     refresh_entries(&mut app).await;
                 }
-                AsyncResult::WtForceRemoveError(msg) => {
-                    app.wt_loading = false;
-                    app.notification = Some(Notification::error(msg));
+                AsyncResult::WtForceRemoveError { path, message } => {
+                    app.wt_inflight.remove(&path);
+                    app.notification = Some(Notification::error(message));
                 }
             }
         }
 
         // Delete worktree if requested (async, non-blocking)
         if let Some(path) = app.wt_delete_requested.take() {
-            app.wt_loading = true;
+            app.wt_inflight.insert(path.clone());
             let tx = tx.clone();
             tokio::spawn(async move {
                 match run_git(&["worktree", "remove", &path]).await {
@@ -560,7 +566,7 @@ async fn run(
 
         // Force delete worktree if confirmed (async, non-blocking)
         if let Some(path) = app.wt_force_delete_requested.take() {
-            app.wt_loading = true;
+            app.wt_inflight.insert(path.clone());
             let tx = tx.clone();
             tokio::spawn(async move {
                 match run_git(&["worktree", "remove", "--force", &path]).await {
@@ -568,9 +574,10 @@ async fn run(
                         let _ = tx.send(AsyncResult::WtForceRemoved(path));
                     }
                     Err(e) => {
-                        let _ = tx.send(AsyncResult::WtForceRemoveError(format!(
-                            "Failed to force remove worktree: {e}"
-                        )));
+                        let _ = tx.send(AsyncResult::WtForceRemoveError {
+                            path,
+                            message: format!("Failed to force remove worktree: {e}"),
+                        });
                     }
                 }
             });
@@ -578,8 +585,8 @@ async fn run(
 
         // Create worktree if requested (async, non-blocking)
         if let Some(branch_name) = app.wt_create_requested.take() {
-            app.wt_loading = true;
             let wt_path = app.config.worktree_path(&branch_name);
+            app.wt_inflight.insert(wt_path.clone());
             if let Some(parent) = std::path::Path::new(&wt_path).parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
@@ -609,9 +616,10 @@ async fn run(
                         });
                     }
                     Err(e) => {
-                        let _ = tx.send(AsyncResult::WtCreateError(format!(
-                            "Failed to create worktree: {e}"
-                        )));
+                        let _ = tx.send(AsyncResult::WtCreateError {
+                            wt_path,
+                            message: format!("Failed to create worktree: {e}"),
+                        });
                     }
                 }
             });


### PR DESCRIPTION
## Summary

A global `wt_loading: bool` guarded Create/Delete Worktree actions to prevent concurrent git ops, but while *any* worktree op was in flight, those menu items vanished from **every** branch's action menu — not just the entry being operated on. Replaces the flag with a per-path `wt_inflight: HashSet<String>` so unrelated worktrees stay actionable.

## Related Issues

Closes #179

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- `src/app.rs`: Replace `wt_loading: bool` with `wt_inflight: HashSet<String>` keyed by worktree path. `open_action_menu` and the `d` / `w` shortcuts only suppress Create/Delete Worktree when the current entry's path — or, for Create, `config.worktree_path(&entry.name)` — is in the set.
- `src/main.rs`: Async spawn blocks insert the path into `wt_inflight`; result handlers remove it. `WtCreateError` and `WtForceRemoveError` now carry the target path so the set is cleaned up on failure. `WtRemoveError` keeps the path in flight until the force-delete decision resolves.
- Declining the force-delete confirm (`n` / Esc) releases the path from `wt_inflight`.
- `tick()` notification auto-dismiss pause now checks `wt_inflight.is_empty()` to preserve the prior "don't dismiss while a worktree op is running" behavior.

## Checklist

- [x] Code compiles / builds without warnings (`cargo build`, `cargo clippy -- -D warnings`)
- [x] Linter passes (`cargo fmt -- --check`)
- [x] Tests pass (`cargo test` — 79 passed)

## Test Plan

Reproduced via tmux against a scratch repo with two non-current worktrees (`wt-a` → `A`, `wt-b` → `B`):

1. Launch `gct` from the main worktree.
2. Move to `A`, press Enter, select "Delete worktree", press `y`.
3. Immediately (before the removal notification fires) move to `B` and press Enter.
4. **Before fix:** action menu for `B` is missing "Delete worktree". **After fix:** action menu for `B` shows "Delete worktree" as expected.

Same-path safety verified: opening the menu on `A` while its own delete is still in flight continues to hide "Delete worktree" (path is in `wt_inflight`, so the guard still fires for that entry).