### PR TITLE
feat(worktree): bulk-delete worktrees alongside selected branches

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -508,7 +508,26 @@ impl App {
                 self.branch_selected.extend(to_select);
             }
             KeyCode::Char('d') => {
+                let mut branch_count = 0usize;
+                let mut worktree_count = 0usize;
+                let mut unmerged_count = 0usize;
                 if !self.branch_selected.is_empty() {
+                    for name in &self.branch_selected {
+                        if let Some(entry) = self.entries.iter().find(|e| &e.name == name) {
+                            if entry.local_branch.is_some() {
+                                branch_count += 1;
+                            }
+                            if entry.worktree.is_some() {
+                                worktree_count += 1;
+                            }
+                            if !entry.is_merged() && !entry.pr_is_merged() {
+                                unmerged_count += 1;
+                            }
+                        }
+                    }
+                }
+
+                if branch_count + worktree_count > 0 {
                     let count = self.branch_selected.len();
                     let names: Vec<&str> =
                         self.branch_selected.iter().map(|s| s.as_str()).collect();
@@ -517,24 +536,20 @@ impl App {
                     } else {
                         format!("{} and {} more", names[..2].join(", "), count - 2)
                     };
-                    let unmerged_count = self
-                        .branch_selected
-                        .iter()
-                        .filter(|name| {
-                            self.entries
-                                .iter()
-                                .any(|e| e.name == **name && !e.is_merged() && !e.pr_is_merged())
-                        })
-                        .count();
-                    let label = if count == 1 { "branch" } else { "branches" };
-                    let msg = if unmerged_count > 0 {
-                        format!(
-                            "Delete {count} {label}? ({unmerged_count} unmerged — will force delete)\n[{preview}]"
-                        )
+                    let msg = compose_bulk_delete_message(
+                        branch_count,
+                        worktree_count,
+                        unmerged_count,
+                        &preview,
+                    );
+                    let title = if worktree_count == 0 {
+                        "Delete Branches"
+                    } else if branch_count == 0 {
+                        "Delete Worktrees"
                     } else {
-                        format!("Delete {count} {label}? [{preview}]")
+                        "Delete Branches + Worktrees"
                     };
-                    self.confirm_dialog = Some(ConfirmDialog::new("Delete Branches", msg));
+                    self.confirm_dialog = Some(ConfirmDialog::new(title, msg));
                 } else if let Some(entry) = self.selected_entry().cloned()
                     && let Some(wt_path) = entry.worktree_path()
                     && !entry.is_current()
@@ -890,6 +905,45 @@ fn char_to_byte_idx(s: &str, char_idx: usize) -> usize {
         .unwrap_or(s.len())
 }
 
+pub(crate) fn compose_bulk_delete_message(
+    branches: usize,
+    worktrees: usize,
+    unmerged: usize,
+    preview: &str,
+) -> String {
+    let branch_label = if branches == 1 { "branch" } else { "branches" };
+    let worktree_label = if worktrees == 1 {
+        "worktree"
+    } else {
+        "worktrees"
+    };
+    let mut head_parts = Vec::with_capacity(2);
+    if branches > 0 {
+        head_parts.push(format!("{branches} {branch_label}"));
+    }
+    if worktrees > 0 {
+        head_parts.push(format!("{worktrees} {worktree_label}"));
+    }
+    let head = head_parts.join(" + ");
+
+    let mut clauses = Vec::with_capacity(2);
+    if unmerged > 0 {
+        clauses.push(format!("{unmerged} unmerged — will force delete"));
+    }
+    if worktrees > 0 {
+        clauses.push(format!(
+            "{worktrees} {worktree_label} will be removed, force if needed"
+        ));
+    }
+
+    let head_with_clauses = if clauses.is_empty() {
+        format!("Delete {head}?")
+    } else {
+        format!("Delete {head}? ({})", clauses.join("; "))
+    };
+    format!("{head_with_clauses}\n[{preview}]")
+}
+
 #[cfg(test)]
 mod text_edit_tests {
     use super::*;
@@ -948,5 +1002,66 @@ mod text_edit_tests {
         let mut s = String::from("αβγ");
         remove_char_at(&mut s, 1);
         assert_eq!(s, "αγ");
+    }
+}
+
+#[cfg(test)]
+mod bulk_delete_message_tests {
+    use super::compose_bulk_delete_message;
+
+    #[test]
+    fn branches_only_clean() {
+        assert_eq!(
+            compose_bulk_delete_message(3, 0, 0, "a, b, c"),
+            "Delete 3 branches?\n[a, b, c]"
+        );
+    }
+
+    #[test]
+    fn single_branch_pluralizes() {
+        assert_eq!(
+            compose_bulk_delete_message(1, 0, 0, "a"),
+            "Delete 1 branch?\n[a]"
+        );
+    }
+
+    #[test]
+    fn branches_with_unmerged() {
+        assert_eq!(
+            compose_bulk_delete_message(3, 0, 1, "a, b, c"),
+            "Delete 3 branches? (1 unmerged — will force delete)\n[a, b, c]"
+        );
+    }
+
+    #[test]
+    fn branches_plus_worktrees() {
+        assert_eq!(
+            compose_bulk_delete_message(3, 2, 0, "a, b, c"),
+            "Delete 3 branches + 2 worktrees? (2 worktrees will be removed, force if needed)\n[a, b, c]"
+        );
+    }
+
+    #[test]
+    fn branches_worktrees_and_unmerged() {
+        assert_eq!(
+            compose_bulk_delete_message(3, 2, 1, "a, b, c"),
+            "Delete 3 branches + 2 worktrees? (1 unmerged — will force delete; 2 worktrees will be removed, force if needed)\n[a, b, c]"
+        );
+    }
+
+    #[test]
+    fn worktree_only_singular() {
+        assert_eq!(
+            compose_bulk_delete_message(0, 1, 0, "a"),
+            "Delete 1 worktree? (1 worktree will be removed, force if needed)\n[a]"
+        );
+    }
+
+    #[test]
+    fn single_branch_and_worktree() {
+        assert_eq!(
+            compose_bulk_delete_message(1, 1, 0, "a"),
+            "Delete 1 branch + 1 worktree? (1 worktree will be removed, force if needed)\n[a]"
+        );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -550,6 +550,13 @@ impl App {
                         "Delete Branches + Worktrees"
                     };
                     self.confirm_dialog = Some(ConfirmDialog::new(title, msg));
+                } else if !self.branch_selected.is_empty() {
+                    // Non-empty selection but nothing deletable (e.g. PR-only entries
+                    // with no local branch and no worktree). Tell the user rather
+                    // than silently no-op.
+                    self.notification = Some(Notification::error(
+                        "Nothing to delete in selection".to_string(),
+                    ));
                 } else if let Some(entry) = self.selected_entry().cloned()
                     && let Some(wt_path) = entry.worktree_path()
                     && !entry.is_current()

--- a/src/app.rs
+++ b/src/app.rs
@@ -942,20 +942,10 @@ pub(crate) fn compose_bulk_delete_message(
     }
     let head = head_parts.join(" + ");
 
-    let mut clauses = Vec::with_capacity(2);
-    if unmerged > 0 {
-        clauses.push(format!("{unmerged} unmerged — will force delete"));
-    }
-    if worktrees > 0 {
-        clauses.push(format!(
-            "{worktrees} {worktree_label} will be removed, force if needed"
-        ));
-    }
-
-    let head_with_clauses = if clauses.is_empty() {
-        format!("Delete {head}?")
+    let head_with_clauses = if unmerged > 0 {
+        format!("Delete {head}? ({unmerged} unmerged — will force delete)")
     } else {
-        format!("Delete {head}? ({})", clauses.join("; "))
+        format!("Delete {head}?")
     };
     format!("{head_with_clauses}\n[{preview}]")
 }
@@ -1053,7 +1043,7 @@ mod bulk_delete_message_tests {
     fn branches_plus_worktrees() {
         assert_eq!(
             compose_bulk_delete_message(3, 2, 0, "a, b, c"),
-            "Delete 3 branches + 2 worktrees? (2 worktrees will be removed, force if needed)\n[a, b, c]"
+            "Delete 3 branches + 2 worktrees?\n[a, b, c]"
         );
     }
 
@@ -1061,7 +1051,7 @@ mod bulk_delete_message_tests {
     fn branches_worktrees_and_unmerged() {
         assert_eq!(
             compose_bulk_delete_message(3, 2, 1, "a, b, c"),
-            "Delete 3 branches + 2 worktrees? (1 unmerged — will force delete; 2 worktrees will be removed, force if needed)\n[a, b, c]"
+            "Delete 3 branches + 2 worktrees? (1 unmerged — will force delete)\n[a, b, c]"
         );
     }
 
@@ -1069,7 +1059,7 @@ mod bulk_delete_message_tests {
     fn worktree_only_singular() {
         assert_eq!(
             compose_bulk_delete_message(0, 1, 0, "a"),
-            "Delete 1 worktree? (1 worktree will be removed, force if needed)\n[a]"
+            "Delete 1 worktree?\n[a]"
         );
     }
 
@@ -1077,7 +1067,7 @@ mod bulk_delete_message_tests {
     fn single_branch_and_worktree() {
         assert_eq!(
             compose_bulk_delete_message(1, 1, 0, "a"),
-            "Delete 1 branch + 1 worktree? (1 worktree will be removed, force if needed)\n[a]"
+            "Delete 1 branch + 1 worktree?\n[a]"
         );
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -508,33 +508,42 @@ impl App {
                 self.branch_selected.extend(to_select);
             }
             KeyCode::Char('d') => {
+                // Only entries that will actually be processed (i.e. have a
+                // local branch or a worktree) contribute to the dialog — PR-only
+                // selections are silently ignored by the dispatcher, so they
+                // must not appear in the preview or inflate the counts.
                 let mut branch_count = 0usize;
                 let mut worktree_count = 0usize;
                 let mut unmerged_count = 0usize;
+                let mut deletable_names: Vec<&str> = Vec::new();
                 if !self.branch_selected.is_empty() {
                     for name in &self.branch_selected {
                         if let Some(entry) = self.entries.iter().find(|e| &e.name == name) {
-                            if entry.local_branch.is_some() {
-                                branch_count += 1;
+                            let has_branch = entry.local_branch.is_some();
+                            let has_worktree = entry.worktree.is_some();
+                            if !has_branch && !has_worktree {
+                                continue;
                             }
-                            if entry.worktree.is_some() {
+                            if has_branch {
+                                branch_count += 1;
+                                if !entry.is_merged() && !entry.pr_is_merged() {
+                                    unmerged_count += 1;
+                                }
+                            }
+                            if has_worktree {
                                 worktree_count += 1;
                             }
-                            if !entry.is_merged() && !entry.pr_is_merged() {
-                                unmerged_count += 1;
-                            }
+                            deletable_names.push(name.as_str());
                         }
                     }
                 }
 
                 if branch_count + worktree_count > 0 {
-                    let count = self.branch_selected.len();
-                    let names: Vec<&str> =
-                        self.branch_selected.iter().map(|s| s.as_str()).collect();
+                    let count = deletable_names.len();
                     let preview = if count <= 3 {
-                        names.join(", ")
+                        deletable_names.join(", ")
                     } else {
-                        format!("{} and {} more", names[..2].join(", "), count - 2)
+                        format!("{} and {} more", deletable_names[..2].join(", "), count - 2)
                     };
                     let msg = compose_bulk_delete_message(
                         branch_count,

--- a/src/main.rs
+++ b/src/main.rs
@@ -703,6 +703,10 @@ async fn run(
             }
             let mut work: Vec<Work> = Vec::with_capacity(selected.len());
             let mut wt_paths_claimed: Vec<String> = Vec::new();
+            // Re-validate each selection at dispatch time — entries / inflight
+            // state may have changed between the user pressing Space and d
+            // (e.g. after a refresh). Silently skipping keeps the batch safe
+            // against races; the final notification reflects what actually ran.
             for name in selected {
                 let Some(entry) = app.entries.iter().find(|e| e.name == name) else {
                     continue;

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,29 @@ enum AsyncResult {
         path: String,
         message: String,
     },
+    BulkDeleteDone {
+        branches_deleted: Vec<String>,
+        worktrees_removed: Vec<String>,
+        failures: Vec<String>,
+        wt_paths_claimed: Vec<String>,
+    },
+}
+
+fn bulk_success_parts(branches: usize, worktrees: usize) -> Vec<String> {
+    let mut parts = Vec::with_capacity(2);
+    if branches > 0 {
+        let label = if branches == 1 { "branch" } else { "branches" };
+        parts.push(format!("{branches} {label}"));
+    }
+    if worktrees > 0 {
+        let label = if worktrees == 1 {
+            "worktree"
+        } else {
+            "worktrees"
+        };
+        parts.push(format!("{worktrees} {label}"));
+    }
+    parts
 }
 
 #[tokio::main]
@@ -540,6 +563,49 @@ async fn run(
                     app.wt_inflight.remove(&path);
                     app.notification = Some(Notification::error(message));
                 }
+                AsyncResult::BulkDeleteDone {
+                    branches_deleted,
+                    worktrees_removed,
+                    failures,
+                    wt_paths_claimed,
+                } => {
+                    for path in &wt_paths_claimed {
+                        app.wt_inflight.remove(path);
+                    }
+                    let success_parts =
+                        bulk_success_parts(branches_deleted.len(), worktrees_removed.len());
+                    if failures.is_empty() {
+                        let msg = if success_parts.is_empty() {
+                            "Nothing to delete".to_string()
+                        } else {
+                            format!("Deleted {}", success_parts.join(", "))
+                        };
+                        app.notification = Some(Notification::success(msg));
+                    } else {
+                        let short: Vec<String> = failures
+                            .iter()
+                            .map(|e| e.lines().next().unwrap_or(e).to_string())
+                            .collect();
+                        let summary = if success_parts.is_empty() {
+                            format!("Bulk delete failed: {}", short.join("; "))
+                        } else {
+                            format!(
+                                "Bulk delete: {}; failed: {}",
+                                success_parts.join(", "),
+                                short.join("; ")
+                            )
+                        };
+                        app.notification = Some(Notification::error(summary));
+                        if app.verbose {
+                            for err in &failures {
+                                if !app.verbose_errors.contains(err) {
+                                    app.verbose_errors.push(err.clone());
+                                }
+                            }
+                        }
+                    }
+                    refresh_entries(&mut app).await;
+                }
             }
         }
 
@@ -625,41 +691,117 @@ async fn run(
             });
         }
 
-        // Delete selected branches if requested
+        // Delete selected entries (branches + optional worktrees) in one spawned task
         if app.branch_delete_requested {
             app.branch_delete_requested = false;
             let selected: Vec<String> = app.branch_selected.drain().collect();
-            let mut deleted = Vec::new();
-            let mut failed = Vec::new();
-            for name in &selected {
-                match run_git(&["branch", "-D", name]).await {
-                    Ok(_) => deleted.push(name.as_str()),
-                    Err(e) => failed.push(format!("{name}: {e}")),
-                }
+
+            struct Work {
+                name: String,
+                wt_path: Option<String>,
+                has_local_branch: bool,
             }
-            if !failed.is_empty() {
-                // Show first line only in notification (git errors can be multi-line)
-                let short: Vec<String> = failed
-                    .iter()
-                    .map(|e| e.lines().next().unwrap_or(e).to_string())
-                    .collect();
-                app.notification = Some(Notification::error(format!(
-                    "Failed to delete: {}",
-                    short.join("; ")
-                )));
-                if app.verbose {
-                    let full_msg = format!("Failed to delete: {}", failed.join("; "));
-                    if !app.verbose_errors.contains(&full_msg) {
-                        app.verbose_errors.push(full_msg);
-                    }
+            let mut work: Vec<Work> = Vec::with_capacity(selected.len());
+            let mut wt_paths_claimed: Vec<String> = Vec::new();
+            for name in selected {
+                let Some(entry) = app.entries.iter().find(|e| e.name == name) else {
+                    continue;
+                };
+                if entry.is_current() || app.is_protected_branch(&entry.name) {
+                    continue;
                 }
-            } else if !deleted.is_empty() {
+                let wt_path = entry.worktree_path().map(str::to_string);
+                if let Some(ref p) = wt_path
+                    && app.wt_inflight.contains(p)
+                {
+                    continue;
+                }
+                if let Some(ref p) = wt_path {
+                    app.wt_inflight.insert(p.clone());
+                    wt_paths_claimed.push(p.clone());
+                }
+                work.push(Work {
+                    name: entry.name.clone(),
+                    wt_path,
+                    has_local_branch: entry.local_branch.is_some(),
+                });
+            }
+
+            if work.is_empty() {
+                app.notification = Some(Notification::error("Nothing to delete".to_string()));
+            } else {
+                let pending_summary = bulk_success_parts(
+                    work.iter().filter(|w| w.has_local_branch).count(),
+                    work.iter().filter(|w| w.wt_path.is_some()).count(),
+                )
+                .join(", ");
                 app.notification = Some(Notification::success(format!(
-                    "Deleted {} branch(es)",
-                    deleted.len()
+                    "Deleting {pending_summary}…"
                 )));
+
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    let mut branches_deleted: Vec<String> = Vec::new();
+                    let mut worktrees_removed: Vec<String> = Vec::new();
+                    let mut failures: Vec<String> = Vec::new();
+
+                    for w in work {
+                        let wt_ok = if let Some(path) = w.wt_path.as_ref() {
+                            match run_git(&["worktree", "remove", path]).await {
+                                Ok(_) => {
+                                    worktrees_removed.push(path.clone());
+                                    true
+                                }
+                                Err(_) => {
+                                    match run_git(&["worktree", "remove", "--force", path]).await {
+                                        Ok(_) => {
+                                            worktrees_removed.push(path.clone());
+                                            true
+                                        }
+                                        Err(e) => {
+                                            let short = e
+                                                .to_string()
+                                                .lines()
+                                                .next()
+                                                .unwrap_or("unknown")
+                                                .to_string();
+                                            failures.push(format!(
+                                                "{}: worktree remove failed: {short}",
+                                                w.name
+                                            ));
+                                            false
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            true
+                        };
+
+                        if wt_ok && w.has_local_branch {
+                            match run_git(&["branch", "-D", &w.name]).await {
+                                Ok(_) => branches_deleted.push(w.name.clone()),
+                                Err(e) => {
+                                    let short = e
+                                        .to_string()
+                                        .lines()
+                                        .next()
+                                        .unwrap_or("unknown")
+                                        .to_string();
+                                    failures.push(format!("{}: {short}", w.name));
+                                }
+                            }
+                        }
+                    }
+
+                    let _ = tx.send(AsyncResult::BulkDeleteDone {
+                        branches_deleted,
+                        worktrees_removed,
+                        failures,
+                        wt_paths_claimed,
+                    });
+                });
             }
-            refresh_entries(&mut app).await;
         }
 
         // Create a new branch from the selected branch if requested


### PR DESCRIPTION
## Summary

Extends the existing bulk-delete flow (Space / `a` to select, `d` / `y` to confirm) so selected entries' worktrees are removed alongside their branches. Fixes the common failure where `git branch -D foo` is blocked by "branch 'foo' is checked out at '/path/to/wt'" — the headline bulk flow was effectively unusable on most selections in a worktree-manager TUI. No new keybinding, no new selection mode — the existing UX just became worktree-aware.

## Related Issues

Closes #181

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- Per selected entry: `git worktree remove <path>` first (retries with `--force` automatically on failure, since the user already confirmed the batch and `git branch -D` is likewise unconditional), then `git branch -D` when the entry has a local branch and the wt step did not fail. If both attempts at wt removal fail, the branch delete is skipped for that entry so a branch is never left pointing at a half-deleted wt.
- Execution moved into a single `tokio::spawn` so the UI redraws while the batch runs (matches the single-wt delete pattern already used in `src/main.rs`). The main-thread dispatcher re-validates `is_current()` / `is_protected_branch()` and skips any wt path already in `wt_inflight`.
- Per-path UI gating introduced in #180 is preserved: the dispatcher claims each wt path into `wt_inflight: HashSet<String>` before spawning; the new `AsyncResult::BulkDeleteDone` handler releases them.
- New pure helper `compose_bulk_delete_message(branches, worktrees, unmerged, preview)` builds the confirm dialog text — covered by 7 unit tests. Title resolves to `Delete Branches`, `Delete Worktrees`, or `Delete Branches + Worktrees` depending on the composition.
- New helper `bulk_success_parts(branches, worktrees)` produces the pluralized summary used in both the "Deleting N entries…" progress notification and the final success / partial-failure notification.

## Checklist

- [x] Code compiles / builds without warnings (`cargo build`)
- [x] Linter passes (`cargo clippy -- -D warnings`, `cargo fmt -- --check`)
- [x] Tests pass (`cargo test` — 86 passed, +7 for the new composer)

## Test Plan

Manually verified in a scratch repo via tmux (same pattern as #180):

1. **Branches only (S1)** — Space-select a branch with no worktree, `d` → confirm says `Delete 1 branch? (1 unmerged — will force delete)\n[feat-e]` under the `Delete Branches` title. `y` → branch gone; only `main` remains.
2. **Branches + worktrees (S2)** — Space-select three branches that each have a worktree, `d` → confirm says `Delete 3 branches + 3 worktrees?` with both clauses joined by `; ` under the `Delete Branches + Worktrees` title. `y` → all three worktrees and all three branches are gone; unselected entries are untouched.
3. **Dirty worktree forces `--force` (S3)** — touch a file in one of the worktrees, Space-select that entry, `d` / `y`. The first `git worktree remove` fails; the code auto-retries with `--force` without asking again; the branch is then deleted.

Regression: pressing `d` with nothing selected on an entry whose wt is not in-flight still opens the single-wt confirm dialog exactly as before.