### PR TITLE
feat(worktree): prompt to cd into new worktree after creation

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -134,6 +134,7 @@ pub struct App {
     pub wt_delete_pending_path: Option<String>, // path stored when confirm dialog shown
     pub wt_force_delete_requested: Option<String>,
     pub wt_force_delete_pending_path: Option<String>,
+    pub wt_cd_pending_path: Option<String>,
     pub wt_create_requested: Option<String>,
     /// Worktree paths with an in-flight create/delete, gated per-path so unrelated
     /// worktrees stay actionable in the UI while one is still running.
@@ -198,6 +199,7 @@ impl App {
             wt_delete_pending_path: None,
             wt_force_delete_requested: None,
             wt_force_delete_pending_path: None,
+            wt_cd_pending_path: None,
             wt_create_requested: None,
             wt_inflight: HashSet::new(),
             branch_selected: HashSet::new(),
@@ -875,7 +877,12 @@ impl App {
     fn handle_confirm_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('y') => {
-                if !self.branch_selected.is_empty() {
+                // Move-to-worktree takes precedence — it can race with a
+                // stale `branch_selected` from before the create finished.
+                if let Some(path) = self.wt_cd_pending_path.take() {
+                    self.cd_path = Some(path);
+                    self.should_quit = true;
+                } else if !self.branch_selected.is_empty() {
                     self.branch_delete_requested = true;
                 } else if let Some(path) = self.wt_force_delete_pending_path.take() {
                     self.wt_force_delete_requested = Some(path);
@@ -886,6 +893,7 @@ impl App {
             }
             KeyCode::Char('n') | KeyCode::Esc => {
                 self.wt_delete_pending_path = None;
+                self.wt_cd_pending_path = None;
                 // Declining force-delete ends the op — release the path so its
                 // action items reappear.
                 if let Some(path) = self.wt_force_delete_pending_path.take() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -533,6 +533,15 @@ async fn run(
                         }
                     }
                     refresh_entries(&mut app).await;
+                    if app.confirm_dialog.is_none() {
+                        app.confirm_dialog = Some(crate::ui::confirm_dialog::ConfirmDialog::new(
+                            "Move to Worktree",
+                            format!(
+                                "Move into the new worktree?\n(Requires shell integration — see README.)\n{wt_path}"
+                            ),
+                        ));
+                        app.wt_cd_pending_path = Some(wt_path);
+                    }
                 }
                 AsyncResult::WtCreateError { wt_path, message } => {
                     app.wt_inflight.remove(&wt_path);


### PR DESCRIPTION
## Summary

After `git worktree add` succeeds (via `w` or the action menu), pop a "Move to Worktree" confirm dialog asking "Move into the new worktree? y/n". `y` exits the TUI and emits the new worktree path on stdout — the existing shell-integration wrapper (documented in README) turns that into a `cd` in the parent shell. `n` / `Esc` dismisses the dialog and stays in the TUI.

Eliminates the five-step manual dance users did today: dismiss notification → scroll to new entry → open action menu → pick "cd into worktree" → Enter.

## Related Issues

Closes #184

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- New `App::wt_cd_pending_path: Option<String>` slot, mirroring the existing `wt_force_delete_pending_path` pattern. Reuses `ConfirmDialog` + the existing `cd_path` / `should_quit` exit hook — no new keybinding, no new `AsyncResult` variant, no spawn changes.
- `AsyncResult::WtCreated` handler opens the modal after `refresh_entries(…).await`, gated on `app.confirm_dialog.is_none()` so it never stomps an already-open dialog.
- In `handle_confirm_key`, the new `cd`-pending arm is placed *first* in the `y`-chain. A `branch_selected` that happened to be non-empty when the create finished cannot misroute this confirm into a bulk branch delete.
- Modal text explicitly notes the shell-integration dependency. The binary cannot detect from a child process whether the parent shell sourced the wrapper, so failing silently without an explanation would be poor UX.

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`)
- [x] Tests pass (`cargo test`, 86 passed, unchanged)
- [x] `cargo fmt -- --check` green

## Test Plan

Manually verified in a scratch repo via tmux:

- **S1 — modal text**: navigate to a branch without a wt, press `w`. Modal renders with title `Move to Worktree`, body `Move into the new worktree?\n(Requires shell integration — see README.)\n<wt_path>`, and ` y  Yes   n  No` buttons.
- **S2 — `y` exits with cd path**: from S1 modal, `y`. Binary exits 0, stdout contains exactly the wt path, `git worktree list` confirms the new wt is on disk.
- **S3 — `n` keeps TUI**: same setup, `n`. Modal dismissed, sidebar refocuses on the new entry, session still alive. `q` to exit; stdout empty.
- **S7 — `branch_selected` survives**: Space-select `feat-a`, press `w` on `feat-b`. On the move modal, `n`. After dismiss, `feat-a` still shows `[x]`.