### PR TITLE
fix(review): exclude PRs authored by the current user

### DIFF
--- a/src/data.rs
+++ b/src/data.rs
@@ -296,6 +296,13 @@ pub async fn fetch_review_prs(
         }
     }
 
+    // Exclude PRs authored by the current user. `reviewed-by:@me` matches PRs
+    // where the user submitted any review, including COMMENT-type reviews the
+    // user added on their own PR — those would otherwise leak into the Review tab.
+    if !gh_user.is_empty() {
+        all_prs.retain(|pr| pr.author != gh_user);
+    }
+
     // When me-only, exclude PRs that only have team review requests
     if !include_team && !gh_user.is_empty() {
         all_prs.retain(|pr| {


### PR DESCRIPTION
## Summary

The Review tab occasionally surfaced PRs authored by the current user. Those leaked in via the `reviewed-by:@me` search, which matches any PR where the user submitted a review — including COMMENT-type self-reviews, which GitHub allows on your own PR. This PR filters them out so the Review tab only shows PRs where someone else is asking the user to review.

## Related Issues

Closes #187

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- `fetch_review_prs` in `src/data.rs` now drops PRs whose `author` matches the current `gh_user` before the remaining team-review filter runs. Guarded by `!gh_user.is_empty()` so the behavior is unchanged when the current user is unknown.

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`)
- [x] Tests pass (`cargo test`, 86 passed)

## Test Plan

- Launch `cargo run`, switch to the Review filter.
- Verify a PR authored by the current user that previously appeared (e.g. one where the user left an inline comment review on their own PR) is no longer listed.
- Verify PRs where the user is the requested reviewer, and PRs where the user has reviewed someone else's work, still appear.