### PR TITLE
feat(worktree): parallelize delete with live ProgressPanel

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -492,8 +492,10 @@ impl App {
                     self.request_details_for_selection();
                 } else if matches!(self.active_view, ActiveView::Log | ActiveView::History) {
                     self.active_view = ActiveView::Main;
-                } else {
+                } else if !self.progress.is_active() || self.quit_pressed_during_progress {
                     self.should_quit = true;
+                } else {
+                    self.quit_pressed_during_progress = true;
                 }
             }
             KeyCode::Char('l') => self.active_view = ActiveView::Log,
@@ -1234,6 +1236,29 @@ mod text_edit_tests {
         let mut app = App::new(Config::default());
         app.handle_key(crossterm::event::KeyEvent::new(
             crossterm::event::KeyCode::Char('q'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn esc_during_progress_requires_two_presses() {
+        use crate::config::Config;
+        let mut app = App::new(Config::default());
+        let id = app.progress.allocate_ids(1).start;
+        app.progress.insert(id, OpProgress::new("a".into()));
+
+        // First Esc: sets the flag, no quit.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Esc,
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(!app.should_quit);
+        assert!(app.quit_pressed_during_progress);
+
+        // Second Esc: force quits.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Esc,
             crossterm::event::KeyModifiers::NONE,
         ));
         assert!(app.should_quit);

--- a/src/app.rs
+++ b/src/app.rs
@@ -81,7 +81,9 @@ pub enum OpStep {
 #[derive(Debug, Clone)]
 pub struct OpProgress {
     pub label: String,
+    #[allow(dead_code)]
     pub wt_path: Option<String>,
+    #[allow(dead_code)]
     pub branch_name: Option<String>,
     pub current_step: OpStep,
     pub step_started_at: Instant,

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,7 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
+use std::time::Instant;
 
 use crate::git::types::{Branch, BranchEntry, Commit, PrDetail, PullRequest, Worktree};
 use crate::ui::confirm_dialog::ConfirmDialog;
@@ -67,6 +68,113 @@ pub struct BranchCreateInput {
     pub source: String,
     pub name: String,
     pub cursor: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OpStep {
+    RunningWtRemove,
+    RunningWtForceRemove,
+    RunningBranchDelete,
+    Done { success: bool },
+}
+
+#[derive(Debug, Clone)]
+pub struct OpProgress {
+    pub label: String,
+    pub wt_path: Option<String>,
+    pub branch_name: Option<String>,
+    pub current_step: OpStep,
+    pub step_started_at: Instant,
+    pub op_started_at: Instant,
+    pub last_command: Option<String>,
+    pub error: Option<String>,
+}
+
+impl OpProgress {
+    pub fn new(label: String, wt_path: Option<String>, branch_name: Option<String>) -> Self {
+        let now = Instant::now();
+        Self {
+            label,
+            wt_path,
+            branch_name,
+            current_step: OpStep::RunningWtRemove, // overwritten by first OpStepBegin
+            step_started_at: now,
+            op_started_at: now,
+            last_command: None,
+            error: None,
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        matches!(self.current_step, OpStep::Done { .. })
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct ProgressTracker {
+    pub ops: BTreeMap<u64, OpProgress>,
+    pub next_id: u64,
+    pub started_at: Option<Instant>,
+}
+
+impl ProgressTracker {
+    pub fn is_active(&self) -> bool {
+        !self.ops.is_empty()
+    }
+
+    pub fn total(&self) -> usize {
+        self.ops.len()
+    }
+
+    pub fn done_count(&self) -> usize {
+        self.ops.values().filter(|p| p.is_done()).count()
+    }
+
+    pub fn allocate_ids(&mut self, n: usize) -> std::ops::Range<u64> {
+        let start = self.next_id;
+        self.next_id += n as u64;
+        if self.started_at.is_none() && n > 0 {
+            self.started_at = Some(Instant::now());
+        }
+        start..self.next_id
+    }
+
+    pub fn insert(&mut self, op_id: u64, op: OpProgress) {
+        self.ops.insert(op_id, op);
+    }
+
+    pub fn update_step(&mut self, op_id: u64, step: OpStep, command: String) {
+        if let Some(op) = self.ops.get_mut(&op_id) {
+            op.current_step = step;
+            op.last_command = Some(command);
+            op.step_started_at = Instant::now();
+        }
+    }
+
+    pub fn finish(&mut self, op_id: u64, success: bool, error: Option<String>) {
+        if let Some(op) = self.ops.get_mut(&op_id) {
+            op.current_step = OpStep::Done { success };
+            op.error = error;
+        }
+    }
+
+    /// Force-finish any non-Done ops as failures. Used when OpAllDone arrives
+    /// but some tasks panicked and never sent OpFinished.
+    pub fn sweep_unfinished(&mut self) {
+        for op in self.ops.values_mut() {
+            if !op.is_done() {
+                op.current_step = OpStep::Done { success: false };
+                if op.error.is_none() {
+                    op.error = Some("interrupted".to_string());
+                }
+            }
+        }
+    }
+
+    pub fn clear(&mut self) {
+        self.ops.clear();
+        self.started_at = None;
+    }
 }
 
 pub struct App {
@@ -139,6 +247,8 @@ pub struct App {
     /// Worktree paths with an in-flight create/delete, gated per-path so unrelated
     /// worktrees stay actionable in the UI while one is still running.
     pub wt_inflight: HashSet<String>,
+    pub progress: ProgressTracker,
+    pub quit_pressed_during_progress: bool,
     pub branch_selected: HashSet<String>,
     pub branch_delete_requested: bool,
     pub open_pr_requested: Option<u64>,
@@ -202,6 +312,8 @@ impl App {
             wt_cd_pending_path: None,
             wt_create_requested: None,
             wt_inflight: HashSet::new(),
+            progress: ProgressTracker::default(),
+            quit_pressed_during_progress: false,
             branch_selected: HashSet::new(),
             branch_delete_requested: false,
             open_pr_requested: None,
@@ -1016,6 +1128,90 @@ mod text_edit_tests {
         let mut s = String::from("αβγ");
         remove_char_at(&mut s, 1);
         assert_eq!(s, "αγ");
+    }
+
+    #[test]
+    fn progress_tracker_allocate_ids_advances() {
+        let mut t = ProgressTracker::default();
+        let r = t.allocate_ids(3);
+        assert_eq!(r, 0..3);
+        let r2 = t.allocate_ids(2);
+        assert_eq!(r2, 3..5);
+        assert_eq!(t.next_id, 5);
+    }
+
+    #[test]
+    fn progress_tracker_allocate_ids_sets_started_at_once() {
+        let mut t = ProgressTracker::default();
+        assert!(t.started_at.is_none());
+        let _ = t.allocate_ids(2);
+        let first = t
+            .started_at
+            .expect("started_at set on first non-empty allocation");
+        let _ = t.allocate_ids(1);
+        assert_eq!(t.started_at, Some(first));
+    }
+
+    #[test]
+    fn progress_tracker_state_transitions() {
+        let mut t = ProgressTracker::default();
+        let ids: Vec<u64> = t.allocate_ids(2).collect();
+        t.insert(
+            ids[0],
+            OpProgress::new("a".into(), Some("/wt/a".into()), Some("a".into())),
+        );
+        t.insert(
+            ids[1],
+            OpProgress::new("b".into(), Some("/wt/b".into()), Some("b".into())),
+        );
+
+        assert_eq!(t.total(), 2);
+        assert_eq!(t.done_count(), 0);
+        assert!(t.is_active());
+
+        t.update_step(
+            ids[0],
+            OpStep::RunningWtForceRemove,
+            "git worktree remove --force /wt/a".into(),
+        );
+        assert_eq!(t.ops[&ids[0]].current_step, OpStep::RunningWtForceRemove);
+        assert_eq!(
+            t.ops[&ids[0]].last_command.as_deref(),
+            Some("git worktree remove --force /wt/a")
+        );
+
+        t.finish(ids[0], true, None);
+        assert!(t.ops[&ids[0]].is_done());
+        assert_eq!(t.done_count(), 1);
+
+        t.finish(ids[1], false, Some("nope".into()));
+        assert_eq!(t.done_count(), 2);
+        assert_eq!(t.ops[&ids[1]].error.as_deref(), Some("nope"));
+    }
+
+    #[test]
+    fn progress_tracker_sweep_unfinished_marks_remaining_as_failed() {
+        let mut t = ProgressTracker::default();
+        let ids: Vec<u64> = t.allocate_ids(2).collect();
+        t.insert(ids[0], OpProgress::new("a".into(), None, Some("a".into())));
+        t.insert(ids[1], OpProgress::new("b".into(), None, Some("b".into())));
+        t.finish(ids[0], true, None);
+
+        t.sweep_unfinished();
+        assert!(t.ops[&ids[1]].is_done());
+        assert_eq!(t.ops[&ids[1]].current_step, OpStep::Done { success: false });
+        assert_eq!(t.ops[&ids[1]].error.as_deref(), Some("interrupted"));
+    }
+
+    #[test]
+    fn progress_tracker_clear_resets_state() {
+        let mut t = ProgressTracker::default();
+        let ids: Vec<u64> = t.allocate_ids(1).collect();
+        t.insert(ids[0], OpProgress::new("a".into(), None, None));
+        t.clear();
+        assert!(!t.is_active());
+        assert!(t.started_at.is_none());
+        assert_eq!(t.total(), 0);
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -486,7 +486,13 @@ impl App {
 
         match key.code {
             KeyCode::Char('?') => self.show_help = true,
-            KeyCode::Char('q') => self.should_quit = true,
+            KeyCode::Char('q') => {
+                if !self.progress.is_active() || self.quit_pressed_during_progress {
+                    self.should_quit = true;
+                } else {
+                    self.quit_pressed_during_progress = true;
+                }
+            }
             KeyCode::Esc => {
                 if !self.search_query.is_empty() {
                     // Clear search filter and restore scroll
@@ -1214,6 +1220,41 @@ mod text_edit_tests {
         assert!(!t.is_active());
         assert!(t.started_at.is_none());
         assert_eq!(t.total(), 0);
+    }
+
+    #[test]
+    fn quit_during_progress_requires_two_presses() {
+        use crate::config::Config;
+        let mut app = App::new(Config::default());
+        let id = app.progress.allocate_ids(1).start;
+        app.progress
+            .insert(id, OpProgress::new("a".into(), None, None));
+
+        // First 'q': sets the flag, no quit.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('q'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(!app.should_quit);
+        assert!(app.quit_pressed_during_progress);
+
+        // Second 'q': force quits.
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('q'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn quit_when_no_progress_quits_immediately() {
+        use crate::config::Config;
+        let mut app = App::new(Config::default());
+        app.handle_key(crossterm::event::KeyEvent::new(
+            crossterm::event::KeyCode::Char('q'),
+            crossterm::event::KeyModifiers::NONE,
+        ));
+        assert!(app.should_quit);
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -81,27 +81,18 @@ pub enum OpStep {
 #[derive(Debug, Clone)]
 pub struct OpProgress {
     pub label: String,
-    #[allow(dead_code)]
-    pub wt_path: Option<String>,
-    #[allow(dead_code)]
-    pub branch_name: Option<String>,
     pub current_step: OpStep,
-    pub step_started_at: Instant,
     pub op_started_at: Instant,
     pub last_command: Option<String>,
     pub error: Option<String>,
 }
 
 impl OpProgress {
-    pub fn new(label: String, wt_path: Option<String>, branch_name: Option<String>) -> Self {
-        let now = Instant::now();
+    pub fn new(label: String) -> Self {
         Self {
             label,
-            wt_path,
-            branch_name,
             current_step: OpStep::RunningWtRemove, // overwritten by first OpStepBegin
-            step_started_at: now,
-            op_started_at: now,
+            op_started_at: Instant::now(),
             last_command: None,
             error: None,
         }
@@ -115,7 +106,7 @@ impl OpProgress {
 #[derive(Debug, Default)]
 pub struct ProgressTracker {
     pub ops: BTreeMap<u64, OpProgress>,
-    pub next_id: u64,
+    next_id: u64,
     pub started_at: Option<Instant>,
 }
 
@@ -149,7 +140,6 @@ impl ProgressTracker {
         if let Some(op) = self.ops.get_mut(&op_id) {
             op.current_step = step;
             op.last_command = Some(command);
-            op.step_started_at = Instant::now();
         }
     }
 
@@ -1145,7 +1135,6 @@ mod text_edit_tests {
         assert_eq!(r, 0..3);
         let r2 = t.allocate_ids(2);
         assert_eq!(r2, 3..5);
-        assert_eq!(t.next_id, 5);
     }
 
     #[test]
@@ -1164,14 +1153,8 @@ mod text_edit_tests {
     fn progress_tracker_state_transitions() {
         let mut t = ProgressTracker::default();
         let ids: Vec<u64> = t.allocate_ids(2).collect();
-        t.insert(
-            ids[0],
-            OpProgress::new("a".into(), Some("/wt/a".into()), Some("a".into())),
-        );
-        t.insert(
-            ids[1],
-            OpProgress::new("b".into(), Some("/wt/b".into()), Some("b".into())),
-        );
+        t.insert(ids[0], OpProgress::new("a".into()));
+        t.insert(ids[1], OpProgress::new("b".into()));
 
         assert_eq!(t.total(), 2);
         assert_eq!(t.done_count(), 0);
@@ -1201,8 +1184,8 @@ mod text_edit_tests {
     fn progress_tracker_sweep_unfinished_marks_remaining_as_failed() {
         let mut t = ProgressTracker::default();
         let ids: Vec<u64> = t.allocate_ids(2).collect();
-        t.insert(ids[0], OpProgress::new("a".into(), None, Some("a".into())));
-        t.insert(ids[1], OpProgress::new("b".into(), None, Some("b".into())));
+        t.insert(ids[0], OpProgress::new("a".into()));
+        t.insert(ids[1], OpProgress::new("b".into()));
         t.finish(ids[0], true, None);
 
         t.sweep_unfinished();
@@ -1215,7 +1198,7 @@ mod text_edit_tests {
     fn progress_tracker_clear_resets_state() {
         let mut t = ProgressTracker::default();
         let ids: Vec<u64> = t.allocate_ids(1).collect();
-        t.insert(ids[0], OpProgress::new("a".into(), None, None));
+        t.insert(ids[0], OpProgress::new("a".into()));
         t.clear();
         assert!(!t.is_active());
         assert!(t.started_at.is_none());
@@ -1227,8 +1210,7 @@ mod text_edit_tests {
         use crate::config::Config;
         let mut app = App::new(Config::default());
         let id = app.progress.allocate_ids(1).start;
-        app.progress
-            .insert(id, OpProgress::new("a".into(), None, None));
+        app.progress.insert(id, OpProgress::new("a".into()));
 
         // First 'q': sets the flag, no quit.
         app.handle_key(crossterm::event::KeyEvent::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -758,11 +758,6 @@ async fn run(
                     error,
                 } => {
                     app.progress.finish(op_id, success, error);
-                    // Optimistic UI: drop the entry from the sidebar early on success.
-                    if success && let Some(op) = app.progress.ops.get(&op_id) {
-                        let label = op.label.clone();
-                        app.entries.retain(|e| e.name != label);
-                    }
                 }
                 AsyncResult::OpAllDone {
                     branches_deleted,
@@ -959,7 +954,6 @@ async fn run(
 
             struct Work {
                 name: String,
-                label: String,
                 wt_path: Option<String>,
                 has_local_branch: bool,
             }
@@ -984,7 +978,6 @@ async fn run(
                 }
                 work.push(Work {
                     name: entry.name.clone(),
-                    label: entry.name.clone(),
                     wt_path,
                     has_local_branch: entry.local_branch.is_some(),
                 });
@@ -999,7 +992,7 @@ async fn run(
                     let tx_c = tx.clone();
                     set.spawn(run_delete_op(
                         op_id,
-                        w.label,
+                        w.name.clone(),
                         w.wt_path,
                         Some(w.name),
                         w.has_local_branch,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,8 +74,6 @@ enum AsyncResult {
     OpStarted {
         op_id: u64,
         label: String,
-        wt_path: Option<String>,
-        branch_name: Option<String>,
     },
     OpStepBegin {
         op_id: u64,
@@ -174,8 +172,6 @@ async fn run_delete_op(
     let _ = tx.send(AsyncResult::OpStarted {
         op_id,
         label: label.clone(),
-        wt_path: wt_path.clone(),
-        branch_name: branch_name.clone(),
     });
 
     let mut worktree_removed = false;
@@ -746,14 +742,8 @@ async fn run(
                     app.wt_inflight.remove(&wt_path);
                     app.notification = Some(Notification::error(message));
                 }
-                AsyncResult::OpStarted {
-                    op_id,
-                    label,
-                    wt_path,
-                    branch_name,
-                } => {
-                    app.progress
-                        .insert(op_id, OpProgress::new(label, wt_path, branch_name));
+                AsyncResult::OpStarted { op_id, label } => {
+                    app.progress.insert(op_id, OpProgress::new(label));
                 }
                 AsyncResult::OpStepBegin {
                     op_id,
@@ -851,12 +841,14 @@ async fn run(
                 .await;
 
                 if let Some(failure) = result.failure {
-                    // Plain failed — emit OpAllDone (closes the panel) then ask
-                    // the user whether to force via WtForceDecisionRequested.
+                    // Plain failed — drain the progress panel without raising a
+                    // failure notification (it would flash before the force-confirm
+                    // dialog appears). The actual outcome is communicated by the
+                    // subsequent force attempt or by the user dismissing the dialog.
                     let _ = tx_c.send(AsyncResult::OpAllDone {
                         branches_deleted: vec![],
                         worktrees_removed: vec![],
-                        failures: vec![failure.clone()],
+                        failures: vec![],
                         wt_paths_claimed: claimed,
                     });
                     let reason = failure

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,8 @@ use tokio::sync::mpsc;
 
 use crate::app::App;
 use crate::app::MainFilter;
+#[allow(unused_imports)]
+use crate::app::{OpProgress, OpStep, ProgressTracker};
 use crate::data::merge_entries;
 use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git};
@@ -44,6 +46,7 @@ struct RepoInfo {
     hostname: Option<String>, // None for github.com
 }
 
+#[allow(dead_code)]
 enum AsyncResult {
     PrDetail(PrDetail),
     PrDetailError(u64, String),
@@ -76,6 +79,28 @@ enum AsyncResult {
         message: String,
     },
     BulkDeleteDone {
+        branches_deleted: Vec<String>,
+        worktrees_removed: Vec<String>,
+        failures: Vec<String>,
+        wt_paths_claimed: Vec<String>,
+    },
+    OpStarted {
+        op_id: u64,
+        label: String,
+        wt_path: Option<String>,
+        branch_name: Option<String>,
+    },
+    OpStepBegin {
+        op_id: u64,
+        step: OpStep,
+        command: String,
+    },
+    OpFinished {
+        op_id: u64,
+        success: bool,
+        error: Option<String>,
+    },
+    OpAllDone {
         branches_deleted: Vec<String>,
         worktrees_removed: Vec<String>,
         failures: Vec<String>,
@@ -615,6 +640,12 @@ async fn run(
                     }
                     refresh_entries(&mut app).await;
                 }
+                // New Op* variants have no producers yet (Task 2 of progress-pipeline).
+                // Reducers wired in Task 3.
+                AsyncResult::OpStarted { .. }
+                | AsyncResult::OpStepBegin { .. }
+                | AsyncResult::OpFinished { .. }
+                | AsyncResult::OpAllDone { .. } => {}
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use crossterm::terminal::{
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 use tokio::sync::mpsc;
+use tokio::task::JoinSet;
 
 use crate::app::App;
 use crate::app::MainFilter;
@@ -76,12 +77,6 @@ enum AsyncResult {
     WtForceRemoveError {
         path: String,
         message: String,
-    },
-    BulkDeleteDone {
-        branches_deleted: Vec<String>,
-        worktrees_removed: Vec<String>,
-        failures: Vec<String>,
-        wt_paths_claimed: Vec<String>,
     },
     OpStarted {
         op_id: u64,
@@ -146,7 +141,6 @@ struct DeleteOpResult {
 }
 
 impl DeleteOpResult {
-    #[allow(dead_code)]
     fn collect_into(
         self,
         branches: &mut Vec<String>,
@@ -169,7 +163,6 @@ impl DeleteOpResult {
     }
 }
 
-#[allow(dead_code)]
 async fn run_delete_op(
     op_id: u64,
     label: String,
@@ -177,29 +170,25 @@ async fn run_delete_op(
     branch_name: Option<String>,
     has_local_branch: bool,
     mode: DeleteMode,
-    tx: mpsc::Sender<AsyncResult>,
+    tx: mpsc::UnboundedSender<AsyncResult>,
 ) -> DeleteOpResult {
-    let _ = tx
-        .send(AsyncResult::OpStarted {
-            op_id,
-            label: label.clone(),
-            wt_path: wt_path.clone(),
-            branch_name: branch_name.clone(),
-        })
-        .await;
+    let _ = tx.send(AsyncResult::OpStarted {
+        op_id,
+        label: label.clone(),
+        wt_path: wt_path.clone(),
+        branch_name: branch_name.clone(),
+    });
 
     let mut worktree_removed = false;
     if let Some(path) = wt_path.as_ref() {
         // Plain attempt (skipped for ForceOnly)
         if matches!(mode, DeleteMode::TryThenForce | DeleteMode::PlainOnly) {
             let cmd = format!("git worktree remove {path}");
-            let _ = tx
-                .send(AsyncResult::OpStepBegin {
-                    op_id,
-                    step: OpStep::RunningWtRemove,
-                    command: cmd,
-                })
-                .await;
+            let _ = tx.send(AsyncResult::OpStepBegin {
+                op_id,
+                step: OpStep::RunningWtRemove,
+                command: cmd,
+            });
             match run_git(&["worktree", "remove", path]).await {
                 Ok(_) => worktree_removed = true,
                 Err(e) => {
@@ -211,13 +200,11 @@ async fn run_delete_op(
                             .next()
                             .unwrap_or("unknown")
                             .to_string();
-                        let _ = tx
-                            .send(AsyncResult::OpFinished {
-                                op_id,
-                                success: false,
-                                error: Some(short.clone()),
-                            })
-                            .await;
+                        let _ = tx.send(AsyncResult::OpFinished {
+                            op_id,
+                            success: false,
+                            error: Some(short.clone()),
+                        });
                         return DeleteOpResult {
                             op_id,
                             branch_name,
@@ -235,13 +222,11 @@ async fn run_delete_op(
         // Force attempt (TryThenForce after plain failure, or ForceOnly always)
         if !worktree_removed {
             let cmd = format!("git worktree remove --force {path}");
-            let _ = tx
-                .send(AsyncResult::OpStepBegin {
-                    op_id,
-                    step: OpStep::RunningWtForceRemove,
-                    command: cmd,
-                })
-                .await;
+            let _ = tx.send(AsyncResult::OpStepBegin {
+                op_id,
+                step: OpStep::RunningWtForceRemove,
+                command: cmd,
+            });
             match run_git(&["worktree", "remove", "--force", path]).await {
                 Ok(_) => worktree_removed = true,
                 Err(e) => {
@@ -251,13 +236,11 @@ async fn run_delete_op(
                         .next()
                         .unwrap_or("unknown")
                         .to_string();
-                    let _ = tx
-                        .send(AsyncResult::OpFinished {
-                            op_id,
-                            success: false,
-                            error: Some(short.clone()),
-                        })
-                        .await;
+                    let _ = tx.send(AsyncResult::OpFinished {
+                        op_id,
+                        success: false,
+                        error: Some(short.clone()),
+                    });
                     return DeleteOpResult {
                         op_id,
                         branch_name,
@@ -275,13 +258,11 @@ async fn run_delete_op(
     if has_local_branch {
         if let Some(name) = branch_name.as_ref() {
             let cmd = format!("git branch -D {name}");
-            let _ = tx
-                .send(AsyncResult::OpStepBegin {
-                    op_id,
-                    step: OpStep::RunningBranchDelete,
-                    command: cmd,
-                })
-                .await;
+            let _ = tx.send(AsyncResult::OpStepBegin {
+                op_id,
+                step: OpStep::RunningBranchDelete,
+                command: cmd,
+            });
             match run_git(&["branch", "-D", name]).await {
                 Ok(_) => branch_deleted = true,
                 Err(e) => {
@@ -291,13 +272,11 @@ async fn run_delete_op(
                         .next()
                         .unwrap_or("unknown")
                         .to_string();
-                    let _ = tx
-                        .send(AsyncResult::OpFinished {
-                            op_id,
-                            success: false,
-                            error: Some(short.clone()),
-                        })
-                        .await;
+                    let _ = tx.send(AsyncResult::OpFinished {
+                        op_id,
+                        success: false,
+                        error: Some(short.clone()),
+                    });
                     return DeleteOpResult {
                         op_id,
                         branch_name,
@@ -311,13 +290,11 @@ async fn run_delete_op(
         }
     }
 
-    let _ = tx
-        .send(AsyncResult::OpFinished {
-            op_id,
-            success: true,
-            error: None,
-        })
-        .await;
+    let _ = tx.send(AsyncResult::OpFinished {
+        op_id,
+        success: true,
+        error: None,
+    });
 
     DeleteOpResult {
         op_id,
@@ -877,49 +854,6 @@ async fn run(
                     app.wt_inflight.remove(&path);
                     app.notification = Some(Notification::error(message));
                 }
-                AsyncResult::BulkDeleteDone {
-                    branches_deleted,
-                    worktrees_removed,
-                    failures,
-                    wt_paths_claimed,
-                } => {
-                    for path in &wt_paths_claimed {
-                        app.wt_inflight.remove(path);
-                    }
-                    let success_parts =
-                        bulk_success_parts(branches_deleted.len(), worktrees_removed.len());
-                    if failures.is_empty() {
-                        let msg = if success_parts.is_empty() {
-                            "Nothing to delete".to_string()
-                        } else {
-                            format!("Deleted {}", success_parts.join(", "))
-                        };
-                        app.notification = Some(Notification::success(msg));
-                    } else {
-                        let short: Vec<String> = failures
-                            .iter()
-                            .map(|e| e.lines().next().unwrap_or(e).to_string())
-                            .collect();
-                        let summary = if success_parts.is_empty() {
-                            format!("Bulk delete failed: {}", short.join("; "))
-                        } else {
-                            format!(
-                                "Bulk delete: {}; failed: {}",
-                                success_parts.join(", "),
-                                short.join("; ")
-                            )
-                        };
-                        app.notification = Some(Notification::error(summary));
-                        if app.verbose {
-                            for err in &failures {
-                                if !app.verbose_errors.contains(err) {
-                                    app.verbose_errors.push(err.clone());
-                                }
-                            }
-                        }
-                    }
-                    refresh_entries(&mut app).await;
-                }
             }
         }
 
@@ -1005,22 +939,19 @@ async fn run(
             });
         }
 
-        // Delete selected entries (branches + optional worktrees) in one spawned task
+        // Delete selected entries (branches + optional worktrees) in parallel.
         if app.branch_delete_requested {
             app.branch_delete_requested = false;
             let selected: Vec<String> = app.branch_selected.drain().collect();
 
             struct Work {
                 name: String,
+                label: String,
                 wt_path: Option<String>,
                 has_local_branch: bool,
             }
             let mut work: Vec<Work> = Vec::with_capacity(selected.len());
             let mut wt_paths_claimed: Vec<String> = Vec::new();
-            // Re-validate each selection at dispatch time — entries / inflight
-            // state may have changed between the user pressing Space and d
-            // (e.g. after a refresh). Silently skipping keeps the batch safe
-            // against races; the final notification reflects what actually ran.
             for name in selected {
                 let Some(entry) = app.entries.iter().find(|e| e.name == name) else {
                     continue;
@@ -1040,6 +971,7 @@ async fn run(
                 }
                 work.push(Work {
                     name: entry.name.clone(),
+                    label: entry.name.clone(),
                     wt_path,
                     has_local_branch: entry.local_branch.is_some(),
                 });
@@ -1048,75 +980,38 @@ async fn run(
             if work.is_empty() {
                 app.notification = Some(Notification::error("Nothing to delete".to_string()));
             } else {
-                let pending_summary = bulk_success_parts(
-                    work.iter().filter(|w| w.has_local_branch).count(),
-                    work.iter().filter(|w| w.wt_path.is_some()).count(),
-                )
-                .join(", ");
-                app.notification = Some(Notification::success(format!(
-                    "Deleting {pending_summary}…"
-                )));
+                let ids: Vec<u64> = app.progress.allocate_ids(work.len()).collect();
+                let mut set: JoinSet<DeleteOpResult> = JoinSet::new();
+                for (op_id, w) in ids.into_iter().zip(work) {
+                    let tx_c = tx.clone();
+                    set.spawn(run_delete_op(
+                        op_id,
+                        w.label,
+                        w.wt_path,
+                        Some(w.name),
+                        w.has_local_branch,
+                        DeleteMode::TryThenForce,
+                        tx_c,
+                    ));
+                }
 
-                let tx = tx.clone();
+                let tx_done = tx.clone();
+                let claimed = wt_paths_claimed;
                 tokio::spawn(async move {
-                    let mut branches_deleted: Vec<String> = Vec::new();
-                    let mut worktrees_removed: Vec<String> = Vec::new();
+                    let mut branches: Vec<String> = Vec::new();
+                    let mut wts: Vec<String> = Vec::new();
                     let mut failures: Vec<String> = Vec::new();
-
-                    for w in work {
-                        let wt_ok = if let Some(path) = w.wt_path.as_ref() {
-                            match run_git(&["worktree", "remove", path]).await {
-                                Ok(_) => {
-                                    worktrees_removed.push(path.clone());
-                                    true
-                                }
-                                Err(_) => {
-                                    match run_git(&["worktree", "remove", "--force", path]).await {
-                                        Ok(_) => {
-                                            worktrees_removed.push(path.clone());
-                                            true
-                                        }
-                                        Err(e) => {
-                                            let short = e
-                                                .to_string()
-                                                .lines()
-                                                .next()
-                                                .unwrap_or("unknown")
-                                                .to_string();
-                                            failures.push(format!(
-                                                "{}: worktree remove failed: {short}",
-                                                w.name
-                                            ));
-                                            false
-                                        }
-                                    }
-                                }
-                            }
-                        } else {
-                            true
-                        };
-
-                        if wt_ok && w.has_local_branch {
-                            match run_git(&["branch", "-D", &w.name]).await {
-                                Ok(_) => branches_deleted.push(w.name.clone()),
-                                Err(e) => {
-                                    let short = e
-                                        .to_string()
-                                        .lines()
-                                        .next()
-                                        .unwrap_or("unknown")
-                                        .to_string();
-                                    failures.push(format!("{}: {short}", w.name));
-                                }
-                            }
+                    while let Some(res) = set.join_next().await {
+                        match res {
+                            Ok(r) => r.collect_into(&mut branches, &mut wts, &mut failures),
+                            Err(e) => failures.push(format!("task panic: {e}")),
                         }
                     }
-
-                    let _ = tx.send(AsyncResult::BulkDeleteDone {
-                        branches_deleted,
-                        worktrees_removed,
+                    let _ = tx_done.send(AsyncResult::OpAllDone {
+                        branches_deleted: branches,
+                        worktrees_removed: wts,
                         failures,
-                        wt_paths_claimed,
+                        wt_paths_claimed: claimed,
                     });
                 });
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,15 +147,15 @@ impl DeleteOpResult {
         wts: &mut Vec<String>,
         failures: &mut Vec<String>,
     ) {
-        if self.branch_deleted {
-            if let Some(n) = self.branch_name {
-                branches.push(n);
-            }
+        if self.branch_deleted
+            && let Some(n) = self.branch_name
+        {
+            branches.push(n);
         }
-        if self.worktree_removed {
-            if let Some(p) = self.wt_path {
-                wts.push(p);
-            }
+        if self.worktree_removed
+            && let Some(p) = self.wt_path
+        {
+            wts.push(p);
         }
         if let Some(f) = self.failure {
             failures.push(f);
@@ -255,37 +255,35 @@ async fn run_delete_op(
     }
 
     let mut branch_deleted = false;
-    if has_local_branch {
-        if let Some(name) = branch_name.as_ref() {
-            let cmd = format!("git branch -D {name}");
-            let _ = tx.send(AsyncResult::OpStepBegin {
-                op_id,
-                step: OpStep::RunningBranchDelete,
-                command: cmd,
-            });
-            match run_git(&["branch", "-D", name]).await {
-                Ok(_) => branch_deleted = true,
-                Err(e) => {
-                    let short = e
-                        .to_string()
-                        .lines()
-                        .next()
-                        .unwrap_or("unknown")
-                        .to_string();
-                    let _ = tx.send(AsyncResult::OpFinished {
-                        op_id,
-                        success: false,
-                        error: Some(short.clone()),
-                    });
-                    return DeleteOpResult {
-                        op_id,
-                        branch_name,
-                        wt_path,
-                        branch_deleted: false,
-                        worktree_removed,
-                        failure: Some(format!("{label}: {short}")),
-                    };
-                }
+    if has_local_branch && let Some(name) = branch_name.as_ref() {
+        let cmd = format!("git branch -D {name}");
+        let _ = tx.send(AsyncResult::OpStepBegin {
+            op_id,
+            step: OpStep::RunningBranchDelete,
+            command: cmd,
+        });
+        match run_git(&["branch", "-D", name]).await {
+            Ok(_) => branch_deleted = true,
+            Err(e) => {
+                let short = e
+                    .to_string()
+                    .lines()
+                    .next()
+                    .unwrap_or("unknown")
+                    .to_string();
+                let _ = tx.send(AsyncResult::OpFinished {
+                    op_id,
+                    success: false,
+                    error: Some(short.clone()),
+                });
+                return DeleteOpResult {
+                    op_id,
+                    branch_name,
+                    wt_path,
+                    branch_deleted: false,
+                    worktree_removed,
+                    failure: Some(format!("{label}: {short}")),
+                };
             }
         }
     }
@@ -776,11 +774,9 @@ async fn run(
                 } => {
                     app.progress.finish(op_id, success, error);
                     // Optimistic UI: drop the entry from the sidebar early on success.
-                    if success {
-                        if let Some(op) = app.progress.ops.get(&op_id) {
-                            let label = op.label.clone();
-                            app.entries.retain(|e| e.name != label);
-                        }
+                    if success && let Some(op) = app.progress.ops.get(&op_id) {
+                        let label = op.label.clone();
+                        app.entries.retain(|e| e.name != label);
                     }
                 }
                 AsyncResult::OpAllDone {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,8 +68,7 @@ enum AsyncResult {
         wt_path: String,
         message: String,
     },
-    WtRemoved(String),
-    WtRemoveError {
+    WtForceDecisionRequested {
         path: String,
         reason: String,
     },
@@ -100,6 +99,15 @@ enum AsyncResult {
         failures: Vec<String>,
         wt_paths_claimed: Vec<String>,
     },
+}
+
+/// Display-friendly label for a worktree path: takes the last path segment.
+fn wt_label_for(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or(path)
+        .to_string()
 }
 
 fn bulk_success_parts(branches: usize, worktrees: usize) -> Vec<String> {
@@ -825,14 +833,8 @@ async fn run(
                     app.quit_pressed_during_progress = false;
                     refresh_entries(&mut app).await;
                 }
-                AsyncResult::WtRemoved(path) => {
-                    app.wt_inflight.remove(&path);
-                    app.notification =
-                        Some(Notification::success(format!("Worktree removed: {path}")));
-                    refresh_entries(&mut app).await;
-                }
-                AsyncResult::WtRemoveError { path, reason } => {
-                    // Keep path in wt_inflight until the force-delete decision resolves.
+                AsyncResult::WtForceDecisionRequested { path, reason } => {
+                    // Plain remove failed; ask the user whether to force.
                     app.confirm_dialog = Some(crate::ui::confirm_dialog::ConfirmDialog::new(
                         "Force Delete Worktree",
                         format!("{reason}\nForce remove {path}?"),
@@ -853,23 +855,53 @@ async fn run(
             }
         }
 
-        // Delete worktree if requested (async, non-blocking)
+        // Delete worktree if requested (single-item, no auto-force fallback).
         if let Some(path) = app.wt_delete_requested.take() {
             app.wt_inflight.insert(path.clone());
-            let tx = tx.clone();
+            let op_id = app.progress.allocate_ids(1).start;
+            let label = wt_label_for(&path);
+            let claimed = vec![path.clone()];
+            let tx_c = tx.clone();
             tokio::spawn(async move {
-                match run_git(&["worktree", "remove", &path]).await {
-                    Ok(_) => {
-                        let _ = tx.send(AsyncResult::WtRemoved(path));
+                let result = run_delete_op(
+                    op_id,
+                    label.clone(),
+                    Some(path.clone()),
+                    None,
+                    false,
+                    DeleteMode::PlainOnly,
+                    tx_c.clone(),
+                )
+                .await;
+
+                if let Some(failure) = result.failure {
+                    // Plain failed — emit OpAllDone (closes the panel) then ask
+                    // the user whether to force via WtForceDecisionRequested.
+                    let _ = tx_c.send(AsyncResult::OpAllDone {
+                        branches_deleted: vec![],
+                        worktrees_removed: vec![],
+                        failures: vec![failure.clone()],
+                        wt_paths_claimed: claimed,
+                    });
+                    let reason = failure
+                        .lines()
+                        .next()
+                        .unwrap_or("unknown error")
+                        .to_string();
+                    let _ = tx_c.send(AsyncResult::WtForceDecisionRequested { path, reason });
+                } else {
+                    let mut wts = vec![];
+                    if result.worktree_removed
+                        && let Some(p) = result.wt_path
+                    {
+                        wts.push(p);
                     }
-                    Err(e) => {
-                        let reason = format!("{e}")
-                            .lines()
-                            .next()
-                            .unwrap_or("unknown error")
-                            .to_string();
-                        let _ = tx.send(AsyncResult::WtRemoveError { path, reason });
-                    }
+                    let _ = tx_c.send(AsyncResult::OpAllDone {
+                        branches_deleted: vec![],
+                        worktrees_removed: wts,
+                        failures: vec![],
+                        wt_paths_claimed: claimed,
+                    });
                 }
             });
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,6 +124,211 @@ fn bulk_success_parts(branches: usize, worktrees: usize) -> Vec<String> {
     parts
 }
 
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
+enum DeleteMode {
+    /// Try plain `worktree remove`; on failure, retry with `--force` (used for bulk).
+    TryThenForce,
+    /// Run `worktree remove` only; do NOT auto-fallback (used for single, first attempt).
+    PlainOnly,
+    /// Run `worktree remove --force` directly (used for single, after user confirms).
+    ForceOnly,
+}
+
+#[allow(dead_code)]
+struct DeleteOpResult {
+    op_id: u64,
+    branch_name: Option<String>,
+    wt_path: Option<String>,
+    branch_deleted: bool,
+    worktree_removed: bool,
+    failure: Option<String>,
+}
+
+impl DeleteOpResult {
+    #[allow(dead_code)]
+    fn collect_into(
+        self,
+        branches: &mut Vec<String>,
+        wts: &mut Vec<String>,
+        failures: &mut Vec<String>,
+    ) {
+        if self.branch_deleted {
+            if let Some(n) = self.branch_name {
+                branches.push(n);
+            }
+        }
+        if self.worktree_removed {
+            if let Some(p) = self.wt_path {
+                wts.push(p);
+            }
+        }
+        if let Some(f) = self.failure {
+            failures.push(f);
+        }
+    }
+}
+
+#[allow(dead_code)]
+async fn run_delete_op(
+    op_id: u64,
+    label: String,
+    wt_path: Option<String>,
+    branch_name: Option<String>,
+    has_local_branch: bool,
+    mode: DeleteMode,
+    tx: mpsc::Sender<AsyncResult>,
+) -> DeleteOpResult {
+    let _ = tx
+        .send(AsyncResult::OpStarted {
+            op_id,
+            label: label.clone(),
+            wt_path: wt_path.clone(),
+            branch_name: branch_name.clone(),
+        })
+        .await;
+
+    let mut worktree_removed = false;
+    if let Some(path) = wt_path.as_ref() {
+        // Plain attempt (skipped for ForceOnly)
+        if matches!(mode, DeleteMode::TryThenForce | DeleteMode::PlainOnly) {
+            let cmd = format!("git worktree remove {path}");
+            let _ = tx
+                .send(AsyncResult::OpStepBegin {
+                    op_id,
+                    step: OpStep::RunningWtRemove,
+                    command: cmd,
+                })
+                .await;
+            match run_git(&["worktree", "remove", path]).await {
+                Ok(_) => worktree_removed = true,
+                Err(e) => {
+                    if matches!(mode, DeleteMode::PlainOnly) {
+                        // Caller decides whether to escalate to force; report failure.
+                        let short = e
+                            .to_string()
+                            .lines()
+                            .next()
+                            .unwrap_or("unknown")
+                            .to_string();
+                        let _ = tx
+                            .send(AsyncResult::OpFinished {
+                                op_id,
+                                success: false,
+                                error: Some(short.clone()),
+                            })
+                            .await;
+                        return DeleteOpResult {
+                            op_id,
+                            branch_name,
+                            wt_path,
+                            branch_deleted: false,
+                            worktree_removed: false,
+                            failure: Some(format!("{label}: {short}")),
+                        };
+                    }
+                    // TryThenForce: fall through to force attempt.
+                }
+            }
+        }
+
+        // Force attempt (TryThenForce after plain failure, or ForceOnly always)
+        if !worktree_removed {
+            let cmd = format!("git worktree remove --force {path}");
+            let _ = tx
+                .send(AsyncResult::OpStepBegin {
+                    op_id,
+                    step: OpStep::RunningWtForceRemove,
+                    command: cmd,
+                })
+                .await;
+            match run_git(&["worktree", "remove", "--force", path]).await {
+                Ok(_) => worktree_removed = true,
+                Err(e) => {
+                    let short = e
+                        .to_string()
+                        .lines()
+                        .next()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let _ = tx
+                        .send(AsyncResult::OpFinished {
+                            op_id,
+                            success: false,
+                            error: Some(short.clone()),
+                        })
+                        .await;
+                    return DeleteOpResult {
+                        op_id,
+                        branch_name,
+                        wt_path,
+                        branch_deleted: false,
+                        worktree_removed: false,
+                        failure: Some(format!("{label}: worktree remove failed: {short}")),
+                    };
+                }
+            }
+        }
+    }
+
+    let mut branch_deleted = false;
+    if has_local_branch {
+        if let Some(name) = branch_name.as_ref() {
+            let cmd = format!("git branch -D {name}");
+            let _ = tx
+                .send(AsyncResult::OpStepBegin {
+                    op_id,
+                    step: OpStep::RunningBranchDelete,
+                    command: cmd,
+                })
+                .await;
+            match run_git(&["branch", "-D", name]).await {
+                Ok(_) => branch_deleted = true,
+                Err(e) => {
+                    let short = e
+                        .to_string()
+                        .lines()
+                        .next()
+                        .unwrap_or("unknown")
+                        .to_string();
+                    let _ = tx
+                        .send(AsyncResult::OpFinished {
+                            op_id,
+                            success: false,
+                            error: Some(short.clone()),
+                        })
+                        .await;
+                    return DeleteOpResult {
+                        op_id,
+                        branch_name,
+                        wt_path,
+                        branch_deleted: false,
+                        worktree_removed,
+                        failure: Some(format!("{label}: {short}")),
+                    };
+                }
+            }
+        }
+    }
+
+    let _ = tx
+        .send(AsyncResult::OpFinished {
+            op_id,
+            success: true,
+            error: None,
+        })
+        .await;
+
+    DeleteOpResult {
+        op_id,
+        branch_name,
+        wt_path,
+        branch_deleted,
+        worktree_removed,
+        failure: None,
+    }
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     // Handle --version / -v before anything else

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,8 +22,7 @@ use tokio::sync::mpsc;
 
 use crate::app::App;
 use crate::app::MainFilter;
-#[allow(unused_imports)]
-use crate::app::{OpProgress, OpStep, ProgressTracker};
+use crate::app::{OpProgress, OpStep};
 use crate::data::merge_entries;
 use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git};
@@ -572,6 +571,82 @@ async fn run(
                     app.wt_inflight.remove(&wt_path);
                     app.notification = Some(Notification::error(message));
                 }
+                AsyncResult::OpStarted {
+                    op_id,
+                    label,
+                    wt_path,
+                    branch_name,
+                } => {
+                    app.progress
+                        .insert(op_id, OpProgress::new(label, wt_path, branch_name));
+                }
+                AsyncResult::OpStepBegin {
+                    op_id,
+                    step,
+                    command,
+                } => {
+                    app.progress.update_step(op_id, step, command);
+                }
+                AsyncResult::OpFinished {
+                    op_id,
+                    success,
+                    error,
+                } => {
+                    app.progress.finish(op_id, success, error);
+                    // Optimistic UI: drop the entry from the sidebar early on success.
+                    if success {
+                        if let Some(op) = app.progress.ops.get(&op_id) {
+                            let label = op.label.clone();
+                            app.entries.retain(|e| e.name != label);
+                        }
+                    }
+                }
+                AsyncResult::OpAllDone {
+                    branches_deleted,
+                    worktrees_removed,
+                    failures,
+                    wt_paths_claimed,
+                } => {
+                    for path in &wt_paths_claimed {
+                        app.wt_inflight.remove(path);
+                    }
+                    app.progress.sweep_unfinished();
+                    let success_parts =
+                        bulk_success_parts(branches_deleted.len(), worktrees_removed.len());
+                    if failures.is_empty() {
+                        let msg = if success_parts.is_empty() {
+                            "Nothing to delete".to_string()
+                        } else {
+                            format!("Deleted {}", success_parts.join(", "))
+                        };
+                        app.notification = Some(Notification::success(msg));
+                    } else {
+                        let short: Vec<String> = failures
+                            .iter()
+                            .map(|e| e.lines().next().unwrap_or(e).to_string())
+                            .collect();
+                        let summary = if success_parts.is_empty() {
+                            format!("Bulk delete failed: {}", short.join("; "))
+                        } else {
+                            format!(
+                                "Bulk delete: {}; failed: {}",
+                                success_parts.join(", "),
+                                short.join("; ")
+                            )
+                        };
+                        app.notification = Some(Notification::error(summary));
+                        if app.verbose {
+                            for err in &failures {
+                                if !app.verbose_errors.contains(err) {
+                                    app.verbose_errors.push(err.clone());
+                                }
+                            }
+                        }
+                    }
+                    app.progress.clear();
+                    app.quit_pressed_during_progress = false;
+                    refresh_entries(&mut app).await;
+                }
                 AsyncResult::WtRemoved(path) => {
                     app.wt_inflight.remove(&path);
                     app.notification =
@@ -640,12 +715,6 @@ async fn run(
                     }
                     refresh_entries(&mut app).await;
                 }
-                // New Op* variants have no producers yet (Task 2 of progress-pipeline).
-                // Reducers wired in Task 3.
-                AsyncResult::OpStarted { .. }
-                | AsyncResult::OpStepBegin { .. }
-                | AsyncResult::OpFinished { .. }
-                | AsyncResult::OpAllDone { .. } => {}
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,6 @@ struct RepoInfo {
     hostname: Option<String>, // None for github.com
 }
 
-#[allow(dead_code)]
 enum AsyncResult {
     PrDetail(PrDetail),
     PrDetailError(u64, String),
@@ -71,11 +70,6 @@ enum AsyncResult {
     WtForceDecisionRequested {
         path: String,
         reason: String,
-    },
-    WtForceRemoved(String),
-    WtForceRemoveError {
-        path: String,
-        message: String,
     },
     OpStarted {
         op_id: u64,
@@ -127,7 +121,6 @@ fn bulk_success_parts(branches: usize, worktrees: usize) -> Vec<String> {
     parts
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 enum DeleteMode {
     /// Try plain `worktree remove`; on failure, retry with `--force` (used for bulk).
@@ -138,9 +131,7 @@ enum DeleteMode {
     ForceOnly,
 }
 
-#[allow(dead_code)]
 struct DeleteOpResult {
-    op_id: u64,
     branch_name: Option<String>,
     wt_path: Option<String>,
     branch_deleted: bool,
@@ -214,7 +205,6 @@ async fn run_delete_op(
                             error: Some(short.clone()),
                         });
                         return DeleteOpResult {
-                            op_id,
                             branch_name,
                             wt_path,
                             branch_deleted: false,
@@ -250,7 +240,6 @@ async fn run_delete_op(
                         error: Some(short.clone()),
                     });
                     return DeleteOpResult {
-                        op_id,
                         branch_name,
                         wt_path,
                         branch_deleted: false,
@@ -285,7 +274,6 @@ async fn run_delete_op(
                     error: Some(short.clone()),
                 });
                 return DeleteOpResult {
-                    op_id,
                     branch_name,
                     wt_path,
                     branch_deleted: false,
@@ -303,7 +291,6 @@ async fn run_delete_op(
     });
 
     DeleteOpResult {
-        op_id,
         branch_name,
         wt_path,
         branch_deleted,
@@ -841,17 +828,6 @@ async fn run(
                     ));
                     app.wt_force_delete_pending_path = Some(path);
                 }
-                AsyncResult::WtForceRemoved(path) => {
-                    app.wt_inflight.remove(&path);
-                    app.notification = Some(Notification::success(format!(
-                        "Worktree force removed: {path}"
-                    )));
-                    refresh_entries(&mut app).await;
-                }
-                AsyncResult::WtForceRemoveError { path, message } => {
-                    app.wt_inflight.remove(&path);
-                    app.notification = Some(Notification::error(message));
-                }
             }
         }
 
@@ -906,22 +882,39 @@ async fn run(
             });
         }
 
-        // Force delete worktree if confirmed (async, non-blocking)
+        // Force delete worktree if confirmed (single-item, force only).
         if let Some(path) = app.wt_force_delete_requested.take() {
             app.wt_inflight.insert(path.clone());
-            let tx = tx.clone();
+            let op_id = app.progress.allocate_ids(1).start;
+            let label = wt_label_for(&path);
+            let claimed = vec![path.clone()];
+            let tx_c = tx.clone();
             tokio::spawn(async move {
-                match run_git(&["worktree", "remove", "--force", &path]).await {
-                    Ok(_) => {
-                        let _ = tx.send(AsyncResult::WtForceRemoved(path));
-                    }
-                    Err(e) => {
-                        let _ = tx.send(AsyncResult::WtForceRemoveError {
-                            path,
-                            message: format!("Failed to force remove worktree: {e}"),
-                        });
-                    }
+                let result = run_delete_op(
+                    op_id,
+                    label,
+                    Some(path),
+                    None,
+                    false,
+                    DeleteMode::ForceOnly,
+                    tx_c.clone(),
+                )
+                .await;
+                let mut wts = vec![];
+                let mut failures = vec![];
+                if let Some(f) = result.failure {
+                    failures.push(f);
+                } else if let Some(p) = result.wt_path
+                    && result.worktree_removed
+                {
+                    wts.push(p);
                 }
+                let _ = tx_c.send(AsyncResult::OpAllDone {
+                    branches_deleted: vec![],
+                    worktrees_removed: wts,
+                    failures,
+                    wt_paths_claimed: claimed,
+                });
             });
         }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -63,8 +63,10 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         branch_create_input::draw(frame, input);
     }
 
-    // Notification overlay
-    if let Some(notif) = &app.notification {
+    // Progress panel takes priority over notification while a delete batch runs.
+    if app.progress.is_active() {
+        progress_panel::draw(frame, &app.progress, app.quit_pressed_during_progress);
+    } else if let Some(notif) = &app.notification {
         notification::draw(frame, notif);
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -7,6 +7,7 @@ mod log_view;
 mod main_view;
 pub mod markdown;
 pub mod notification;
+pub mod progress_panel;
 pub mod sidebar;
 
 use ratatui::{

--- a/src/ui/progress_panel.rs
+++ b/src/ui/progress_panel.rs
@@ -1,0 +1,207 @@
+use std::time::Instant;
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+use crate::app::{OpProgress, OpStep, ProgressTracker};
+
+const MAX_VISIBLE_OPS: usize = 7;
+
+pub fn draw(frame: &mut Frame, tracker: &ProgressTracker, quit_warning: bool) {
+    let lines = build_lines(tracker, quit_warning, Instant::now());
+    let height = (lines.len() as u16) + 2; // borders
+    let area = bottom_rect(80, height, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn build_lines(tracker: &ProgressTracker, quit_warning: bool, now: Instant) -> Vec<Line<'static>> {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+
+    if quit_warning {
+        lines.push(Line::from(Span::styled(
+            "Delete in progress. Press q again to quit anyway.".to_string(),
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD),
+        )));
+    }
+
+    let total = tracker.total();
+    let done = tracker.done_count();
+    let elapsed = tracker
+        .started_at
+        .map(|s| now.saturating_duration_since(s).as_secs_f32())
+        .unwrap_or(0.0);
+    lines.push(Line::from(Span::styled(
+        format!("Deleting ({done}/{total} done · {elapsed:.1}s)"),
+        Style::default()
+            .fg(Color::White)
+            .add_modifier(Modifier::BOLD),
+    )));
+
+    let mut ops_iter = tracker.ops.values();
+    for _ in 0..MAX_VISIBLE_OPS.min(total) {
+        if let Some(op) = ops_iter.next() {
+            lines.push(format_op_line(op, now));
+        }
+    }
+    let remaining = total.saturating_sub(MAX_VISIBLE_OPS);
+    if remaining > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("  +{remaining} more"),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    lines
+}
+
+fn format_op_line(op: &OpProgress, now: Instant) -> Line<'static> {
+    let icon = match op.current_step {
+        OpStep::Done { success: true } => "✓",
+        OpStep::Done { success: false } => "✗",
+        _ => "⏳",
+    };
+    let icon_style = match op.current_step {
+        OpStep::Done { success: true } => Style::default().fg(Color::Green),
+        OpStep::Done { success: false } => Style::default().fg(Color::Red),
+        _ => Style::default().fg(Color::Yellow),
+    };
+    let label = format!(" {:<14}", trunc(&op.label, 14));
+    let cmd = op
+        .last_command
+        .clone()
+        .or_else(|| op.error.clone())
+        .unwrap_or_else(|| "starting…".to_string());
+    let elapsed = now
+        .saturating_duration_since(op.op_started_at)
+        .as_secs_f32();
+    let row_style = if matches!(op.current_step, OpStep::Done { success: true }) {
+        Style::default().fg(Color::DarkGray)
+    } else if matches!(op.current_step, OpStep::Done { success: false }) {
+        Style::default().fg(Color::Red)
+    } else {
+        Style::default().fg(Color::White)
+    };
+
+    Line::from(vec![
+        Span::styled(format!("  {icon}"), icon_style),
+        Span::styled(label, row_style),
+        Span::styled(format!(" {cmd}"), row_style),
+        Span::styled(
+            format!("  {elapsed:.1}s"),
+            Style::default().fg(Color::DarkGray),
+        ),
+    ])
+}
+
+fn trunc(s: &str, n: usize) -> String {
+    if s.chars().count() <= n {
+        s.to_string()
+    } else {
+        let mut out: String = s.chars().take(n.saturating_sub(1)).collect();
+        out.push('…');
+        out
+    }
+}
+
+fn bottom_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Min(0), Constraint::Length(height)]).split(area);
+    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
+        .flex(Flex::Center)
+        .split(vertical[1]);
+    horizontal[0]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    fn fixed_now() -> Instant {
+        // Anchor "now" for deterministic elapsed values.
+        Instant::now()
+    }
+
+    #[test]
+    fn build_lines_includes_header_when_active() {
+        let mut t = ProgressTracker::default();
+        let id = t.allocate_ids(1).start;
+        t.insert(
+            id,
+            OpProgress::new("feat-a".into(), Some("/wt/a".into()), Some("feat-a".into())),
+        );
+        let now = fixed_now();
+        let lines = build_lines(&t, false, now);
+        assert!(lines.len() >= 2);
+        let header_text: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(header_text.contains("Deleting"));
+        assert!(header_text.contains("0/1"));
+    }
+
+    #[test]
+    fn build_lines_overflow_shows_more_marker() {
+        let mut t = ProgressTracker::default();
+        let ids: Vec<u64> = t.allocate_ids(MAX_VISIBLE_OPS + 3).collect();
+        for (i, id) in ids.iter().enumerate() {
+            t.insert(*id, OpProgress::new(format!("op{i}"), None, None));
+        }
+        let lines = build_lines(&t, false, fixed_now());
+        let last: String = lines
+            .last()
+            .unwrap()
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect();
+        assert!(
+            last.contains("+3 more"),
+            "expected overflow marker, got: {last}"
+        );
+    }
+
+    #[test]
+    fn build_lines_quit_warning_prepended() {
+        let mut t = ProgressTracker::default();
+        let id = t.allocate_ids(1).start;
+        t.insert(id, OpProgress::new("a".into(), None, None));
+        let lines = build_lines(&t, true, fixed_now());
+        let first: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(first.contains("Delete in progress"));
+        assert!(first.contains("Press q again"));
+    }
+
+    #[test]
+    fn format_op_line_done_success_uses_check_icon() {
+        let mut op = OpProgress::new("a".into(), Some("/wt/a".into()), None);
+        op.current_step = OpStep::Done { success: true };
+        op.last_command = Some("git worktree remove /wt/a".into());
+        let line = format_op_line(&op, Instant::now() + Duration::from_secs(1));
+        let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(txt.contains("✓"));
+        assert!(txt.contains("git worktree remove /wt/a"));
+    }
+
+    #[test]
+    fn format_op_line_done_failure_uses_cross_icon() {
+        let mut op = OpProgress::new("a".into(), Some("/wt/a".into()), None);
+        op.current_step = OpStep::Done { success: false };
+        op.error = Some("perm denied".into());
+        let line = format_op_line(&op, Instant::now());
+        let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(txt.contains("✗"));
+        assert!(txt.contains("perm denied"));
+    }
+}

--- a/src/ui/progress_panel.rs
+++ b/src/ui/progress_panel.rs
@@ -107,6 +107,10 @@ fn format_op_line(op: &OpProgress, now: Instant) -> Line<'static> {
     ])
 }
 
+// Counts unicode scalar values (chars), not display columns. CJK / emoji
+// labels render wider than their char count, so the column may overflow
+// for non-ASCII branch names. Acceptable for current usage; revisit with
+// `unicode-width` if internationalized labels become common.
 fn trunc(s: &str, n: usize) -> String {
     if s.chars().count() <= n {
         s.to_string()
@@ -139,10 +143,7 @@ mod tests {
     fn build_lines_includes_header_when_active() {
         let mut t = ProgressTracker::default();
         let id = t.allocate_ids(1).start;
-        t.insert(
-            id,
-            OpProgress::new("feat-a".into(), Some("/wt/a".into()), Some("feat-a".into())),
-        );
+        t.insert(id, OpProgress::new("feat-a".into()));
         let now = fixed_now();
         let lines = build_lines(&t, false, now);
         assert!(lines.len() >= 2);
@@ -156,7 +157,7 @@ mod tests {
         let mut t = ProgressTracker::default();
         let ids: Vec<u64> = t.allocate_ids(MAX_VISIBLE_OPS + 3).collect();
         for (i, id) in ids.iter().enumerate() {
-            t.insert(*id, OpProgress::new(format!("op{i}"), None, None));
+            t.insert(*id, OpProgress::new(format!("op{i}")));
         }
         let lines = build_lines(&t, false, fixed_now());
         let last: String = lines
@@ -176,7 +177,7 @@ mod tests {
     fn build_lines_quit_warning_prepended() {
         let mut t = ProgressTracker::default();
         let id = t.allocate_ids(1).start;
-        t.insert(id, OpProgress::new("a".into(), None, None));
+        t.insert(id, OpProgress::new("a".into()));
         let lines = build_lines(&t, true, fixed_now());
         let first: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(first.contains("Delete in progress"));
@@ -185,7 +186,7 @@ mod tests {
 
     #[test]
     fn format_op_line_done_success_uses_check_icon() {
-        let mut op = OpProgress::new("a".into(), Some("/wt/a".into()), None);
+        let mut op = OpProgress::new("a".into());
         op.current_step = OpStep::Done { success: true };
         op.last_command = Some("git worktree remove /wt/a".into());
         let line = format_op_line(&op, Instant::now() + Duration::from_secs(1));
@@ -196,7 +197,7 @@ mod tests {
 
     #[test]
     fn format_op_line_done_failure_uses_cross_icon() {
-        let mut op = OpProgress::new("a".into(), Some("/wt/a".into()), None);
+        let mut op = OpProgress::new("a".into());
         op.current_step = OpStep::Done { success: false };
         op.error = Some("perm denied".into());
         let line = format_op_line(&op, Instant::now());

--- a/src/ui/progress_panel.rs
+++ b/src/ui/progress_panel.rs
@@ -31,7 +31,7 @@ fn build_lines(tracker: &ProgressTracker, quit_warning: bool, now: Instant) -> V
 
     if quit_warning {
         lines.push(Line::from(Span::styled(
-            "Delete in progress. Press q again to quit anyway.".to_string(),
+            "Delete in progress. Press q/Esc again to quit anyway.".to_string(),
             Style::default()
                 .fg(Color::Yellow)
                 .add_modifier(Modifier::BOLD),
@@ -181,7 +181,7 @@ mod tests {
         let lines = build_lines(&t, true, fixed_now());
         let first: String = lines[0].spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(first.contains("Delete in progress"));
-        assert!(first.contains("Press q again"));
+        assert!(first.contains("Press q/Esc again"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Worktree deletion is now parallel for bulk operations and surfaces per-item progress (current command + elapsed time) in a new bottom overlay. Bulk wall time drops from Σ(per-item) to ≈ max(per-item), and the user can finally see what's happening on which worktree during the wait.

Closes #190.

## Type of Change

- [x] New feature
- [x] Refactoring

## Changes

- Added `ProgressTracker` data model in `src/app.rs` with per-op state, panic-safe sweep, and clear-on-batch-end semantics.
- Introduced `run_delete_op` async helper in `src/main.rs` as the unified entry point for all worktree deletions (bulk, single plain, single force) via a `DeleteMode { TryThenForce, PlainOnly, ForceOnly }` discriminator. Helper emits `OpStarted` / `OpStepBegin` / `OpFinished` events through an mpsc channel.
- Bulk dispatcher now spawns N concurrent `run_delete_op` tasks into a `tokio::JoinSet`; a separate drainer task awaits all results and emits a single `OpAllDone` summary.
- Single-delete plain and force paths now flow through the same pipeline. The user-mediated "force confirm" UX is preserved via a new `WtForceDecisionRequested` event.
- Added `src/ui/progress_panel.rs` rendering a multi-line bottom overlay with icons (⏳ / ✓ / ✗), command strings, and elapsed times per op, with a `+N more` overflow row past 7 ops.
- `src/ui/mod.rs` swaps the footer overlay between ProgressPanel (when a delete batch is in flight) and Notification (otherwise).
- `q` during an in-flight batch shows a yellow "Press q again to quit anyway." warning; the second press force-quits. Flag resets on `OpAllDone`.
- Removed legacy AsyncResult variants `WtRemoved`, `WtRemoveError`, `WtForceRemoved`, `WtForceRemoveError`, `BulkDeleteDone`. Match exhaustiveness ensured nothing was left orphaned.

## Checklist

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` passes (98 tests: 91 prior + 5 progress_panel + 2 quit handling)
- [x] `cargo build --release` clean

## Test Plan

1. Run `cargo run` inside a repo with multiple worktrees.
2. Bulk delete: select 3+ branches with worktrees, press `d`, confirm. Verify the ProgressPanel shows per-op commands and elapsed time, and that on completion the panel disappears and a summary Notification is shown.
3. Single force delete: with one worktree containing untracked files, trigger single delete from the action menu. Verify the plain `git worktree remove` fails, the existing confirm dialog appears, and on confirm the force delete completes via the new pipeline.
4. Quit-during-progress: during an active bulk delete, press `q` once; verify the yellow `Press q again to quit anyway.` line appears in the panel header. Press a non-`q` key (e.g. `j`); verify the warning persists. Pressing `q` twice in rapid succession during progress force-quits gct.

## Known follow-ups

- Mid-batch notifications (e.g. PR-fetch errors) are silently overwritten by the `OpAllDone` summary. Out of scope here; tracked for a future pending-notification queue.
- `bottom_rect` helper is duplicated between `notification.rs` and `progress_panel.rs` — small dedup opportunity.
- Single-delete success notification wording changed from "Worktree removed: <path>" to "Deleted 1 worktree" as a side effect of the unified pipeline.