### PR TITLE
feat: cross-repo PR aggregation in My PR / Review modes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +183,17 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -183,6 +215,7 @@ dependencies = [
  "ratatui",
  "serde",
  "serde_json",
+ "shellexpand",
  "tempfile",
  "tokio",
  "toml",
@@ -285,6 +318,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +385,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
@@ -441,6 +489,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror",
 ]
 
 [[package]]
@@ -546,6 +605,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -644,10 +712,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 base64 = "0.22.1"
+shellexpand = "3"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,27 @@ gct reads configuration from the first file found in this order:
 
 Project-local config is useful for per-repo worktree hooks (e.g. copying `.env`, running `npm ci`).
 
+### Cross-repo Reviews
+
+`My PR` (`2`) and `Review` (`3`) modes show pull requests across **all** of your GitHub repositories, not just the one you launched gct from. When the result spans multiple repos, the sidebar groups branches under repo headers; otherwise it stays flat as before.
+
+For cross-repo PRs, `Create Worktree` and `cd into Worktree` operate on the local clone of that repo. gct discovers the clone path one of two ways:
+
+1. **Auto-inferred from your active repo's path.** If you launched gct from `~/workspace/github.com/owner/name`, gct strips the `<host>/<owner>/<name>` suffix and treats `~/workspace` as the clone root. ghq users get this for free.
+
+2. **Configured explicitly** when auto-inference fails. Add to `.gct.toml` or `~/.config/gct/config.toml`:
+
+   ```toml
+   [workspace]
+   clone_root = "~/workspace"
+   ```
+
+   gct then expects clones at `<clone_root>/<host>/<owner>/<name>`.
+
+If neither path resolves, cross-repo entries remain visible but `Create Worktree` is greyed out with a one-line hint pointing at the expected clone location.
+
+**Limitations (v1):** Only github.com is searched (PRs on GitHub Enterprise hosts are not aggregated). Bulk delete (`d` after Space-selection) still operates on active-repo branches only.
+
 ### Worktree Settings
 
 ```toml

--- a/scripts/demo/gh-stub
+++ b/scripts/demo/gh-stub
@@ -43,6 +43,60 @@ case "${1:-}" in
       fi
     elif [[ "$query" == *"repository("* ]]; then
       cat "$GH_DIR/local-prs-${DEMO_SCENE}.json"
+    elif [[ "$query" == *"search(query:"*"review-requested:@me"* ]]; then
+      # Cross-repo review-requested PRs — return multi-repo fixture
+      cat <<'JSON'
+{
+  "data": {
+    "search": {
+      "nodes": [
+        {
+          "number": 45,
+          "title": "Add OAuth login flow",
+          "state": "OPEN",
+          "headRefName": "feature/oauth",
+          "updatedAt": "2026-05-06T10:00:00Z",
+          "isDraft": false,
+          "author": {"login": "alice"},
+          "repository": {"name": "git-control-tower", "url": "https://github.com/katzkb/git-control-tower", "owner": {"login": "katzkb"}},
+          "reviewRequests": {"nodes": []},
+          "latestReviews": {"nodes": []}
+        },
+        {
+          "number": 12,
+          "title": "Fix login bug",
+          "state": "OPEN",
+          "headRefName": "fix/login-bug",
+          "updatedAt": "2026-05-05T09:00:00Z",
+          "isDraft": false,
+          "author": {"login": "bob"},
+          "repository": {"name": "web", "url": "https://github.com/org-x/web", "owner": {"login": "org-x"}},
+          "reviewRequests": {"nodes": []},
+          "latestReviews": {"nodes": [{"author": {"login": "katzkb"}, "state": "APPROVED"}]}
+        },
+        {
+          "number": 5,
+          "title": "Improve zsh prompt",
+          "state": "OPEN",
+          "headRefName": "feature/zsh-fix",
+          "updatedAt": "2026-05-04T08:00:00Z",
+          "isDraft": false,
+          "author": {"login": "charlie"},
+          "repository": {"name": "dotfiles", "url": "https://github.com/katzkb/dotfiles", "owner": {"login": "katzkb"}},
+          "reviewRequests": {"nodes": [{"requestedReviewer": {"login": "katzkb"}}]},
+          "latestReviews": {"nodes": []}
+        }
+      ]
+    }
+  }
+}
+JSON
+    elif [[ "$query" == *"search(query:"*"reviewed-by:@me"* ]]; then
+      echo '{"data":{"search":{"nodes":[]}}}'
+    elif [[ "$query" == *"search(query:"*"team-review-requested:@me"* ]]; then
+      echo '{"data":{"search":{"nodes":[]}}}'
+    elif [[ "$query" == *"search(query:"*"author:@me"* ]]; then
+      echo '{"data":{"search":{"nodes":[]}}}'
     else
       echo "gh-stub: unsupported graphql query" >&2
       exit 1

--- a/src/app.rs
+++ b/src/app.rs
@@ -33,6 +33,11 @@ impl MainFilter {
     }
 }
 
+pub enum SidebarRow<'a> {
+    Header { repo_id: crate::git::types::RepoId },
+    Entry(&'a crate::git::types::BranchEntry),
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ActionItem {
     CreateWorktree,
@@ -431,6 +436,39 @@ impl App {
                 passes_filter && passes_search
             })
             .collect()
+    }
+
+    /// Build the sidebar rendering rows. Returns a flat list of headers and
+    /// entries; cross-repo grouping kicks in only for My PR / Review when
+    /// `entries` span more than one repo.
+    pub fn sidebar_rows(&self) -> Vec<SidebarRow<'_>> {
+        let filtered = self.filtered_entries();
+        let group_active = matches!(
+            self.main_filter,
+            MainFilter::MyPr | MainFilter::ReviewRequested
+        );
+        let repo_set: std::collections::HashSet<_> =
+            filtered.iter().map(|e| e.repo_id.clone()).collect();
+        let do_group = group_active && repo_set.len() > 1;
+
+        let mut rows = Vec::with_capacity(filtered.len() + repo_set.len());
+        if !do_group {
+            for e in filtered {
+                rows.push(SidebarRow::Entry(e));
+            }
+            return rows;
+        }
+        let mut last_repo: Option<crate::git::types::RepoId> = None;
+        for e in filtered {
+            if last_repo.as_ref() != Some(&e.repo_id) {
+                rows.push(SidebarRow::Header {
+                    repo_id: e.repo_id.clone(),
+                });
+                last_repo = Some(e.repo_id.clone());
+            }
+            rows.push(SidebarRow::Entry(e));
+        }
+        rows
     }
 
     pub fn selected_entry(&self) -> Option<&BranchEntry> {
@@ -1425,6 +1463,164 @@ mod resolve_local_path_tests {
         let meta = app.repos.get(&id).unwrap();
         assert!(meta.local_path_resolved);
         assert!(meta.local_path.is_none());
+    }
+}
+
+#[cfg(test)]
+mod sidebar_rows_tests {
+    use super::*;
+
+    #[test]
+    fn render_rows_groups_when_multi_repo() {
+        use crate::app::SidebarRow;
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, PullRequest, RepoId};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "r1".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "b".into(),
+            name: "r2".into(),
+        };
+        app.active_repo = Some(active.clone());
+        app.main_filter = MainFilter::ReviewRequested;
+        let make_pr = |num: u64, head: &str, repo: &RepoId| PullRequest {
+            number: num,
+            title: "x".into(),
+            author: "u".into(),
+            state: "OPEN".into(),
+            head_ref: head.into(),
+            updated_at: "2024".into(),
+            is_draft: false,
+            review_requests: vec![],
+            latest_reviews: vec![],
+            review_status: None,
+            repo_id: repo.clone(),
+        };
+        app.entries = vec![
+            BranchEntry {
+                name: "f1".into(),
+                repo_id: active.clone(),
+                local_branch: None,
+                worktree: None,
+                pull_request: Some(make_pr(1, "f1", &active)),
+                git_status: None,
+            },
+            BranchEntry {
+                name: "f2".into(),
+                repo_id: other.clone(),
+                local_branch: None,
+                worktree: None,
+                pull_request: Some(make_pr(2, "f2", &other)),
+                git_status: None,
+            },
+        ];
+        let rows = app.sidebar_rows();
+        let header_count = rows
+            .iter()
+            .filter(|r| matches!(r, SidebarRow::Header { .. }))
+            .count();
+        let entry_count = rows
+            .iter()
+            .filter(|r| matches!(r, SidebarRow::Entry(_)))
+            .count();
+        assert_eq!(header_count, 2);
+        assert_eq!(entry_count, 2);
+    }
+
+    #[test]
+    fn render_rows_no_headers_when_single_repo() {
+        use crate::app::SidebarRow;
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, PullRequest, RepoId};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "r1".into(),
+        };
+        app.active_repo = Some(active.clone());
+        app.main_filter = MainFilter::ReviewRequested;
+        let make_pr = |num: u64, head: &str| PullRequest {
+            number: num,
+            title: "x".into(),
+            author: "u".into(),
+            state: "OPEN".into(),
+            head_ref: head.into(),
+            updated_at: "2024".into(),
+            is_draft: false,
+            review_requests: vec![],
+            latest_reviews: vec![],
+            review_status: None,
+            repo_id: active.clone(),
+        };
+        app.entries = vec![
+            BranchEntry {
+                name: "f1".into(),
+                repo_id: active.clone(),
+                local_branch: None,
+                worktree: None,
+                pull_request: Some(make_pr(1, "f1")),
+                git_status: None,
+            },
+            BranchEntry {
+                name: "f2".into(),
+                repo_id: active.clone(),
+                local_branch: None,
+                worktree: None,
+                pull_request: Some(make_pr(2, "f2")),
+                git_status: None,
+            },
+        ];
+        let rows = app.sidebar_rows();
+        assert_eq!(
+            rows.iter()
+                .filter(|r| matches!(r, SidebarRow::Header { .. }))
+                .count(),
+            0
+        );
+        assert_eq!(rows.len(), 2);
+    }
+
+    #[test]
+    fn render_rows_local_filter_never_groups() {
+        use crate::app::SidebarRow;
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, RepoId};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "r1".into(),
+        };
+        app.active_repo = Some(active.clone());
+        app.main_filter = MainFilter::Local;
+        // Local mode: filtered_entries requires has_local. Give entries a local branch.
+        let make_branch = |name: &str| crate::git::types::Branch {
+            name: name.into(),
+            is_current: false,
+            upstream: None,
+            is_merged: false,
+        };
+        app.entries = vec![BranchEntry {
+            name: "f1".into(),
+            repo_id: active.clone(),
+            local_branch: Some(make_branch("f1")),
+            worktree: None,
+            pull_request: None,
+            git_status: None,
+        }];
+        let rows = app.sidebar_rows();
+        assert_eq!(
+            rows.iter()
+                .filter(|r| matches!(r, SidebarRow::Header { .. }))
+                .count(),
+            0
+        );
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -755,6 +755,7 @@ impl App {
                 if let Some(entry) = self.selected_entry().cloned()
                     && !entry.is_current()
                     && !self.is_protected_branch(&entry.name)
+                    && self.active_repo.as_ref() == Some(&entry.repo_id)
                 {
                     if self.branch_selected.contains(&entry.name) {
                         self.branch_selected.remove(&entry.name);

--- a/src/app.rs
+++ b/src/app.rs
@@ -1056,7 +1056,7 @@ impl App {
         }
     }
 
-    fn execute_action(&mut self, action: ActionItem, target_name: &str) {
+    pub(crate) fn execute_action(&mut self, action: ActionItem, target_name: &str) {
         let entry = match self.entries.iter().find(|e| e.name == target_name).cloned() {
             Some(e) => e,
             None => return,
@@ -1978,5 +1978,41 @@ mod action_menu_cross_repo_tests {
         let menu = app.action_menu.as_ref().unwrap();
         assert!(menu.items.contains(&ActionItem::CreateWorktree));
         assert!(menu.footer.is_none());
+    }
+
+    #[test]
+    fn cd_into_worktree_cross_repo_uses_absolute_path() {
+        use crate::app::ActionItem;
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, RepoId, Worktree};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "x".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "b".into(),
+            name: "y".into(),
+        };
+        app.active_repo = Some(active);
+        app.entries = vec![BranchEntry {
+            name: "feat".into(),
+            repo_id: other.clone(),
+            local_branch: None,
+            worktree: Some(Worktree {
+                path: "/tmp/clones/b/feat".into(),
+                head: "abc".into(),
+                branch: Some("feat".into()),
+                is_bare: false,
+            }),
+            pull_request: None,
+            git_status: None,
+        }];
+        app.snap_scroll_to_entry();
+        app.execute_action(ActionItem::CdIntoWorktree, "feat");
+        assert_eq!(app.cd_path.as_deref(), Some("/tmp/clones/b/feat"));
+        assert!(app.should_quit);
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -67,6 +67,7 @@ pub struct ActionMenu {
     pub items: Vec<ActionItem>,
     pub scroll: usize,
     pub target_name: String, // branch name captured when menu was opened
+    pub footer: Option<String>,
 }
 
 pub struct BranchCreateInput {
@@ -942,38 +943,83 @@ impl App {
             Some(e) => e,
             None => return,
         };
+        let is_active_repo = self.active_repo.as_ref() == Some(&entry.repo_id);
+        let clone_path: Option<std::path::PathBuf> = if is_active_repo {
+            None // active repo runs in CWD, no clone path needed
+        } else {
+            // cross-repo: resolve once, then read
+            self.resolve_local_path(&entry.repo_id);
+            self.repos
+                .get(&entry.repo_id)
+                .and_then(|m| m.local_path.clone())
+        };
+        let cross_repo_no_clone = !is_active_repo && clone_path.is_none();
+
         let mut items = Vec::new();
+        let mut footer = None;
 
         if entry.pull_request.is_some() {
             items.push(ActionItem::OpenPrInBrowser);
         }
         items.push(ActionItem::CopyBranchName);
-        if entry.worktree.is_some() {
+
+        let wt_already_exists = entry.worktree.is_some();
+        let wt_path_for_inflight = if is_active_repo {
+            self.config.worktree_path(&entry.name)
+        } else if let Some(ref root) = clone_path {
+            // Interim inline path-building logic until Task 13 introduces worktree_path_for.
+            let dir = self.config.worktree.dir.trim();
+            let base_dir = if dir.is_empty() { ".." } else { dir };
+            root.join(base_dir)
+                .join(&entry.name)
+                .to_string_lossy()
+                .to_string()
+        } else {
+            String::new()
+        };
+
+        if wt_already_exists {
             items.push(ActionItem::CdIntoWorktree);
         }
-        if entry.worktree.is_none()
+
+        let can_create_wt = !wt_already_exists
             && !entry.is_current()
             && (entry.local_branch.is_some() || entry.pull_request.is_some())
-            && !self
-                .wt_inflight
-                .contains(&self.config.worktree_path(&entry.name))
-        {
+            && !cross_repo_no_clone
+            && !self.wt_inflight.contains(&wt_path_for_inflight);
+        if can_create_wt {
             items.push(ActionItem::CreateWorktree);
         }
-        if let Some(wt_path) = entry.worktree_path()
+
+        // DeleteWorktree is active-repo only (cross-repo wt management is OUT for v1).
+        if is_active_repo
+            && let Some(wt_path) = entry.worktree_path()
             && !entry.is_current()
             && !self.wt_inflight.contains(wt_path)
         {
             items.push(ActionItem::DeleteWorktree);
         }
-        if entry.local_branch.is_some() {
+        if is_active_repo && entry.local_branch.is_some() {
             items.push(ActionItem::CreateBranch);
         }
-        if entry.local_branch.is_some()
+        if is_active_repo
+            && entry.local_branch.is_some()
             && !entry.is_current()
             && !self.is_protected_branch(&entry.name)
         {
             items.push(ActionItem::DeleteBranch);
+        }
+
+        if cross_repo_no_clone {
+            let hint_root = self
+                .clone_root
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "[workspace] clone_root".to_string());
+            footer = Some(format!(
+                "{} not cloned. Clone under {hint_root}.",
+                entry.repo_id
+            ));
         }
 
         if !items.is_empty() {
@@ -981,6 +1027,7 @@ impl App {
                 items,
                 scroll: 0,
                 target_name: entry.name.clone(),
+                footer,
             });
         }
     }
@@ -1814,5 +1861,123 @@ mod bulk_delete_message_tests {
             compose_bulk_delete_message(1, 1, 0, "a"),
             "Delete 1 branch + 1 worktree?\n[a]"
         );
+    }
+}
+
+#[cfg(test)]
+mod action_menu_cross_repo_tests {
+    use super::*;
+
+    #[test]
+    fn action_menu_cross_repo_no_clone_excludes_worktree_actions() {
+        use crate::app::ActionItem;
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, PullRequest, RepoId, RepoMeta};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "x".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "b".into(),
+            name: "y".into(),
+        };
+        app.active_repo = Some(active.clone());
+        app.repos.insert(
+            other.clone(),
+            RepoMeta {
+                id: other.clone(),
+                local_path: None,
+                local_path_resolved: true,
+            },
+        );
+        app.main_filter = MainFilter::ReviewRequested;
+        app.entries = vec![BranchEntry {
+            name: "feat".into(),
+            repo_id: other.clone(),
+            local_branch: None,
+            worktree: None,
+            pull_request: Some(PullRequest {
+                number: 1,
+                title: "x".into(),
+                author: "u".into(),
+                state: "OPEN".into(),
+                head_ref: "feat".into(),
+                updated_at: "2024".into(),
+                is_draft: false,
+                review_requests: vec![],
+                latest_reviews: vec![],
+                review_status: None,
+                repo_id: other.clone(),
+            }),
+            git_status: None,
+        }];
+        app.snap_scroll_to_entry();
+        app.open_action_menu();
+        let menu = app.action_menu.as_ref().unwrap();
+        assert!(menu.items.contains(&ActionItem::OpenPrInBrowser));
+        assert!(menu.items.contains(&ActionItem::CopyBranchName));
+        assert!(!menu.items.contains(&ActionItem::CreateWorktree));
+        assert!(!menu.items.contains(&ActionItem::DeleteBranch));
+        assert!(menu.footer.is_some());
+        assert!(menu.footer.as_ref().unwrap().contains("not cloned"));
+    }
+
+    #[test]
+    fn action_menu_cross_repo_with_clone_enables_worktree_create() {
+        use crate::app::ActionItem;
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, PullRequest, RepoId, RepoMeta};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "x".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "b".into(),
+            name: "y".into(),
+        };
+        let tmp = tempfile::tempdir().unwrap();
+        let clone_path = tmp.path().join("github.com").join("b").join("y");
+        std::fs::create_dir_all(&clone_path).unwrap();
+        app.active_repo = Some(active.clone());
+        app.repos.insert(
+            other.clone(),
+            RepoMeta {
+                id: other.clone(),
+                local_path: Some(clone_path),
+                local_path_resolved: true,
+            },
+        );
+        app.main_filter = MainFilter::ReviewRequested;
+        app.entries = vec![BranchEntry {
+            name: "feat".into(),
+            repo_id: other.clone(),
+            local_branch: None,
+            worktree: None,
+            pull_request: Some(PullRequest {
+                number: 1,
+                title: "x".into(),
+                author: "u".into(),
+                state: "OPEN".into(),
+                head_ref: "feat".into(),
+                updated_at: "2024".into(),
+                is_draft: false,
+                review_requests: vec![],
+                latest_reviews: vec![],
+                review_status: None,
+                repo_id: other.clone(),
+            }),
+            git_status: None,
+        }];
+        app.snap_scroll_to_entry();
+        app.open_action_menu();
+        let menu = app.action_menu.as_ref().unwrap();
+        assert!(menu.items.contains(&ActionItem::CreateWorktree));
+        assert!(menu.footer.is_none());
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -271,7 +271,6 @@ pub struct App {
     pub repos: std::collections::HashMap<crate::git::types::RepoId, crate::git::types::RepoMeta>,
 
     // Worktree lists per repo (populated lazily as cross-repo PRs are selected)
-    #[allow(dead_code)]
     pub wt_lists_per_repo:
         std::collections::HashMap<crate::git::types::RepoId, Vec<crate::git::types::Worktree>>,
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -685,6 +685,9 @@ impl App {
                     // one — stale detail bodies are risky after a refresh, and the
                     // detail pane will refetch on the next selection.
                     self.pr_detail_cache.clear();
+                    // Invalidate cross-repo worktree list caches so they re-fetch.
+                    self.wt_lists_per_repo.clear();
+                    self.wt_list_inflight.clear();
                     // Signal branches/worktrees reload + PR fetch
                     self.branches_reload_requested = true;
                     self.pr_fetch_requested = Some(self.main_filter);

--- a/src/app.rs
+++ b/src/app.rs
@@ -771,6 +771,7 @@ impl App {
                         (e.is_merged() || e.pr_is_merged())
                             && !e.is_current()
                             && !self.is_protected_branch(&e.name)
+                            && self.active_repo.as_ref() == Some(&e.repo_id)
                     })
                     .map(|e| e.name.clone())
                     .collect();

--- a/src/app.rs
+++ b/src/app.rs
@@ -832,18 +832,44 @@ impl App {
                 }
             }
             KeyCode::Char('w') => {
-                if let Some(entry) = self.selected_entry()
-                    && entry.worktree.is_none()
-                    && !entry.is_current()
-                    && (entry.local_branch.is_some() || entry.pull_request.is_some())
-                    && !self
-                        .wt_inflight
-                        .contains(&self.config.worktree_path(&entry.name))
+                let Some(entry) = self.selected_entry().cloned() else {
+                    return;
+                };
+                if entry.worktree.is_some()
+                    || entry.is_current()
+                    || (entry.local_branch.is_none() && entry.pull_request.is_none())
                 {
-                    self.wt_create_requested = Some(entry.name.clone());
-                    self.notification =
-                        Some(Notification::success("Creating worktree...".to_string()));
+                    return;
                 }
+                let is_active = self.active_repo.as_ref() == Some(&entry.repo_id);
+                let clone_path: Option<std::path::PathBuf> = if is_active {
+                    None
+                } else {
+                    self.resolve_local_path(&entry.repo_id);
+                    self.repos
+                        .get(&entry.repo_id)
+                        .and_then(|m| m.local_path.clone())
+                };
+                let cross_repo_no_clone = !is_active && clone_path.is_none();
+                if cross_repo_no_clone {
+                    self.notification = Some(Notification::error(format!(
+                        "{} not cloned. Set [workspace] clone_root.",
+                        entry.repo_id
+                    )));
+                    return;
+                }
+                let wt_path = if is_active {
+                    self.config.worktree_path(&entry.name)
+                } else {
+                    // unwrap is safe: cross_repo_no_clone is false above
+                    self.config
+                        .worktree_path_for(clone_path.as_ref().unwrap(), &entry.name)
+                };
+                if self.wt_inflight.contains(&wt_path) {
+                    return;
+                }
+                self.wt_create_requested = Some(entry.name.clone());
+                self.notification = Some(Notification::success("Creating worktree...".to_string()));
             }
             KeyCode::Enter => {
                 self.open_action_menu();

--- a/src/app.rs
+++ b/src/app.rs
@@ -510,6 +510,32 @@ impl App {
         }
     }
 
+    /// Find the next entry-row index after `from`, skipping headers. None if no entry follows.
+    fn next_entry_index(&self, from: usize) -> Option<usize> {
+        let rows = self.sidebar_rows();
+        let mut next = from + 1;
+        while next < rows.len() && matches!(rows[next], SidebarRow::Header { .. }) {
+            next += 1;
+        }
+        if next < rows.len() { Some(next) } else { None }
+    }
+
+    /// Find the previous entry-row index before `from`, skipping headers. None if no entry precedes.
+    fn prev_entry_index(&self, from: usize) -> Option<usize> {
+        if from == 0 {
+            return None;
+        }
+        let rows = self.sidebar_rows();
+        let mut prev = from - 1;
+        while matches!(rows.get(prev), Some(SidebarRow::Header { .. })) {
+            if prev == 0 {
+                return None;
+            }
+            prev -= 1;
+        }
+        Some(prev)
+    }
+
     /// Return the cached PR detail for the currently selected entry, if available.
     pub fn selected_pr_detail(&self) -> Option<&PrDetail> {
         let entry = self.selected_entry()?;
@@ -714,24 +740,13 @@ impl App {
     fn handle_main_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
-                let rows = self.sidebar_rows();
-                let mut next = self.sidebar_scroll + 1;
-                while next < rows.len() && matches!(rows[next], SidebarRow::Header { .. }) {
-                    next += 1;
-                }
-                if next < rows.len() {
+                if let Some(next) = self.next_entry_index(self.sidebar_scroll) {
                     self.sidebar_scroll = next;
                     self.request_details_for_selection();
                 }
             }
             KeyCode::Char('k') | KeyCode::Up if self.sidebar_scroll > 0 => {
-                let rows = self.sidebar_rows();
-                let mut prev = self.sidebar_scroll.saturating_sub(1);
-                while prev > 0 && matches!(rows[prev], SidebarRow::Header { .. }) {
-                    prev -= 1;
-                }
-                // If we landed on a Header at index 0, no Entry exists above; stay put.
-                if !matches!(rows.get(prev), Some(SidebarRow::Header { .. })) {
+                if let Some(prev) = self.prev_entry_index(self.sidebar_scroll) {
                     self.sidebar_scroll = prev;
                     self.request_details_for_selection();
                 }
@@ -967,23 +982,13 @@ impl App {
                 self.request_details_for_selection();
             }
             KeyCode::Down => {
-                let rows = self.sidebar_rows();
-                let mut next = self.sidebar_scroll + 1;
-                while next < rows.len() && matches!(rows[next], SidebarRow::Header { .. }) {
-                    next += 1;
-                }
-                if next < rows.len() {
+                if let Some(next) = self.next_entry_index(self.sidebar_scroll) {
                     self.sidebar_scroll = next;
                     self.request_details_for_selection();
                 }
             }
             KeyCode::Up if self.sidebar_scroll > 0 => {
-                let rows = self.sidebar_rows();
-                let mut prev = self.sidebar_scroll.saturating_sub(1);
-                while prev > 0 && matches!(rows[prev], SidebarRow::Header { .. }) {
-                    prev -= 1;
-                }
-                if !matches!(rows.get(prev), Some(SidebarRow::Header { .. })) {
+                if let Some(prev) = self.prev_entry_index(self.sidebar_scroll) {
                     self.sidebar_scroll = prev;
                     self.request_details_for_selection();
                 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -66,7 +66,9 @@ impl ActionItem {
 pub struct ActionMenu {
     pub items: Vec<ActionItem>,
     pub scroll: usize,
-    pub target_name: String, // branch name captured when menu was opened
+    /// `(repo_id, branch_name)` captured when the menu was opened. Carrying
+    /// both fields prevents wrong-repo lookup when two repos share a branch name.
+    pub target: (crate::git::types::RepoId, String),
     pub footer: Option<String>,
 }
 
@@ -241,7 +243,9 @@ pub struct App {
     pub wt_force_delete_requested: Option<String>,
     pub wt_force_delete_pending_path: Option<String>,
     pub wt_cd_pending_path: Option<String>,
-    pub wt_create_requested: Option<String>,
+    /// `(repo_id, branch_name)` for the worktree to create. Carries `RepoId` so
+    /// the main-loop lookup matches the correct repo when branch names collide.
+    pub wt_create_requested: Option<(crate::git::types::RepoId, String)>,
     /// Worktree paths with an in-flight create/delete, gated per-path so unrelated
     /// worktrees stay actionable in the UI while one is still running.
     pub wt_inflight: HashSet<String>,
@@ -866,7 +870,7 @@ impl App {
                 if self.wt_inflight.contains(&wt_path) {
                     return;
                 }
-                self.wt_create_requested = Some(entry.name.clone());
+                self.wt_create_requested = Some((entry.repo_id.clone(), entry.name.clone()));
                 self.notification = Some(Notification::success("Creating worktree...".to_string()));
             }
             KeyCode::Enter => {
@@ -1070,7 +1074,7 @@ impl App {
             self.action_menu = Some(ActionMenu {
                 items,
                 scroll: 0,
-                target_name: entry.name.clone(),
+                target: (entry.repo_id.clone(), entry.name.clone()),
                 footer,
             });
         }
@@ -1090,9 +1094,9 @@ impl App {
             }
             KeyCode::Enter => {
                 let action = menu.items[menu.scroll];
-                let target = menu.target_name.clone();
+                let (repo_id, branch_name) = menu.target.clone();
                 self.action_menu = None;
-                self.execute_action(action, &target);
+                self.execute_action(action, &repo_id, &branch_name);
             }
             KeyCode::Esc => {
                 self.action_menu = None;
@@ -1101,14 +1105,24 @@ impl App {
         }
     }
 
-    pub(crate) fn execute_action(&mut self, action: ActionItem, target_name: &str) {
-        let entry = match self.entries.iter().find(|e| e.name == target_name).cloned() {
+    pub(crate) fn execute_action(
+        &mut self,
+        action: ActionItem,
+        repo_id: &crate::git::types::RepoId,
+        name: &str,
+    ) {
+        let entry = match self
+            .entries
+            .iter()
+            .find(|e| e.repo_id == *repo_id && e.name == name)
+            .cloned()
+        {
             Some(e) => e,
             None => return,
         };
         match action {
             ActionItem::CreateWorktree => {
-                self.wt_create_requested = Some(entry.name.clone());
+                self.wt_create_requested = Some((entry.repo_id.clone(), entry.name.clone()));
                 self.notification = Some(Notification::success("Creating worktree...".to_string()));
             }
             ActionItem::CdIntoWorktree => {
@@ -2055,9 +2069,76 @@ mod action_menu_cross_repo_tests {
             git_status: None,
         }];
         app.snap_scroll_to_entry();
-        app.execute_action(ActionItem::CdIntoWorktree, "feat");
+        app.execute_action(ActionItem::CdIntoWorktree, &other, "feat");
         assert_eq!(app.cd_path.as_deref(), Some("/tmp/clones/b/feat"));
         assert!(app.should_quit);
+    }
+
+    #[test]
+    fn execute_action_targets_correct_repo_when_branch_names_collide() {
+        use crate::app::ActionItem;
+        use crate::config::Config;
+        use crate::git::types::{Branch, BranchEntry, PullRequest, RepoId, Worktree};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "active".into(),
+            name: "x".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "other".into(),
+            name: "y".into(),
+        };
+        app.active_repo = Some(active.clone());
+
+        // Active repo has a local branch called feature/auth
+        let active_entry = BranchEntry {
+            name: "feature/auth".into(),
+            repo_id: active.clone(),
+            local_branch: Some(Branch {
+                name: "feature/auth".into(),
+                is_current: false,
+                upstream: None,
+                is_merged: false,
+            }),
+            worktree: None,
+            pull_request: None,
+            git_status: None,
+        };
+        // Cross-repo also has a PR on feature/auth, with a known worktree
+        let cross_entry = BranchEntry {
+            name: "feature/auth".into(),
+            repo_id: other.clone(),
+            local_branch: None,
+            worktree: Some(Worktree {
+                path: "/cross/repo/feature/auth".into(),
+                head: "abc".into(),
+                branch: Some("feature/auth".into()),
+                is_bare: false,
+            }),
+            pull_request: Some(PullRequest {
+                number: 7,
+                title: "x".into(),
+                author: "u".into(),
+                state: "OPEN".into(),
+                head_ref: "feature/auth".into(),
+                updated_at: "2024".into(),
+                is_draft: false,
+                review_requests: vec![],
+                latest_reviews: vec![],
+                review_status: None,
+                repo_id: other.clone(),
+            }),
+            git_status: None,
+        };
+        // Active repo first per merge_entries sort
+        app.entries = vec![active_entry, cross_entry];
+
+        // Dispatch CdIntoWorktree targeting cross-repo branch.
+        // The tuple-based execute_action must NOT pick the active-repo entry.
+        app.execute_action(ActionItem::CdIntoWorktree, &other, "feature/auth");
+        assert_eq!(app.cd_path.as_deref(), Some("/cross/repo/feature/auth"));
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -546,9 +546,9 @@ impl App {
     /// Signal that the selection changed; request PR detail and git status as needed.
     pub fn request_details_for_selection(&mut self) {
         self.pr_detail_scroll = 0;
-
         let selected = self.selected_entry().cloned();
-        if let Some(entry) = selected {
+
+        if let Some(entry) = &selected {
             // Request PR detail if entry has a PR and it's not cached
             if let Some(pr_num) = entry.pr_number()
                 && !self
@@ -566,9 +566,8 @@ impl App {
             }
         }
 
-        // Signal lazy load of cross-repo worktree list if not yet fetched
-        let selected_for_wt = self.selected_entry().cloned();
-        if let Some(entry) = selected_for_wt
+        // Signal lazy load of cross-repo worktree list if not yet fetched (use the same `selected` binding)
+        if let Some(entry) = &selected
             && self.active_repo.as_ref() != Some(&entry.repo_id)
             && !self.wt_lists_per_repo.contains_key(&entry.repo_id)
             && !self.wt_list_inflight.contains(&entry.repo_id)

--- a/src/app.rs
+++ b/src/app.rs
@@ -993,13 +993,7 @@ impl App {
         let wt_path_for_inflight = if is_active_repo {
             self.config.worktree_path(&entry.name)
         } else if let Some(ref root) = clone_path {
-            // Interim inline path-building logic until Task 13 introduces worktree_path_for.
-            let dir = self.config.worktree.dir.trim();
-            let base_dir = if dir.is_empty() { ".." } else { dir };
-            root.join(base_dir)
-                .join(&entry.name)
-                .to_string_lossy()
-                .to_string()
+            self.config.worktree_path_for(root, &entry.name)
         } else {
             String::new()
         };

--- a/src/app.rs
+++ b/src/app.rs
@@ -1601,7 +1601,6 @@ mod resolve_local_path_tests {
         app.repos.insert(
             id.clone(),
             crate::git::types::RepoMeta {
-                id: id.clone(),
                 local_path: None,
                 local_path_resolved: false,
             },
@@ -1627,7 +1626,6 @@ mod resolve_local_path_tests {
         app.repos.insert(
             id.clone(),
             crate::git::types::RepoMeta {
-                id: id.clone(),
                 local_path: None,
                 local_path_resolved: false,
             },
@@ -1955,7 +1953,6 @@ mod action_menu_cross_repo_tests {
         app.repos.insert(
             other.clone(),
             RepoMeta {
-                id: other.clone(),
                 local_path: None,
                 local_path_resolved: true,
             },
@@ -2015,7 +2012,6 @@ mod action_menu_cross_repo_tests {
         app.repos.insert(
             other.clone(),
             RepoMeta {
-                id: other.clone(),
                 local_path: Some(clone_path),
                 local_path_resolved: true,
             },
@@ -2180,7 +2176,6 @@ mod wt_list_lazy_load_tests {
         app.repos.insert(
             other.clone(),
             RepoMeta {
-                id: other.clone(),
                 local_path: None,
                 local_path_resolved: false,
             },

--- a/src/app.rs
+++ b/src/app.rs
@@ -385,7 +385,6 @@ impl App {
         // Clamp scroll to valid range
         if item_count > 0 {
             self.sidebar_scroll = self.sidebar_scroll.min(item_count - 1);
-            self.snap_scroll_to_entry();
         } else {
             self.sidebar_scroll = 0;
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -377,6 +377,7 @@ impl App {
         // Clamp scroll to valid range
         if item_count > 0 {
             self.sidebar_scroll = self.sidebar_scroll.min(item_count - 1);
+            self.snap_scroll_to_entry();
         } else {
             self.sidebar_scroll = 0;
         }
@@ -472,7 +473,33 @@ impl App {
     }
 
     pub fn selected_entry(&self) -> Option<&BranchEntry> {
-        self.filtered_entries().into_iter().nth(self.sidebar_scroll)
+        let rows = self.sidebar_rows();
+        match rows.get(self.sidebar_scroll)? {
+            SidebarRow::Entry(e) => Some(*e),
+            SidebarRow::Header { .. } => None,
+        }
+    }
+
+    /// If `sidebar_scroll` lands on a Header, advance to the next Entry. If past
+    /// the end, clamp to the last Entry. No-op if already on an Entry.
+    pub fn snap_scroll_to_entry(&mut self) {
+        // Collect row kinds into a plain bool vec (true = is_header) to avoid holding
+        // a borrow on self while mutating sidebar_scroll.
+        let is_header: Vec<bool> = self
+            .sidebar_rows()
+            .iter()
+            .map(|r| matches!(r, SidebarRow::Header { .. }))
+            .collect();
+        if is_header.is_empty() {
+            self.sidebar_scroll = 0;
+            return;
+        }
+        while self.sidebar_scroll < is_header.len() && is_header[self.sidebar_scroll] {
+            self.sidebar_scroll += 1;
+        }
+        if self.sidebar_scroll >= is_header.len() {
+            self.sidebar_scroll = is_header.len().saturating_sub(1);
+        }
     }
 
     /// Return the cached PR detail for the currently selected entry, if available.
@@ -557,6 +584,7 @@ impl App {
                     self.search_query.clear();
                     self.sidebar_scroll = self.search_pre_scroll;
                     self.sidebar_offset = 0;
+                    self.snap_scroll_to_entry();
                     self.request_details_for_selection();
                 } else if matches!(self.active_view, ActiveView::Log | ActiveView::History) {
                     self.active_view = ActiveView::Main;
@@ -580,6 +608,7 @@ impl App {
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
+                self.snap_scroll_to_entry();
                 if !self.local_prs_loaded {
                     self.pr_fetch_requested = Some(MainFilter::Local);
                 }
@@ -592,6 +621,7 @@ impl App {
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
+                self.snap_scroll_to_entry();
                 if !self.my_prs_loaded {
                     self.pr_fetch_requested = Some(MainFilter::MyPr);
                 }
@@ -604,6 +634,7 @@ impl App {
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
+                self.snap_scroll_to_entry();
                 if !self.review_prs_loaded {
                     self.pr_fetch_requested = Some(MainFilter::ReviewRequested);
                 }
@@ -652,17 +683,29 @@ impl App {
     }
 
     fn handle_main_key(&mut self, code: KeyCode) {
-        let filtered_len = self.filtered_entries().len();
         match code {
-            KeyCode::Char('j') | KeyCode::Down
-                if filtered_len > 0 && self.sidebar_scroll + 1 < filtered_len =>
-            {
-                self.sidebar_scroll += 1;
-                self.request_details_for_selection();
+            KeyCode::Char('j') | KeyCode::Down => {
+                let rows = self.sidebar_rows();
+                let mut next = self.sidebar_scroll + 1;
+                while next < rows.len() && matches!(rows[next], SidebarRow::Header { .. }) {
+                    next += 1;
+                }
+                if next < rows.len() {
+                    self.sidebar_scroll = next;
+                    self.request_details_for_selection();
+                }
             }
             KeyCode::Char('k') | KeyCode::Up if self.sidebar_scroll > 0 => {
-                self.sidebar_scroll = self.sidebar_scroll.saturating_sub(1);
-                self.request_details_for_selection();
+                let rows = self.sidebar_rows();
+                let mut prev = self.sidebar_scroll.saturating_sub(1);
+                while prev > 0 && matches!(rows[prev], SidebarRow::Header { .. }) {
+                    prev -= 1;
+                }
+                // If we landed on a Header at index 0, no Entry exists above; stay put.
+                if !matches!(rows.get(prev), Some(SidebarRow::Header { .. })) {
+                    self.sidebar_scroll = prev;
+                    self.request_details_for_selection();
+                }
             }
             KeyCode::Char(' ') => {
                 if let Some(entry) = self.selected_entry().cloned()
@@ -793,6 +836,7 @@ impl App {
                     self.pr_fetch_requested = Some(self.main_filter);
                     self.sidebar_scroll = 0;
                     self.sidebar_offset = 0;
+                    self.snap_scroll_to_entry();
                 }
             }
             KeyCode::Char('t') if self.main_filter == MainFilter::ReviewRequested => {
@@ -803,6 +847,7 @@ impl App {
                 self.pr_fetch_requested = Some(MainFilter::ReviewRequested);
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
+                self.snap_scroll_to_entry();
             }
             KeyCode::Char('/') => {
                 self.search_pre_scroll = self.sidebar_scroll;
@@ -844,6 +889,7 @@ impl App {
                 self.search_active = false;
                 self.search_query.clear();
                 self.sidebar_scroll = self.search_pre_scroll;
+                self.snap_scroll_to_entry();
                 self.request_details_for_selection();
             }
             KeyCode::Enter => {
@@ -855,24 +901,37 @@ impl App {
                 self.search_query.pop();
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
+                self.snap_scroll_to_entry();
                 self.request_details_for_selection();
             }
             KeyCode::Char(c) => {
                 self.search_query.push(c);
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
+                self.snap_scroll_to_entry();
                 self.request_details_for_selection();
             }
             KeyCode::Down => {
-                let len = self.filtered_entries().len();
-                if len > 0 && self.sidebar_scroll + 1 < len {
-                    self.sidebar_scroll += 1;
+                let rows = self.sidebar_rows();
+                let mut next = self.sidebar_scroll + 1;
+                while next < rows.len() && matches!(rows[next], SidebarRow::Header { .. }) {
+                    next += 1;
+                }
+                if next < rows.len() {
+                    self.sidebar_scroll = next;
                     self.request_details_for_selection();
                 }
             }
             KeyCode::Up if self.sidebar_scroll > 0 => {
-                self.sidebar_scroll -= 1;
-                self.request_details_for_selection();
+                let rows = self.sidebar_rows();
+                let mut prev = self.sidebar_scroll.saturating_sub(1);
+                while prev > 0 && matches!(rows[prev], SidebarRow::Header { .. }) {
+                    prev -= 1;
+                }
+                if !matches!(rows.get(prev), Some(SidebarRow::Header { .. })) {
+                    self.sidebar_scroll = prev;
+                    self.request_details_for_selection();
+                }
             }
             _ => {}
         }
@@ -1463,6 +1522,79 @@ mod resolve_local_path_tests {
         let meta = app.repos.get(&id).unwrap();
         assert!(meta.local_path_resolved);
         assert!(meta.local_path.is_none());
+    }
+}
+
+#[cfg(test)]
+mod cursor_skip_tests {
+    use super::*;
+
+    #[test]
+    fn cursor_moves_skips_headers_in_grouped_view() {
+        use crate::app::SidebarRow;
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, PullRequest, RepoId};
+        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "x".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "b".into(),
+            name: "y".into(),
+        };
+        app.active_repo = Some(active.clone());
+        app.main_filter = MainFilter::ReviewRequested;
+        let make_pr = |num: u64, head: &str, repo: &RepoId| PullRequest {
+            number: num,
+            title: "t".into(),
+            author: "u".into(),
+            state: "OPEN".into(),
+            head_ref: head.into(),
+            updated_at: "2024".into(),
+            is_draft: false,
+            review_requests: vec![],
+            latest_reviews: vec![],
+            review_status: None,
+            repo_id: repo.clone(),
+        };
+        app.entries = vec![
+            BranchEntry {
+                name: "e1".into(),
+                repo_id: active.clone(),
+                local_branch: None,
+                worktree: None,
+                pull_request: Some(make_pr(1, "e1", &active)),
+                git_status: None,
+            },
+            BranchEntry {
+                name: "e2".into(),
+                repo_id: other.clone(),
+                local_branch: None,
+                worktree: None,
+                pull_request: Some(make_pr(2, "e2", &other)),
+                git_status: None,
+            },
+        ];
+        // rows = [Header(active), Entry(e1), Header(other), Entry(e2)] → indices 0..=3
+        // Initial: snap to first Entry (= 1)
+        app.snap_scroll_to_entry();
+        assert_eq!(app.sidebar_scroll, 1);
+
+        // j → should jump from index 1 to index 3 (skip Header at index 2)
+        app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
+        let rows = app.sidebar_rows();
+        assert_eq!(app.sidebar_scroll, 3);
+        assert!(matches!(rows[app.sidebar_scroll], SidebarRow::Entry(_)));
+
+        // k → should jump back from 3 to 1
+        app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
+        let rows = app.sidebar_rows();
+        assert_eq!(app.sidebar_scroll, 1);
+        assert!(matches!(rows[app.sidebar_scroll], SidebarRow::Entry(_)));
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -254,6 +254,12 @@ pub struct App {
 
     // Loaded TOML config (protected_branches, worktree, …)
     pub config: crate::config::Config,
+
+    // Cross-repo context (set at startup)
+    #[allow(dead_code)]
+    pub active_repo: Option<crate::git::types::RepoId>,
+    #[allow(dead_code)]
+    pub clone_root: Option<std::path::PathBuf>,
 }
 
 impl App {
@@ -315,6 +321,8 @@ impl App {
             commits_reload_requested: false,
             spinner_tick: 0,
             config,
+            active_repo: None,
+            clone_root: None,
         }
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -262,12 +262,10 @@ pub struct App {
     pub config: crate::config::Config,
 
     // Cross-repo context (set at startup)
-    #[allow(dead_code)]
     pub active_repo: Option<crate::git::types::RepoId>,
     pub clone_root: Option<std::path::PathBuf>,
 
     // Per-repo metadata (populated lazily as repos are selected)
-    #[allow(dead_code)]
     pub repos: std::collections::HashMap<crate::git::types::RepoId, crate::git::types::RepoMeta>,
 
     // Worktree lists per repo (populated lazily as cross-repo PRs are selected)
@@ -1244,7 +1242,6 @@ impl App {
     /// Resolve a repo's local clone path under `clone_root`. Idempotent: only
     /// hits the filesystem once per repo. Sets `local_path_resolved = true`
     /// regardless of outcome to prevent re-tries.
-    #[allow(dead_code)]
     pub fn resolve_local_path(&mut self, id: &crate::git::types::RepoId) {
         // Snapshot clone_root first (no borrow on self.repos held).
         let root = self.clone_root.clone();

--- a/src/app.rs
+++ b/src/app.rs
@@ -258,8 +258,11 @@ pub struct App {
     // Cross-repo context (set at startup)
     #[allow(dead_code)]
     pub active_repo: Option<crate::git::types::RepoId>,
-    #[allow(dead_code)]
     pub clone_root: Option<std::path::PathBuf>,
+
+    // Per-repo metadata (populated lazily as repos are selected)
+    #[allow(dead_code)]
+    pub repos: std::collections::HashMap<crate::git::types::RepoId, crate::git::types::RepoMeta>,
 }
 
 impl App {
@@ -323,6 +326,7 @@ impl App {
             config,
             active_repo: None,
             clone_root: None,
+            repos: HashMap::new(),
         }
     }
 
@@ -1028,6 +1032,30 @@ impl App {
     pub fn is_protected_branch(&self, name: &str) -> bool {
         self.config.protected_branches.iter().any(|b| b == name)
     }
+
+    /// Resolve a repo's local clone path under `clone_root`. Idempotent: only
+    /// hits the filesystem once per repo. Sets `local_path_resolved = true`
+    /// regardless of outcome to prevent re-tries.
+    #[allow(dead_code)]
+    pub fn resolve_local_path(&mut self, id: &crate::git::types::RepoId) {
+        // Snapshot clone_root first (no borrow on self.repos held).
+        let root = self.clone_root.clone();
+        let Some(meta) = self.repos.get_mut(id) else {
+            return;
+        };
+        if meta.local_path_resolved {
+            return;
+        }
+        meta.local_path_resolved = true;
+        let Some(root) = root else {
+            return;
+        };
+        let host = id.host.as_deref().unwrap_or("github.com");
+        let candidate = root.join(host).join(&id.owner).join(&id.name);
+        if candidate.is_dir() {
+            meta.local_path = Some(candidate);
+        }
+    }
 }
 
 fn insert_char_at(s: &mut String, char_idx: usize, c: char) {
@@ -1270,6 +1298,66 @@ mod text_edit_tests {
             crossterm::event::KeyModifiers::NONE,
         ));
         assert!(app.should_quit);
+    }
+}
+
+#[cfg(test)]
+mod resolve_local_path_tests {
+    use super::*;
+
+    #[test]
+    fn resolve_local_path_ghq_layout_hits() {
+        use crate::config::Config;
+        use crate::git::types::RepoId;
+        let tmp = tempfile::tempdir().unwrap();
+        let host_dir = tmp.path().join("github.com").join("owner").join("name");
+        std::fs::create_dir_all(&host_dir).unwrap();
+
+        let mut app = App::new(Config::default());
+        app.clone_root = Some(tmp.path().to_path_buf());
+        let id = RepoId {
+            host: None,
+            owner: "owner".into(),
+            name: "name".into(),
+        };
+        app.repos.insert(
+            id.clone(),
+            crate::git::types::RepoMeta {
+                id: id.clone(),
+                local_path: None,
+                local_path_resolved: false,
+            },
+        );
+        app.resolve_local_path(&id);
+        let meta = app.repos.get(&id).unwrap();
+        assert!(meta.local_path_resolved);
+        assert_eq!(meta.local_path.as_ref().unwrap(), &host_dir);
+    }
+
+    #[test]
+    fn resolve_local_path_misses_when_dir_absent() {
+        use crate::config::Config;
+        use crate::git::types::RepoId;
+        let tmp = tempfile::tempdir().unwrap();
+        let mut app = App::new(Config::default());
+        app.clone_root = Some(tmp.path().to_path_buf());
+        let id = RepoId {
+            host: None,
+            owner: "x".into(),
+            name: "y".into(),
+        };
+        app.repos.insert(
+            id.clone(),
+            crate::git::types::RepoMeta {
+                id: id.clone(),
+                local_path: None,
+                local_path_resolved: false,
+            },
+        );
+        app.resolve_local_path(&id);
+        let meta = app.repos.get(&id).unwrap();
+        assert!(meta.local_path_resolved);
+        assert!(meta.local_path.is_none());
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1023,12 +1023,14 @@ impl App {
         items.push(ActionItem::CopyBranchName);
 
         let wt_already_exists = entry.worktree.is_some();
-        let wt_path_for_inflight = if is_active_repo {
-            self.config.worktree_path(&entry.name)
+        let wt_path_for_inflight: Option<String> = if cross_repo_no_clone {
+            None
+        } else if is_active_repo {
+            Some(self.config.worktree_path(&entry.name))
         } else if let Some(ref root) = clone_path {
-            self.config.worktree_path_for(root, &entry.name)
+            Some(self.config.worktree_path_for(root, &entry.name))
         } else {
-            String::new()
+            None
         };
 
         if wt_already_exists {
@@ -1039,7 +1041,10 @@ impl App {
             && !entry.is_current()
             && (entry.local_branch.is_some() || entry.pull_request.is_some())
             && !cross_repo_no_clone
-            && !self.wt_inflight.contains(&wt_path_for_inflight);
+            && wt_path_for_inflight
+                .as_deref()
+                .map(|p| !self.wt_inflight.contains(p))
+                .unwrap_or(false);
         if can_create_wt {
             items.push(ActionItem::CreateWorktree);
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -207,10 +207,10 @@ pub struct App {
     pub include_team_reviews: bool,
     pub pr_fetch_requested: Option<MainFilter>,
 
-    // PR Detail (for detail pane, cached by PR number)
-    pub pr_detail_cache: HashMap<u64, PrDetail>,
+    // PR Detail (for detail pane, cached by (RepoId, PR number))
+    pub pr_detail_cache: HashMap<(crate::git::types::RepoId, u64), PrDetail>,
     pub pr_detail_scroll: usize,
-    pub pr_detail_requested: Option<u64>,
+    pub pr_detail_requested: Option<(crate::git::types::RepoId, u64)>,
 
     // Git status loading
     pub git_status_requested: Option<String>, // worktree path
@@ -243,7 +243,7 @@ pub struct App {
     pub quit_pressed_during_progress: bool,
     pub branch_selected: HashSet<String>,
     pub branch_delete_requested: bool,
-    pub open_pr_requested: Option<u64>,
+    pub open_pr_requested: Option<(crate::git::types::RepoId, u64)>,
     pub copy_branch_requested: Option<String>,
     pub branch_create_requested: Option<(String, String)>, // (source, name)
     pub branches_reload_requested: bool,
@@ -441,7 +441,7 @@ impl App {
     pub fn selected_pr_detail(&self) -> Option<&PrDetail> {
         let entry = self.selected_entry()?;
         let pr_num = entry.pr_number()?;
-        self.pr_detail_cache.get(&pr_num)
+        self.pr_detail_cache.get(&(entry.repo_id.clone(), pr_num))
     }
 
     /// Signal that the selection changed; request PR detail and git status as needed.
@@ -452,9 +452,11 @@ impl App {
         if let Some(entry) = selected {
             // Request PR detail if entry has a PR and it's not cached
             if let Some(pr_num) = entry.pr_number()
-                && !self.pr_detail_cache.contains_key(&pr_num)
+                && !self
+                    .pr_detail_cache
+                    .contains_key(&(entry.repo_id.clone(), pr_num))
             {
-                self.pr_detail_requested = Some(pr_num);
+                self.pr_detail_requested = Some((entry.repo_id.clone(), pr_num));
             }
 
             // Request git status if entry has a worktree and status not yet loaded
@@ -960,7 +962,7 @@ impl App {
             }
             ActionItem::OpenPrInBrowser => {
                 if let Some(pr) = &entry.pull_request {
-                    self.open_pr_requested = Some(pr.number);
+                    self.open_pr_requested = Some((entry.repo_id.clone(), pr.number));
                 }
             }
             ActionItem::CopyBranchName => {
@@ -1314,6 +1316,55 @@ mod text_edit_tests {
             crossterm::event::KeyModifiers::NONE,
         ));
         assert!(app.should_quit);
+    }
+}
+
+#[cfg(test)]
+mod pr_detail_cache_tests {
+    use super::*;
+
+    #[test]
+    fn pr_detail_cache_keyed_by_repo_id() {
+        use crate::config::Config;
+        use crate::git::types::{PrDetail, RepoId};
+        let mut app = App::new(Config::default());
+        let id_a = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "x".into(),
+        };
+        let id_b = RepoId {
+            host: None,
+            owner: "b".into(),
+            name: "x".into(),
+        };
+        let detail_a = PrDetail {
+            number: 1,
+            title: "A".into(),
+            author: "u".into(),
+            state: "OPEN".into(),
+            body: String::new(),
+            additions: 0,
+            deletions: 0,
+            head_ref: "f".into(),
+        };
+        let detail_b = PrDetail {
+            number: 1,
+            title: "B".into(),
+            author: "u".into(),
+            state: "OPEN".into(),
+            body: String::new(),
+            additions: 0,
+            deletions: 0,
+            head_ref: "f".into(),
+        };
+        app.pr_detail_cache
+            .insert((id_a.clone(), 1), detail_a.clone());
+        app.pr_detail_cache
+            .insert((id_b.clone(), 1), detail_b.clone());
+        assert_eq!(app.pr_detail_cache.len(), 2);
+        assert_eq!(app.pr_detail_cache.get(&(id_a, 1)).unwrap().title, "A");
+        assert_eq!(app.pr_detail_cache.get(&(id_b, 1)).unwrap().title, "B");
     }
 }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -263,6 +263,11 @@ pub struct App {
     // Per-repo metadata (populated lazily as repos are selected)
     #[allow(dead_code)]
     pub repos: std::collections::HashMap<crate::git::types::RepoId, crate::git::types::RepoMeta>,
+
+    // Worktree lists per repo (populated lazily as cross-repo PRs are selected)
+    #[allow(dead_code)]
+    pub wt_lists_per_repo:
+        std::collections::HashMap<crate::git::types::RepoId, Vec<crate::git::types::Worktree>>,
 }
 
 impl App {
@@ -327,6 +332,7 @@ impl App {
             active_repo: None,
             clone_root: None,
             repos: HashMap::new(),
+            wt_lists_per_repo: HashMap::new(),
         }
     }
 
@@ -390,8 +396,18 @@ impl App {
     }
 
     pub fn rebuild_entries(&mut self) {
-        self.entries =
-            crate::data::merge_entries(&self.branches, &self.worktrees, self.current_prs());
+        // When `active_repo` is absent (startup couldn't infer one), unwrap_or_default
+        // produces a sentinel empty RepoId. It can't collide with any real PR's repo_id,
+        // so cross-repo entries are still keyed correctly and worktree injection no-ops
+        // safely.
+        let active = self.active_repo.clone().unwrap_or_default();
+        self.entries = crate::data::merge_entries(
+            &active,
+            &self.branches,
+            &self.worktrees,
+            self.current_prs(),
+            &self.wt_lists_per_repo,
+        );
     }
 
     pub fn filtered_entries(&self) -> Vec<&BranchEntry> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -273,6 +273,10 @@ pub struct App {
     // Worktree lists per repo (populated lazily as cross-repo PRs are selected)
     pub wt_lists_per_repo:
         std::collections::HashMap<crate::git::types::RepoId, Vec<crate::git::types::Worktree>>,
+
+    // Cross-repo worktree list lazy-load state
+    pub wt_list_inflight: HashSet<crate::git::types::RepoId>,
+    pub wt_list_requested: Option<crate::git::types::RepoId>,
 }
 
 impl App {
@@ -338,6 +342,8 @@ impl App {
             clone_root: None,
             repos: HashMap::new(),
             wt_lists_per_repo: HashMap::new(),
+            wt_list_inflight: HashSet::new(),
+            wt_list_requested: None,
         }
     }
 
@@ -529,6 +535,24 @@ impl App {
                 && entry.git_status.is_none()
             {
                 self.git_status_requested = Some(wt_path.to_string());
+            }
+        }
+
+        // Signal lazy load of cross-repo worktree list if not yet fetched
+        let selected_for_wt = self.selected_entry().cloned();
+        if let Some(entry) = selected_for_wt
+            && self.active_repo.as_ref() != Some(&entry.repo_id)
+            && !self.wt_lists_per_repo.contains_key(&entry.repo_id)
+            && !self.wt_list_inflight.contains(&entry.repo_id)
+        {
+            self.resolve_local_path(&entry.repo_id);
+            if self
+                .repos
+                .get(&entry.repo_id)
+                .and_then(|m| m.local_path.as_ref())
+                .is_some()
+            {
+                self.wt_list_requested = Some(entry.repo_id.clone());
             }
         }
     }
@@ -2014,5 +2038,95 @@ mod action_menu_cross_repo_tests {
         app.execute_action(ActionItem::CdIntoWorktree, "feat");
         assert_eq!(app.cd_path.as_deref(), Some("/tmp/clones/b/feat"));
         assert!(app.should_quit);
+    }
+}
+
+#[cfg(test)]
+mod wt_list_lazy_load_tests {
+    use super::*;
+
+    #[test]
+    fn selecting_cross_repo_entry_signals_wt_list_load() {
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, PullRequest, RepoId, RepoMeta};
+        let tmp = tempfile::tempdir().unwrap();
+        let clone_path = tmp.path().join("github.com").join("b").join("y");
+        std::fs::create_dir_all(&clone_path).unwrap();
+
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "x".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "b".into(),
+            name: "y".into(),
+        };
+        app.active_repo = Some(active);
+        app.clone_root = Some(tmp.path().to_path_buf());
+        app.repos.insert(
+            other.clone(),
+            RepoMeta {
+                id: other.clone(),
+                local_path: None,
+                local_path_resolved: false,
+            },
+        );
+        app.main_filter = MainFilter::ReviewRequested;
+        app.entries = vec![BranchEntry {
+            name: "feat".into(),
+            repo_id: other.clone(),
+            local_branch: None,
+            worktree: None,
+            pull_request: Some(PullRequest {
+                number: 1,
+                title: "x".into(),
+                author: "u".into(),
+                state: "OPEN".into(),
+                head_ref: "feat".into(),
+                updated_at: "2024".into(),
+                is_draft: false,
+                review_requests: vec![],
+                latest_reviews: vec![],
+                review_status: None,
+                repo_id: other.clone(),
+            }),
+            git_status: None,
+        }];
+        app.snap_scroll_to_entry();
+        app.request_details_for_selection();
+        assert_eq!(app.wt_list_requested.as_ref(), Some(&other));
+    }
+
+    #[test]
+    fn selecting_active_repo_entry_does_not_signal_wt_list_load() {
+        use crate::config::Config;
+        use crate::git::types::{BranchEntry, RepoId};
+        let mut app = App::new(Config::default());
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "x".into(),
+        };
+        app.active_repo = Some(active.clone());
+        let make_branch = |name: &str| crate::git::types::Branch {
+            name: name.into(),
+            is_current: false,
+            upstream: None,
+            is_merged: false,
+        };
+        app.entries = vec![BranchEntry {
+            name: "feat".into(),
+            repo_id: active.clone(),
+            local_branch: Some(make_branch("feat")),
+            worktree: None,
+            pull_request: None,
+            git_status: None,
+        }];
+        app.snap_scroll_to_entry();
+        app.request_details_for_selection();
+        assert!(app.wt_list_requested.is_none());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -100,7 +100,6 @@ impl Config {
 
     /// Build a worktree path relative to a specific repo root.
     /// `dir = ".."` produces `<repo_root>/../<branch>` (= sibling of repo).
-    #[allow(dead_code)]
     pub fn worktree_path_for(&self, repo_root: &Path, branch_name: &str) -> String {
         let dir = self.worktree.dir.trim();
         let base = if dir.is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -10,12 +10,10 @@ pub struct WorkspaceConfig {
     /// `~` is expanded at lookup time; absent means cross-repo Worktree
     /// actions degrade to read-only when auto-detection also fails.
     #[serde(default)]
-    #[allow(dead_code)]
     pub clone_root: Option<String>,
 }
 
 impl WorkspaceConfig {
-    #[allow(dead_code)]
     pub fn clone_root_expanded(&self) -> Option<PathBuf> {
         let raw = self.clone_root.as_deref()?;
         let expanded = shellexpand::tilde(raw);
@@ -30,7 +28,6 @@ pub struct Config {
     #[serde(default = "default_protected_branches")]
     pub protected_branches: Vec<String>,
     #[serde(default)]
-    #[allow(dead_code)]
     pub workspace: WorkspaceConfig,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -97,6 +97,23 @@ impl Config {
             .to_string_lossy()
             .to_string()
     }
+
+    /// Build a worktree path relative to a specific repo root.
+    /// `dir = ".."` produces `<repo_root>/../<branch>` (= sibling of repo).
+    #[allow(dead_code)]
+    pub fn worktree_path_for(&self, repo_root: &Path, branch_name: &str) -> String {
+        let dir = self.worktree.dir.trim();
+        let base = if dir.is_empty() {
+            DEFAULT_WORKTREE_DIR
+        } else {
+            dir
+        };
+        repo_root
+            .join(base)
+            .join(branch_name)
+            .to_string_lossy()
+            .to_string()
+    }
 }
 
 /// Run post-create actions after worktree creation.
@@ -619,5 +636,31 @@ clone_root = "~/workspace"
         // No raw "~" should remain; the final component should be "foo".
         assert!(!path.to_string_lossy().contains('~'));
         assert!(path.ends_with("foo"));
+    }
+
+    #[test]
+    fn worktree_path_for_default_dir() {
+        let config = Config::default();
+        let root = Path::new("/repos/owner/name");
+        let p = config.worktree_path_for(root, "feature/auth");
+        let expected = Path::new("/repos/owner/name")
+            .join("..")
+            .join("feature/auth");
+        assert_eq!(p, expected.to_string_lossy().to_string());
+    }
+
+    #[test]
+    fn worktree_path_for_custom_dir() {
+        let config = Config {
+            worktree: WorktreeConfig {
+                dir: "wt".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let root = Path::new("/repos/owner/name");
+        let p = config.worktree_path_for(root, "feature/x");
+        let expected = Path::new("/repos/owner/name").join("wt").join("feature/x");
+        assert_eq!(p, expected.to_string_lossy().to_string());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,12 +4,34 @@ use std::path::{Path, PathBuf};
 
 const DEFAULT_WORKTREE_DIR: &str = "..";
 
+#[derive(Debug, Deserialize, Clone, Default)]
+pub struct WorkspaceConfig {
+    /// Optional root path to look up local clones for cross-repo entries.
+    /// `~` is expanded at lookup time; absent means cross-repo Worktree
+    /// actions degrade to read-only when auto-detection also fails.
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub clone_root: Option<String>,
+}
+
+impl WorkspaceConfig {
+    #[allow(dead_code)]
+    pub fn clone_root_expanded(&self) -> Option<PathBuf> {
+        let raw = self.clone_root.as_deref()?;
+        let expanded = shellexpand::tilde(raw);
+        Some(PathBuf::from(expanded.into_owned()))
+    }
+}
+
 #[derive(Debug, Deserialize, Clone)]
 pub struct Config {
     #[serde(default)]
     pub worktree: WorktreeConfig,
     #[serde(default = "default_protected_branches")]
     pub protected_branches: Vec<String>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub workspace: WorkspaceConfig,
 }
 
 fn default_protected_branches() -> Vec<String> {
@@ -21,6 +43,7 @@ impl Default for Config {
         Self {
             worktree: WorktreeConfig::default(),
             protected_branches: default_protected_branches(),
+            workspace: WorkspaceConfig::default(),
         }
     }
 }
@@ -569,5 +592,32 @@ command = "npm ci"
         let errors = run_post_create(&actions, &repo, &wt);
         assert_eq!(errors.len(), 1);
         assert!(errors[0].contains("exit 1"));
+    }
+
+    #[test]
+    fn parse_workspace_clone_root() {
+        let toml_str = r#"
+[workspace]
+clone_root = "~/workspace"
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.workspace.clone_root.as_deref(), Some("~/workspace"));
+    }
+
+    #[test]
+    fn workspace_default_empty() {
+        let config: Config = toml::from_str("").unwrap();
+        assert!(config.workspace.clone_root.is_none());
+    }
+
+    #[test]
+    fn workspace_clone_root_expanded_strips_tilde() {
+        let cfg = WorkspaceConfig {
+            clone_root: Some("~/foo".into()),
+        };
+        let path = cfg.clone_root_expanded().unwrap();
+        // No raw "~" should remain; the final component should be "foo".
+        assert!(!path.to_string_lossy().contains('~'));
+        assert!(path.ends_with("foo"));
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -341,6 +341,8 @@ fn host_from_url(url: &str) -> Option<String> {
 
 // gh api graphql does not accept --hostname here; v1 supports github.com only.
 // Cross-host (GHE) PR aggregation will require routing through per-host gh config.
+// TODO(future): GitHub's search index supports up to 1000 results; if very active
+// reviewers report missing PRs, paginate via search.pageInfo.endCursor.
 async fn fetch_search_prs(query_str: &str, limit: u32) -> (Vec<PullRequest>, Vec<String>) {
     let escaped_query = query_str.replace('\\', "\\\\").replace('"', "\\\"");
     let query = format!(
@@ -381,6 +383,8 @@ pub async fn fetch_my_prs(show_merged: bool) -> (Vec<PullRequest>, Vec<String>) 
     }
     // When show_merged is on we lose the OPEN-only narrowing, so widen the limit
     // to compensate (the previous fetch_pr_list returned 100 open + 50 merged).
+    // TODO(future): GitHub's search index supports up to 1000 results; if very active
+    // reviewers report missing PRs, paginate via search.pageInfo.endCursor.
     let limit = if show_merged { 150 } else { 100 };
     let (mut prs, errors) = fetch_search_prs(&q, limit).await;
     prs.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));

--- a/src/data.rs
+++ b/src/data.rs
@@ -216,6 +216,17 @@ pub async fn fetch_local_prs(
         }
     }
 
+    let repo_id_for_local = crate::git::types::RepoId {
+        host: hostname.map(|h| h.to_string()),
+        owner: owner.to_string(),
+        name: repo.to_string(),
+    };
+    for pr in &mut all_prs {
+        if pr.repo_id.owner.is_empty() {
+            pr.repo_id = repo_id_for_local.clone();
+        }
+    }
+
     (all_prs, errors)
 }
 
@@ -257,15 +268,97 @@ fn parse_graphql_pr(node: &serde_json::Value) -> Option<PullRequest> {
         review_requests,
         latest_reviews: Vec::new(),
         review_status: None,
+        repo_id: Default::default(),
     })
 }
 
-/// Fetch PRs authored by the current user (`gh pr list --author @me`).
-pub async fn fetch_my_prs(show_merged: bool) -> (Vec<PullRequest>, Vec<String>) {
-    fetch_pr_list(&["--author", "@me"], show_merged).await
+/// Parse a GraphQL `search.nodes[]` PR (with `repository` field) into PullRequest.
+fn parse_graphql_search_pr(node: &serde_json::Value) -> Option<PullRequest> {
+    let mut pr = parse_graphql_pr(node)?;
+    let repo_owner = node["repository"]["owner"]["login"].as_str()?.to_string();
+    let repo_name = node["repository"]["name"].as_str()?.to_string();
+    let repo_url = node["repository"]["url"].as_str().unwrap_or("");
+    let host = host_from_url(repo_url);
+    pr.repo_id = crate::git::types::RepoId {
+        host,
+        owner: repo_owner,
+        name: repo_name,
+    };
+    if let Some(arr) = node["latestReviews"]["nodes"].as_array() {
+        pr.latest_reviews = arr
+            .iter()
+            .filter_map(|r| {
+                Some(crate::git::types::LatestReview {
+                    author: r["author"]["login"].as_str()?.to_string(),
+                    state: r["state"].as_str()?.to_string(),
+                })
+            })
+            .collect();
+    }
+    Some(pr)
 }
 
-/// Fetch PRs with review requested from the current user.
+fn host_from_url(url: &str) -> Option<String> {
+    let rest = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))?;
+    let host = rest.split('/').next()?;
+    if host == "github.com" {
+        None
+    } else {
+        Some(host.to_string())
+    }
+}
+
+// gh api graphql does not accept --hostname here; v1 supports github.com only.
+// Cross-host (GHE) PR aggregation will require routing through per-host gh config.
+async fn fetch_search_prs(query_str: &str, limit: u32) -> (Vec<PullRequest>, Vec<String>) {
+    let escaped_query = query_str.replace('\\', "\\\\").replace('"', "\\\"");
+    let query = format!(
+        r#"{{ search(query: "{escaped_query}", type: ISSUE, first: {limit}) {{ nodes {{ ... on PullRequest {{ number title state headRefName updatedAt isDraft author {{ login }} repository {{ name url owner {{ login }} }} reviewRequests(first: 10) {{ nodes {{ requestedReviewer {{ ... on User {{ login }} }} }} }} latestReviews(first: 20) {{ nodes {{ author {{ login }} state }} }} }} }} }} }}"#
+    );
+    let query_arg = format!("query={query}");
+    let args = vec!["api", "graphql", "-f", &query_arg];
+    match run_gh(&args).await {
+        Ok(output) => match serde_json::from_str::<serde_json::Value>(&output) {
+            Ok(json) => {
+                let mut prs = Vec::new();
+                if let Some(arr) = json["data"]["search"]["nodes"].as_array() {
+                    for node in arr {
+                        if let Some(pr) = parse_graphql_search_pr(node) {
+                            prs.push(pr);
+                        }
+                    }
+                }
+                (prs, Vec::new())
+            }
+            Err(e) => {
+                debug_log(&format!("  → GraphQL search parse error: {e}"));
+                (Vec::new(), vec![format!("search parse error: {e}")])
+            }
+        },
+        Err(e) => {
+            debug_log(&format!("  → GraphQL search fetch error: {e}"));
+            (Vec::new(), vec![format!("search fetch failed: {e}")])
+        }
+    }
+}
+
+/// Fetch PRs authored by the current user via cross-repo GraphQL search.
+pub async fn fetch_my_prs(show_merged: bool) -> (Vec<PullRequest>, Vec<String>) {
+    let mut q = String::from("is:pr author:@me");
+    if !show_merged {
+        q.push_str(" is:open");
+    }
+    // When show_merged is on we lose the OPEN-only narrowing, so widen the limit
+    // to compensate (the previous fetch_pr_list returned 100 open + 50 merged).
+    let limit = if show_merged { 150 } else { 100 };
+    let (mut prs, errors) = fetch_search_prs(&q, limit).await;
+    prs.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+    (prs, errors)
+}
+
+/// Fetch PRs with review requested from the current user via cross-repo GraphQL search.
 /// Runs separate queries and merges results to avoid GHE `OR` incompatibility.
 /// When `include_team` is true, also includes team review requests.
 pub async fn fetch_review_prs(
@@ -273,24 +366,40 @@ pub async fn fetch_review_prs(
     include_team: bool,
     gh_user: &str,
 ) -> (Vec<PullRequest>, Vec<String>) {
-    let mut queries = vec!["review-requested:@me", "reviewed-by:@me"];
+    let mut queries: Vec<String> = vec![
+        "is:pr review-requested:@me".into(),
+        "is:pr reviewed-by:@me".into(),
+    ];
     if include_team {
-        queries.push("team-review-requested:@me");
+        queries.push("is:pr team-review-requested:@me".into());
+    }
+    if !show_merged {
+        for q in &mut queries {
+            q.push_str(" is:open");
+        }
     }
 
     let mut all_prs = Vec::new();
     let mut all_errors = Vec::new();
-    let mut seen: HashSet<u64> = HashSet::new();
-    let mut reviewed_numbers: HashSet<u64> = HashSet::new();
+    let mut seen: HashSet<(crate::git::types::RepoId, u64)> = HashSet::new();
+    let mut reviewed_keys: HashSet<(crate::git::types::RepoId, u64)> = HashSet::new();
 
-    for query in &queries {
-        let (prs, errors) = fetch_pr_list(&["--search", query], show_merged).await;
+    // Two separate sets:
+    // - `seen` deduplicates PRs across queries (keyed by RepoId+number).
+    // - `reviewed_keys` records every PR returned by the reviewed-by query, even
+    //   if `seen` rejects it as a duplicate. This is intentional: the me-only
+    //   filter below uses `reviewed_keys` as a predicate, not as a display list.
+    const REVIEWED_BY_INDEX: usize = 1;
+    for (idx, query) in queries.iter().enumerate() {
+        let is_reviewed = idx == REVIEWED_BY_INDEX;
+        let (prs, errors) = fetch_search_prs(query, 100).await;
         all_errors.extend(errors);
         for pr in prs {
-            if *query == "reviewed-by:@me" {
-                reviewed_numbers.insert(pr.number);
+            let key = (pr.repo_id.clone(), pr.number);
+            if is_reviewed {
+                reviewed_keys.insert(key.clone());
             }
-            if seen.insert(pr.number) {
+            if seen.insert(key) {
                 all_prs.push(pr);
             }
         }
@@ -306,7 +415,8 @@ pub async fn fetch_review_prs(
     // When me-only, exclude PRs that only have team review requests
     if !include_team && !gh_user.is_empty() {
         all_prs.retain(|pr| {
-            reviewed_numbers.contains(&pr.number)
+            let key = (pr.repo_id.clone(), pr.number);
+            reviewed_keys.contains(&key)
                 || pr
                     .review_requests
                     .iter()
@@ -314,69 +424,8 @@ pub async fn fetch_review_prs(
         });
     }
 
-    // Sort by updated_at descending for consistent ordering
     all_prs.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
-
     (all_prs, all_errors)
-}
-
-/// Common helper for fetching PR lists with a filter.
-/// `filter_args` is passed directly to `gh pr list` (e.g., `["--author", "@me"]`).
-/// Returns (prs, errors) where errors contains any fetch/parse failures.
-async fn fetch_pr_list(filter_args: &[&str], show_merged: bool) -> (Vec<PullRequest>, Vec<String>) {
-    let pr_fields =
-        "number,title,author,state,headRefName,updatedAt,isDraft,reviewRequests,latestReviews";
-    let filter_label = filter_args.join(" ");
-    let mut prs = Vec::new();
-    let mut errors = Vec::new();
-
-    // Always fetch open PRs
-    let mut args = vec!["pr", "list"];
-    args.extend_from_slice(filter_args);
-    args.extend_from_slice(&["--json", pr_fields, "--limit", "100"]);
-    match run_gh(&args).await {
-        Ok(output) => match serde_json::from_str::<Vec<PullRequest>>(&output) {
-            Ok(open) => prs.extend(open),
-            Err(e) => {
-                debug_log(&format!(
-                    "  → pr list [{filter_label}] JSON parse error: {e}"
-                ));
-                errors.push(format!("pr list [{filter_label}] parse error: {e}"));
-            }
-        },
-        Err(e) => {
-            debug_log(&format!("  → pr list [{filter_label}] fetch error: {e}"));
-            errors.push(format!("pr list [{filter_label}] failed: {e}"));
-        }
-    }
-
-    // Optionally fetch merged PRs
-    if show_merged {
-        let mut args = vec!["pr", "list"];
-        args.extend_from_slice(filter_args);
-        args.extend_from_slice(&["--state", "merged", "--json", pr_fields, "--limit", "50"]);
-        match run_gh(&args).await {
-            Ok(output) => match serde_json::from_str::<Vec<PullRequest>>(&output) {
-                Ok(merged) => prs.extend(merged),
-                Err(e) => {
-                    debug_log(&format!(
-                        "  → pr list [{filter_label}] (merged) JSON parse error: {e}"
-                    ));
-                    errors.push(format!(
-                        "pr list [{filter_label}] (merged) parse error: {e}"
-                    ));
-                }
-            },
-            Err(e) => {
-                debug_log(&format!(
-                    "  → pr list [{filter_label}] (merged) fetch error: {e}"
-                ));
-                errors.push(format!("pr list [{filter_label}] (merged) failed: {e}"));
-            }
-        }
-    }
-
-    (prs, errors)
 }
 
 #[cfg(test)]
@@ -419,6 +468,7 @@ mod tests {
             is_merged: false,
         }];
         let worktrees = vec![];
+        use crate::git::types::RepoId;
         let prs = vec![PullRequest {
             number: 42,
             title: "Add feature A".to_string(),
@@ -430,6 +480,7 @@ mod tests {
             is_draft: false,
             latest_reviews: vec![],
             review_status: None,
+            repo_id: RepoId::default(),
         }];
 
         let entries = merge_entries(&branches, &worktrees, &prs);
@@ -443,6 +494,7 @@ mod tests {
     fn test_merge_entries_remote_only_pr() {
         let branches = vec![];
         let worktrees = vec![];
+        use crate::git::types::RepoId;
         let prs = vec![PullRequest {
             number: 99,
             title: "Remote only PR".to_string(),
@@ -454,6 +506,7 @@ mod tests {
             is_draft: false,
             latest_reviews: vec![],
             review_status: None,
+            repo_id: RepoId::default(),
         }];
 
         let entries = merge_entries(&branches, &worktrees, &prs);
@@ -470,6 +523,7 @@ mod tests {
             upstream: None,
             is_merged: false,
         }];
+        use crate::git::types::RepoId;
         let prs = vec![PullRequest {
             number: 10,
             title: "Feature A".to_string(),
@@ -481,6 +535,7 @@ mod tests {
             is_draft: false,
             latest_reviews: vec![],
             review_status: None,
+            repo_id: RepoId::default(),
         }];
 
         let entries = merge_entries(&branches, &[], &prs);
@@ -498,6 +553,7 @@ mod tests {
             upstream: None,
             is_merged: false,
         }];
+        use crate::git::types::RepoId;
         let prs = vec![
             PullRequest {
                 number: 5,
@@ -510,6 +566,7 @@ mod tests {
                 is_draft: false,
                 latest_reviews: vec![],
                 review_status: None,
+                repo_id: RepoId::default(),
             },
             PullRequest {
                 number: 10,
@@ -522,6 +579,7 @@ mod tests {
                 is_draft: false,
                 latest_reviews: vec![],
                 review_status: None,
+                repo_id: RepoId::default(),
             },
         ];
 
@@ -624,6 +682,53 @@ mod tests {
         assert_eq!(pr.review_requests[0].login.as_deref(), Some("bob"));
         assert_eq!(pr.review_requests[1].login, None);
         assert_eq!(pr.review_requests[2].login, None);
+    }
+
+    #[test]
+    fn parse_graphql_search_pr_with_repo() {
+        let node = serde_json::json!({
+            "number": 42,
+            "title": "Cross repo",
+            "state": "OPEN",
+            "headRefName": "feat",
+            "updatedAt": "2024-01-15T00:00:00Z",
+            "isDraft": false,
+            "author": { "login": "alice" },
+            "repository": {
+                "name": "repo",
+                "owner": { "login": "owner" },
+                "url": "https://github.com/owner/repo"
+            },
+            "reviewRequests": { "nodes": [] },
+            "latestReviews": { "nodes": [] }
+        });
+        let pr = parse_graphql_search_pr(&node).unwrap();
+        assert_eq!(pr.number, 42);
+        assert_eq!(pr.repo_id.owner, "owner");
+        assert_eq!(pr.repo_id.name, "repo");
+        assert!(pr.repo_id.host.is_none());
+    }
+
+    #[test]
+    fn parse_graphql_search_pr_with_ghe_repo() {
+        let node = serde_json::json!({
+            "number": 1,
+            "title": "GHE",
+            "state": "OPEN",
+            "headRefName": "x",
+            "updatedAt": "2024-01-15T00:00:00Z",
+            "isDraft": false,
+            "author": { "login": "a" },
+            "repository": {
+                "name": "svc",
+                "owner": { "login": "team" },
+                "url": "https://ghe.company.com/team/svc"
+            },
+            "reviewRequests": { "nodes": [] },
+            "latestReviews": { "nodes": [] }
+        });
+        let pr = parse_graphql_search_pr(&node).unwrap();
+        assert_eq!(pr.repo_id.host.as_deref(), Some("ghe.company.com"));
     }
 
     #[test]

--- a/src/data.rs
+++ b/src/data.rs
@@ -5,17 +5,25 @@ use crate::git::types::{Branch, BranchEntry, GitStatus, PullRequest, ReviewReque
 
 /// Merge local branches, worktrees, and PRs into unified BranchEntry list.
 pub fn merge_entries(
+    active_repo: &crate::git::types::RepoId,
     branches: &[Branch],
     worktrees: &[Worktree],
     pull_requests: &[PullRequest],
+    wt_lists_per_repo: &std::collections::HashMap<
+        crate::git::types::RepoId,
+        Vec<crate::git::types::Worktree>,
+    >,
 ) -> Vec<BranchEntry> {
-    let mut map: HashMap<String, BranchEntry> = HashMap::new();
+    use crate::git::types::RepoId;
+    let mut map: HashMap<(RepoId, String), BranchEntry> = HashMap::new();
 
-    // Add local branches
+    // Local branches → all keyed under active_repo
     for branch in branches {
-        map.entry(branch.name.clone())
+        let key = (active_repo.clone(), branch.name.clone());
+        map.entry(key.clone())
             .or_insert_with(|| BranchEntry {
                 name: branch.name.clone(),
+                repo_id: active_repo.clone(),
                 local_branch: None,
                 worktree: None,
                 pull_request: None,
@@ -24,12 +32,14 @@ pub fn merge_entries(
             .local_branch = Some(branch.clone());
     }
 
-    // Add worktrees (match by branch name)
+    // Active-repo worktrees
     for wt in worktrees {
         if let Some(branch_name) = &wt.branch {
-            map.entry(branch_name.clone())
+            let key = (active_repo.clone(), branch_name.clone());
+            map.entry(key.clone())
                 .or_insert_with(|| BranchEntry {
                     name: branch_name.clone(),
+                    repo_id: active_repo.clone(),
                     local_branch: None,
                     worktree: None,
                     pull_request: None,
@@ -39,17 +49,17 @@ pub fn merge_entries(
         }
     }
 
-    // Add PRs (match by head_ref, prefer OPEN over MERGED)
+    // PRs (active repo merges with branches/worktrees, other repos are PR-only)
     for pr in pull_requests {
-        let entry = map
-            .entry(pr.head_ref.clone())
-            .or_insert_with(|| BranchEntry {
-                name: pr.head_ref.clone(),
-                local_branch: None,
-                worktree: None,
-                pull_request: None,
-                git_status: None,
-            });
+        let key = (pr.repo_id.clone(), pr.head_ref.clone());
+        let entry = map.entry(key.clone()).or_insert_with(|| BranchEntry {
+            name: pr.head_ref.clone(),
+            repo_id: pr.repo_id.clone(),
+            local_branch: None,
+            worktree: None,
+            pull_request: None,
+            git_status: None,
+        });
         match (&entry.pull_request, pr.state.as_str()) {
             (Some(existing), "MERGED") if existing.state == "OPEN" => {
                 // Don't overwrite an OPEN PR with a MERGED one
@@ -58,14 +68,33 @@ pub fn merge_entries(
                 entry.pull_request = Some(pr.clone());
             }
         }
+
+        // Cross-repo worktree injection from wt_lists_per_repo
+        if pr.repo_id != *active_repo
+            && entry.worktree.is_none()
+            && let Some(wts) = wt_lists_per_repo.get(&pr.repo_id)
+            && let Some(wt) = wts
+                .iter()
+                .find(|w| w.branch.as_deref() == Some(&pr.head_ref))
+        {
+            entry.worktree = Some(wt.clone());
+        }
     }
 
-    // Sort: current branch first, then alphabetical
+    // Sort: active repo first, then RepoId string order; current branch first within active repo
     let mut entries: Vec<BranchEntry> = map.into_values().collect();
     entries.sort_by(|a, b| {
-        let a_current = a.is_current();
-        let b_current = b.is_current();
-        b_current.cmp(&a_current).then(a.name.cmp(&b.name))
+        let a_active = a.repo_id == *active_repo;
+        let b_active = b.repo_id == *active_repo;
+        b_active
+            .cmp(&a_active)
+            .then_with(|| a.repo_id.to_string().cmp(&b.repo_id.to_string()))
+            .then_with(|| {
+                let a_cur = a.is_current();
+                let b_cur = b.is_current();
+                b_cur.cmp(&a_cur)
+            })
+            .then_with(|| a.name.cmp(&b.name))
     });
 
     entries
@@ -434,6 +463,8 @@ mod tests {
 
     #[test]
     fn test_merge_entries_basic() {
+        use crate::git::types::RepoId;
+        let active = RepoId::default();
         let branches = vec![
             Branch {
                 name: "main".to_string(),
@@ -451,7 +482,7 @@ mod tests {
         let worktrees = vec![];
         let prs = vec![];
 
-        let entries = merge_entries(&branches, &worktrees, &prs);
+        let entries = merge_entries(&active, &branches, &worktrees, &prs, &Default::default());
         assert_eq!(entries.len(), 2);
         // Current branch should come first
         assert_eq!(entries[0].name, "main");
@@ -461,6 +492,8 @@ mod tests {
 
     #[test]
     fn test_merge_entries_with_pr() {
+        use crate::git::types::RepoId;
+        let active = RepoId::default();
         let branches = vec![Branch {
             name: "feature-a".to_string(),
             is_current: false,
@@ -468,7 +501,6 @@ mod tests {
             is_merged: false,
         }];
         let worktrees = vec![];
-        use crate::git::types::RepoId;
         let prs = vec![PullRequest {
             number: 42,
             title: "Add feature A".to_string(),
@@ -483,7 +515,7 @@ mod tests {
             repo_id: RepoId::default(),
         }];
 
-        let entries = merge_entries(&branches, &worktrees, &prs);
+        let entries = merge_entries(&active, &branches, &worktrees, &prs, &Default::default());
         assert_eq!(entries.len(), 1);
         assert!(entries[0].local_branch.is_some());
         assert!(entries[0].pull_request.is_some());
@@ -492,9 +524,10 @@ mod tests {
 
     #[test]
     fn test_merge_entries_remote_only_pr() {
+        use crate::git::types::RepoId;
+        let active = RepoId::default();
         let branches = vec![];
         let worktrees = vec![];
-        use crate::git::types::RepoId;
         let prs = vec![PullRequest {
             number: 99,
             title: "Remote only PR".to_string(),
@@ -509,7 +542,7 @@ mod tests {
             repo_id: RepoId::default(),
         }];
 
-        let entries = merge_entries(&branches, &worktrees, &prs);
+        let entries = merge_entries(&active, &branches, &worktrees, &prs, &Default::default());
         assert_eq!(entries.len(), 1);
         assert!(!entries[0].has_local());
         assert!(entries[0].pull_request.is_some());
@@ -517,13 +550,14 @@ mod tests {
 
     #[test]
     fn test_pr_is_merged() {
+        use crate::git::types::RepoId;
+        let active = RepoId::default();
         let branches = vec![Branch {
             name: "feature-a".to_string(),
             is_current: false,
             upstream: None,
             is_merged: false,
         }];
-        use crate::git::types::RepoId;
         let prs = vec![PullRequest {
             number: 10,
             title: "Feature A".to_string(),
@@ -538,7 +572,7 @@ mod tests {
             repo_id: RepoId::default(),
         }];
 
-        let entries = merge_entries(&branches, &[], &prs);
+        let entries = merge_entries(&active, &branches, &[], &prs, &Default::default());
         assert_eq!(entries.len(), 1);
         // git says not merged, but PR says merged
         assert!(!entries[0].is_merged());
@@ -547,13 +581,14 @@ mod tests {
 
     #[test]
     fn test_open_pr_preferred_over_merged() {
+        use crate::git::types::RepoId;
+        let active = RepoId::default();
         let branches = vec![Branch {
             name: "feature-a".to_string(),
             is_current: false,
             upstream: None,
             is_merged: false,
         }];
-        use crate::git::types::RepoId;
         let prs = vec![
             PullRequest {
                 number: 5,
@@ -583,7 +618,7 @@ mod tests {
             },
         ];
 
-        let entries = merge_entries(&branches, &[], &prs);
+        let entries = merge_entries(&active, &branches, &[], &prs, &Default::default());
         assert_eq!(entries.len(), 1);
         // OPEN PR should win over MERGED
         assert_eq!(entries[0].pr_number(), Some(10));
@@ -729,6 +764,139 @@ mod tests {
         });
         let pr = parse_graphql_search_pr(&node).unwrap();
         assert_eq!(pr.repo_id.host.as_deref(), Some("ghe.company.com"));
+    }
+
+    #[test]
+    fn merge_entries_cross_repo_collision() {
+        use crate::git::types::RepoId;
+        let active = RepoId {
+            host: None,
+            owner: "active".into(),
+            name: "repo".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "other".into(),
+            name: "repo".into(),
+        };
+
+        let branches = vec![Branch {
+            name: "feature/auth".to_string(),
+            is_current: false,
+            upstream: None,
+            is_merged: false,
+        }];
+        let prs = vec![
+            PullRequest {
+                number: 1,
+                title: "active PR".into(),
+                author: "a".into(),
+                state: "OPEN".into(),
+                head_ref: "feature/auth".into(),
+                updated_at: "2024".into(),
+                is_draft: false,
+                review_requests: vec![],
+                latest_reviews: vec![],
+                review_status: None,
+                repo_id: active.clone(),
+            },
+            PullRequest {
+                number: 99,
+                title: "other PR".into(),
+                author: "b".into(),
+                state: "OPEN".into(),
+                head_ref: "feature/auth".into(),
+                updated_at: "2024".into(),
+                is_draft: false,
+                review_requests: vec![],
+                latest_reviews: vec![],
+                review_status: None,
+                repo_id: other.clone(),
+            },
+        ];
+        let entries = merge_entries(&active, &branches, &[], &prs, &Default::default());
+        assert_eq!(entries.len(), 2);
+        let active_entry = entries.iter().find(|e| e.repo_id == active).unwrap();
+        assert!(active_entry.local_branch.is_some());
+        assert_eq!(active_entry.pr_number(), Some(1));
+        let other_entry = entries.iter().find(|e| e.repo_id == other).unwrap();
+        assert!(other_entry.local_branch.is_none());
+        assert_eq!(other_entry.pr_number(), Some(99));
+    }
+
+    #[test]
+    fn merge_entries_injects_worktree_from_cross_repo_list() {
+        use crate::git::types::{RepoId, Worktree};
+        let active = RepoId {
+            host: None,
+            owner: "active".into(),
+            name: "repo".into(),
+        };
+        let other = RepoId {
+            host: None,
+            owner: "other".into(),
+            name: "repo".into(),
+        };
+
+        let prs = vec![PullRequest {
+            number: 7,
+            title: "x".into(),
+            author: "u".into(),
+            state: "OPEN".into(),
+            head_ref: "feat/x".into(),
+            updated_at: "2024".into(),
+            is_draft: false,
+            review_requests: vec![],
+            latest_reviews: vec![],
+            review_status: None,
+            repo_id: other.clone(),
+        }];
+        let mut wt_lists = std::collections::HashMap::new();
+        wt_lists.insert(
+            other.clone(),
+            vec![Worktree {
+                path: "/tmp/clones/other/repo/feat/x".into(),
+                head: "abc".into(),
+                branch: Some("feat/x".into()),
+                is_bare: false,
+            }],
+        );
+
+        let entries = merge_entries(&active, &[], &[], &prs, &wt_lists);
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.repo_id, other);
+        assert!(entry.worktree.is_some());
+        assert_eq!(entry.worktree_path(), Some("/tmp/clones/other/repo/feat/x"));
+    }
+
+    #[test]
+    fn merge_entries_single_repo_unchanged_order() {
+        use crate::git::types::RepoId;
+        let active = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "r".into(),
+        };
+        let branches = vec![
+            Branch {
+                name: "main".to_string(),
+                is_current: true,
+                upstream: None,
+                is_merged: false,
+            },
+            Branch {
+                name: "feature".to_string(),
+                is_current: false,
+                upstream: None,
+                is_merged: false,
+            },
+        ];
+        let entries = merge_entries(&active, &branches, &[], &[], &Default::default());
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].name, "main");
+        assert_eq!(entries[1].name, "feature");
+        assert!(entries.iter().all(|e| e.repo_id == active));
     }
 
     #[test]

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -149,7 +149,6 @@ pub async fn run_gh_in(cwd: &Path, args: &[&str]) -> Result<String> {
 }
 
 /// `run_git_in` variant that tags the command-history record with a `RepoId`.
-#[allow(dead_code)]
 pub async fn run_git_in_with_id(
     cwd: &Path,
     repo: Option<crate::git::types::RepoId>,

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -134,7 +134,6 @@ pub async fn run_gh(args: &[&str]) -> Result<String> {
 }
 
 /// Run `git -C <cwd> <args>` for repo-specific operations.
-#[allow(dead_code)]
 pub async fn run_git_in(cwd: &Path, args: &[&str]) -> Result<String> {
     run_git_in_with_id(cwd, None, args).await
 }

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -138,6 +138,10 @@ pub async fn run_git_in(cwd: &Path, args: &[&str]) -> Result<String> {
     run_git_in_with_id(cwd, None, args).await
 }
 
+// TODO(future): run_gh_in / run_gh_in_with_id are scaffolding for cross-repo gh actions
+// (e.g. gh CLI invocations against a specific clone). Used selectively today; v1 doesn't
+// need all of them.
+
 /// Run `gh <args>` with `current_dir(cwd)` for repo-specific operations.
 #[allow(dead_code)]
 pub async fn run_gh_in(cwd: &Path, args: &[&str]) -> Result<String> {

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -1,7 +1,7 @@
 use std::collections::VecDeque;
 use std::fs::{File, OpenOptions};
 use std::io::Write;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
@@ -92,6 +92,8 @@ pub struct CommandRecord {
     /// stdout bytes on success, stderr bytes on failure.
     pub output_bytes: usize,
     pub error: Option<String>,
+    #[allow(dead_code)]
+    pub repo: Option<crate::git::types::RepoId>,
 }
 
 fn history() -> &'static Mutex<VecDeque<CommandRecord>> {
@@ -124,17 +126,58 @@ pub fn command_history_len() -> usize {
 // ---- Command execution ----
 
 pub async fn run_git(args: &[&str]) -> Result<String> {
-    run_cmd("git", args).await
+    run_cmd_tagged("git", args, None).await
 }
 
 pub async fn run_gh(args: &[&str]) -> Result<String> {
-    run_cmd("gh", args).await
+    run_cmd_tagged("gh", args, None).await
+}
+
+/// Run `git -C <cwd> <args>` for repo-specific operations.
+#[allow(dead_code)]
+pub async fn run_git_in(cwd: &Path, args: &[&str]) -> Result<String> {
+    run_git_in_with_id(cwd, None, args).await
+}
+
+/// Run `gh <args>` with `current_dir(cwd)` for repo-specific operations.
+#[allow(dead_code)]
+pub async fn run_gh_in(cwd: &Path, args: &[&str]) -> Result<String> {
+    run_gh_in_with_id(cwd, None, args).await
+}
+
+/// `run_git_in` variant that tags the command-history record with a `RepoId`.
+#[allow(dead_code)]
+pub async fn run_git_in_with_id(
+    cwd: &Path,
+    repo: Option<crate::git::types::RepoId>,
+    args: &[&str],
+) -> Result<String> {
+    let cwd_str = cwd.to_string_lossy().to_string();
+    let mut full = Vec::with_capacity(args.len() + 2);
+    full.push("-C");
+    full.push(cwd_str.as_str());
+    full.extend_from_slice(args);
+    run_cmd_tagged("git", &full, repo).await
+}
+
+/// `run_gh_in` variant that tags the command-history record with a `RepoId`.
+#[allow(dead_code)]
+pub async fn run_gh_in_with_id(
+    cwd: &Path,
+    repo: Option<crate::git::types::RepoId>,
+    args: &[&str],
+) -> Result<String> {
+    run_cmd_in_dir_tagged("gh", cwd, args, repo).await
 }
 
 /// Shared execution path for `run_git`/`run_gh`:
 /// - logs to the debug file if enabled
 /// - records a `CommandRecord` in the in-memory history buffer
-async fn run_cmd(executable: &'static str, args: &[&str]) -> Result<String> {
+async fn run_cmd_tagged(
+    executable: &'static str,
+    args: &[&str],
+    repo: Option<crate::git::types::RepoId>,
+) -> Result<String> {
     // Initialize session start lazily; cheap and idempotent.
     let _ = session_start();
     debug_log(&format!("$ {executable} {}", args.join(" ")));
@@ -152,6 +195,7 @@ async fn run_cmd(executable: &'static str, args: &[&str]) -> Result<String> {
                 duration: started_at.elapsed(),
                 output_bytes: 0,
                 error: Some(format!("spawn failed: {e}")),
+                repo,
             });
             return Err(anyhow::Error::new(e))
                 .with_context(|| format!("failed to execute {executable}"));
@@ -171,6 +215,7 @@ async fn run_cmd(executable: &'static str, args: &[&str]) -> Result<String> {
             duration,
             output_bytes: output.stderr.len(),
             error: Some(stderr.clone()),
+            repo,
         });
         bail!("{executable} {} failed: {stderr}", owned_args.join(" "));
     }
@@ -185,6 +230,113 @@ async fn run_cmd(executable: &'static str, args: &[&str]) -> Result<String> {
         duration,
         output_bytes: stdout.len(),
         error: None,
+        repo,
     });
     Ok(stdout)
+}
+
+/// Like `run_cmd_tagged` but sets `current_dir` on the spawned process.
+#[allow(dead_code)]
+async fn run_cmd_in_dir_tagged(
+    executable: &'static str,
+    cwd: &Path,
+    args: &[&str],
+    repo: Option<crate::git::types::RepoId>,
+) -> Result<String> {
+    let _ = session_start();
+    debug_log(&format!(
+        "$ {executable} {} [cwd={}]",
+        args.join(" "),
+        cwd.display()
+    ));
+    let started_at = Instant::now();
+    let owned_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
+
+    let output = match Command::new(executable)
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            push_record(CommandRecord {
+                started_at,
+                executable,
+                args: owned_args,
+                success: false,
+                duration: started_at.elapsed(),
+                output_bytes: 0,
+                error: Some(format!("spawn failed: {e}")),
+                repo,
+            });
+            return Err(anyhow::Error::new(e))
+                .with_context(|| format!("failed to execute {executable}"));
+        }
+    };
+
+    let duration = started_at.elapsed();
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        debug_log(&format!("  → FAIL: {stderr}"));
+        push_record(CommandRecord {
+            started_at,
+            executable,
+            args: owned_args.clone(),
+            success: false,
+            duration,
+            output_bytes: output.stderr.len(),
+            error: Some(stderr.clone()),
+            repo,
+        });
+        bail!("{executable} {} failed: {stderr}", owned_args.join(" "));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    debug_log(&format!("  → OK ({} bytes)", stdout.len()));
+    push_record(CommandRecord {
+        started_at,
+        executable,
+        args: owned_args,
+        success: true,
+        duration,
+        output_bytes: stdout.len(),
+        error: None,
+        repo,
+    });
+    Ok(stdout)
+}
+
+#[cfg(test)]
+mod plumbing_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn run_git_in_uses_cwd() {
+        let cwd = std::env::current_dir().unwrap();
+        let result = run_git_in(&cwd, &["rev-parse", "--show-toplevel"]).await;
+        let toplevel = result.expect("git -C should succeed");
+        let expected = std::fs::canonicalize(&cwd).unwrap();
+        let actual = std::fs::canonicalize(toplevel.trim()).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[tokio::test]
+    async fn run_git_in_records_repo_when_provided() {
+        let cwd = std::env::current_dir().unwrap();
+        let _ = run_git_in_with_id(
+            &cwd,
+            Some(crate::git::types::RepoId {
+                host: None,
+                owner: "katzkb".into(),
+                name: "git-control-tower".into(),
+            }),
+            &["--version"],
+        )
+        .await;
+        let history = command_history_snapshot();
+        let last = history.first().expect("history should have an entry");
+        assert!(last.repo.is_some());
+    }
 }

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use serde::Deserialize;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct RepoId {
     /// `None` means github.com (canonical default for GitHub Enterprise omitted).
     pub host: Option<String>,
@@ -81,6 +81,8 @@ pub struct PullRequest {
     pub latest_reviews: Vec<LatestReview>,
     #[serde(skip)]
     pub review_status: Option<ReviewStatus>,
+    #[serde(skip)]
+    pub repo_id: RepoId,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -1,4 +1,23 @@
+use std::fmt;
+
 use serde::Deserialize;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct RepoId {
+    /// `None` means github.com (canonical default for GitHub Enterprise omitted).
+    pub host: Option<String>,
+    pub owner: String,
+    pub name: String,
+}
+
+impl fmt::Display for RepoId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.host {
+            None => write!(f, "{}/{}", self.owner, self.name),
+            Some(host) => write!(f, "{}/{}@{}", self.owner, self.name, host),
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum ReviewStatus {
@@ -156,4 +175,53 @@ pub struct GitStatus {
     pub staged: Vec<String>,
     pub ahead: u32,
     pub behind: u32,
+}
+
+#[cfg(test)]
+mod repo_id_tests {
+    use super::*;
+
+    #[test]
+    fn display_github_dot_com() {
+        let id = RepoId {
+            host: None,
+            owner: "katzkb".into(),
+            name: "git-control-tower".into(),
+        };
+        assert_eq!(id.to_string(), "katzkb/git-control-tower");
+    }
+
+    #[test]
+    fn display_ghe_host() {
+        let id = RepoId {
+            host: Some("ghe.company.com".into()),
+            owner: "org".into(),
+            name: "repo".into(),
+        };
+        assert_eq!(id.to_string(), "org/repo@ghe.company.com");
+    }
+
+    #[test]
+    fn equality_and_hash() {
+        use std::collections::HashSet;
+        let a = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "b".into(),
+        };
+        let b = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "b".into(),
+        };
+        let c = RepoId {
+            host: None,
+            owner: "a".into(),
+            name: "c".into(),
+        };
+        let mut set = HashSet::new();
+        set.insert(a);
+        assert!(set.contains(&b));
+        assert!(!set.contains(&c));
+    }
 }

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -19,6 +19,16 @@ impl fmt::Display for RepoId {
     }
 }
 
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct RepoMeta {
+    pub id: RepoId,
+    /// Resolved lazily on first selection. `None` after `resolved == true`
+    /// means we tried but the clone path doesn't exist.
+    pub local_path: Option<std::path::PathBuf>,
+    pub local_path_resolved: bool,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ReviewStatus {
     NeedsReview,

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -20,9 +20,7 @@ impl fmt::Display for RepoId {
 }
 
 #[derive(Debug, Clone)]
-#[allow(dead_code)]
 pub struct RepoMeta {
-    pub id: RepoId,
     /// Resolved lazily on first selection. `None` after `local_path_resolved == true`
     /// means we tried but the clone path doesn't exist.
     pub local_path: Option<std::path::PathBuf>,

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -23,7 +23,7 @@ impl fmt::Display for RepoId {
 #[allow(dead_code)]
 pub struct RepoMeta {
     pub id: RepoId,
-    /// Resolved lazily on first selection. `None` after `resolved == true`
+    /// Resolved lazily on first selection. `None` after `local_path_resolved == true`
     /// means we tried but the clone path doesn't exist.
     pub local_path: Option<std::path::PathBuf>,
     pub local_path_resolved: bool,

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -146,6 +146,7 @@ pub struct Worktree {
 #[derive(Debug, Clone)]
 pub struct BranchEntry {
     pub name: String,
+    pub repo_id: RepoId,
     pub local_branch: Option<Branch>,
     pub worktree: Option<Worktree>,
     pub pull_request: Option<PullRequest>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1042,9 +1042,13 @@ async fn run(
         }
 
         // Create worktree if requested (async, non-blocking)
-        if let Some(branch_name) = app.wt_create_requested.take() {
+        if let Some((req_repo_id, branch_name)) = app.wt_create_requested.take() {
             // Resolve target repo (active or cross-repo) and its root path.
-            let entry = app.entries.iter().find(|e| e.name == branch_name).cloned();
+            let entry = app
+                .entries
+                .iter()
+                .find(|e| e.repo_id == req_repo_id && e.name == branch_name)
+                .cloned();
             let Some(entry) = entry else {
                 continue;
             };

--- a/src/main.rs
+++ b/src/main.rs
@@ -419,7 +419,6 @@ async fn run(
         app.repos
             .entry(id.clone())
             .or_insert_with(|| crate::git::types::RepoMeta {
-                id,
                 local_path: active_root.clone(),
                 local_path_resolved: true,
             });
@@ -1470,7 +1469,6 @@ fn seed_repos_from_prs(
         repos
             .entry(pr.repo_id.clone())
             .or_insert_with(|| crate::git::types::RepoMeta {
-                id: pr.repo_id.clone(),
                 local_path: None,
                 local_path_resolved: false,
             });

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,7 @@ use crate::data::merge_entries;
 use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git};
 use crate::git::parser::{parse_branches, parse_log, parse_worktrees};
-use crate::git::types::{GitStatus, PrDetail, PullRequest, ReviewStatus};
+use crate::git::types::{GitStatus, PrDetail, PullRequest, RepoId, ReviewStatus};
 use crate::ui::notification::Notification;
 
 /// Args used for fetching commits in the Log view (startup + `r` refresh).
@@ -39,12 +39,6 @@ const LOG_ARGS: &[&str] = &[
     "-n",
     "200",
 ];
-
-struct RepoInfo {
-    owner: String,
-    repo: String,
-    hostname: Option<String>, // None for github.com
-}
 
 enum AsyncResult {
     PrDetail(PrDetail),
@@ -410,7 +404,7 @@ async fn run(
     app.request_details_for_selection();
 
     // Phase 2: Slow network loads (background, non-blocking)
-    let gh_hostname = repo_info.as_ref().and_then(|r| r.hostname.clone());
+    let gh_hostname = repo_info.as_ref().and_then(|r| r.host.clone());
 
     let tx_user = tx.clone();
     let hostname_for_user = gh_hostname.clone();
@@ -444,8 +438,8 @@ async fn run(
         let tx_local = tx.clone();
         let branch_names: Vec<String> = app.branches.iter().map(|b| b.name.clone()).collect();
         let owner = info.owner.clone();
-        let repo = info.repo.clone();
-        let hostname = info.hostname.clone();
+        let repo = info.name.clone();
+        let hostname = info.host.clone();
         tokio::spawn(async move {
             let (prs, errors) =
                 data::fetch_local_prs(&branch_names, &owner, &repo, hostname.as_deref()).await;
@@ -549,8 +543,8 @@ async fn run(
                         let branch_names: Vec<String> =
                             app.branches.iter().map(|b| b.name.clone()).collect();
                         let owner = info.owner.clone();
-                        let repo = info.repo.clone();
-                        let hostname = info.hostname.clone();
+                        let repo = info.name.clone();
+                        let hostname = info.host.clone();
                         tokio::spawn(async move {
                             let (prs, errors) = data::fetch_local_prs(
                                 &branch_names,
@@ -1287,8 +1281,8 @@ fn compute_review_status(pr: &PullRequest, gh_user: &str) -> ReviewStatus {
     ReviewStatus::NeedsReview
 }
 
-/// Extract owner, repo, and hostname from a git remote URL.
-fn extract_repo_info(remote_url: &str) -> Option<RepoInfo> {
+/// Parse a git remote URL into a `RepoId` (owner, name, host).
+fn extract_repo_info(remote_url: &str) -> Option<RepoId> {
     let hostname = extract_gh_hostname(remote_url)?;
     let gh_hostname = if hostname == "github.com" {
         None
@@ -1326,10 +1320,10 @@ fn extract_repo_info(remote_url: &str) -> Option<RepoInfo> {
         return None;
     }
 
-    Some(RepoInfo {
+    Some(RepoId {
         owner: parts[0].to_string(),
-        repo: parts[1].to_string(),
-        hostname: gh_hostname,
+        name: parts[1].to_string(),
+        host: gh_hostname,
     })
 }
 
@@ -1429,40 +1423,40 @@ mod tests {
     fn test_extract_repo_info_ssh() {
         let info = extract_repo_info("git@github.com:katzkb/repo.git").unwrap();
         assert_eq!(info.owner, "katzkb");
-        assert_eq!(info.repo, "repo");
-        assert!(info.hostname.is_none()); // github.com → None
+        assert_eq!(info.name, "repo");
+        assert!(info.host.is_none()); // github.com → None
     }
 
     #[test]
     fn test_extract_repo_info_ghe() {
         let info = extract_repo_info("git@ghe.company.com:org/repo.git").unwrap();
         assert_eq!(info.owner, "org");
-        assert_eq!(info.repo, "repo");
-        assert_eq!(info.hostname.as_deref(), Some("ghe.company.com"));
+        assert_eq!(info.name, "repo");
+        assert_eq!(info.host.as_deref(), Some("ghe.company.com"));
     }
 
     #[test]
     fn test_extract_repo_info_https() {
         let info = extract_repo_info("https://github.com/katzkb/repo.git").unwrap();
         assert_eq!(info.owner, "katzkb");
-        assert_eq!(info.repo, "repo");
-        assert!(info.hostname.is_none());
+        assert_eq!(info.name, "repo");
+        assert!(info.host.is_none());
     }
 
     #[test]
     fn test_extract_repo_info_ssh_url() {
         let info = extract_repo_info("ssh://git@ghe.company.com/org/repo.git").unwrap();
         assert_eq!(info.owner, "org");
-        assert_eq!(info.repo, "repo");
-        assert_eq!(info.hostname.as_deref(), Some("ghe.company.com"));
+        assert_eq!(info.name, "repo");
+        assert_eq!(info.host.as_deref(), Some("ghe.company.com"));
     }
 
     #[test]
     fn test_extract_repo_info_ssh_url_with_port() {
         let info = extract_repo_info("ssh://git@ghe.company.com:2222/org/repo.git").unwrap();
         assert_eq!(info.owner, "org");
-        assert_eq!(info.repo, "repo");
-        assert_eq!(info.hostname.as_deref(), Some("ghe.company.com"));
+        assert_eq!(info.name, "repo");
+        assert_eq!(info.host.as_deref(), Some("ghe.company.com"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -414,6 +414,17 @@ async fn run(
     }
     .or_else(|| app.config.workspace.clone_root_expanded());
 
+    // Seed repos with the active repo immediately (local_path and resolved flag known now).
+    if let Some(id) = app.active_repo.clone() {
+        app.repos
+            .entry(id.clone())
+            .or_insert_with(|| crate::git::types::RepoMeta {
+                id,
+                local_path: active_root.clone(),
+                local_path_resolved: true,
+            });
+    }
+
     // Phase 1: Fast local loads (blocking, ~170ms)
     if let Ok(output) = run_git(LOG_ARGS).await {
         app.commits = parse_log(&output);
@@ -725,6 +736,15 @@ async fn run(
                             }
                         }
                     }
+                    for pr in &app.local_prs {
+                        app.repos.entry(pr.repo_id.clone()).or_insert_with(|| {
+                            crate::git::types::RepoMeta {
+                                id: pr.repo_id.clone(),
+                                local_path: None,
+                                local_path_resolved: false,
+                            }
+                        });
+                    }
                     if app.main_filter == MainFilter::Local {
                         let active = app.active_repo.clone().unwrap_or_default();
                         app.entries = merge_entries(
@@ -750,6 +770,15 @@ async fn run(
                                 app.verbose_errors.push(e);
                             }
                         }
+                    }
+                    for pr in &app.my_prs {
+                        app.repos.entry(pr.repo_id.clone()).or_insert_with(|| {
+                            crate::git::types::RepoMeta {
+                                id: pr.repo_id.clone(),
+                                local_path: None,
+                                local_path_resolved: false,
+                            }
+                        });
                     }
                     if app.main_filter == MainFilter::MyPr {
                         let active = app.active_repo.clone().unwrap_or_default();
@@ -779,6 +808,15 @@ async fn run(
                                 app.verbose_errors.push(e);
                             }
                         }
+                    }
+                    for pr in &app.review_prs {
+                        app.repos.entry(pr.repo_id.clone()).or_insert_with(|| {
+                            crate::git::types::RepoMeta {
+                                id: pr.repo_id.clone(),
+                                local_path: None,
+                                local_path_resolved: false,
+                            }
+                        });
                     }
                     if app.main_filter == MainFilter::ReviewRequested {
                         let active = app.active_repo.clone().unwrap_or_default();

--- a/src/main.rs
+++ b/src/main.rs
@@ -387,6 +387,21 @@ async fn run(
     let mut pr_inflight: HashSet<u64> = HashSet::new();
     let mut status_inflight: HashSet<String> = HashSet::new();
 
+    let active_root = run_git(&["rev-parse", "--show-toplevel"])
+        .await
+        .ok()
+        .map(|s| std::path::PathBuf::from(s.trim()));
+    let active_id = run_git(&["remote", "get-url", "origin"])
+        .await
+        .ok()
+        .and_then(|url| extract_repo_info(url.trim()));
+    app.active_repo = active_id.clone();
+    app.clone_root = match (&active_root, &active_id) {
+        (Some(p), Some(id)) => infer_clone_root(p, id),
+        _ => None,
+    }
+    .or_else(|| app.config.workspace.clone_root_expanded());
+
     // Phase 1: Fast local loads (blocking, ~170ms)
     if let Ok(output) = run_git(LOG_ARGS).await {
         app.commits = parse_log(&output);
@@ -395,10 +410,7 @@ async fn run(
         app.worktrees = parse_worktrees(&output);
     }
     load_branches(&mut app).await;
-    let repo_info = run_git(&["remote", "get-url", "origin"])
-        .await
-        .ok()
-        .and_then(|url| extract_repo_info(url.trim()));
+    let repo_info = active_id;
     app.entries = merge_entries(&app.branches, &app.worktrees, &[]);
     app.entries_loaded = true;
     app.request_details_for_selection();
@@ -1327,6 +1339,33 @@ fn extract_repo_info(remote_url: &str) -> Option<RepoId> {
     })
 }
 
+/// If `local_path` ends with `<…>/<host>/<owner>/<name>`, strip that suffix
+/// and return the prefix. `RepoId.host == None` is treated as `github.com`
+/// for the purpose of suffix matching.
+fn infer_clone_root(
+    local_path: &std::path::Path,
+    repo_id: &crate::git::types::RepoId,
+) -> Option<std::path::PathBuf> {
+    let host = repo_id.host.as_deref().unwrap_or("github.com");
+    let mut comps: Vec<&std::ffi::OsStr> = local_path.iter().collect();
+    if comps.len() < 3 {
+        return None;
+    }
+    let last = comps.pop()?;
+    let owner = comps.pop()?;
+    let host_seg = comps.pop()?;
+    if last != std::ffi::OsStr::new(repo_id.name.as_str()) {
+        return None;
+    }
+    if owner != std::ffi::OsStr::new(repo_id.owner.as_str()) {
+        return None;
+    }
+    if host_seg != std::ffi::OsStr::new(host) {
+        return None;
+    }
+    Some(comps.iter().collect::<std::path::PathBuf>())
+}
+
 /// Extract the hostname from a git remote URL.
 /// Returns None for unrecognized formats.
 fn extract_gh_hostname(remote_url: &str) -> Option<String> {
@@ -1365,6 +1404,44 @@ fn extract_gh_hostname(remote_url: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn infer_clone_root_ghq_layout() {
+        use std::path::PathBuf;
+        let local = PathBuf::from("/Users/me/workspace/github.com/owner/repo");
+        let id = RepoId {
+            host: None,
+            owner: "owner".into(),
+            name: "repo".into(),
+        };
+        let root = infer_clone_root(&local, &id).expect("should strip suffix");
+        assert_eq!(root, PathBuf::from("/Users/me/workspace"));
+    }
+
+    #[test]
+    fn infer_clone_root_ghe_layout() {
+        use std::path::PathBuf;
+        let local = PathBuf::from("/work/ghe.company.com/team/svc");
+        let id = RepoId {
+            host: Some("ghe.company.com".into()),
+            owner: "team".into(),
+            name: "svc".into(),
+        };
+        let root = infer_clone_root(&local, &id).expect("should strip suffix");
+        assert_eq!(root, PathBuf::from("/work"));
+    }
+
+    #[test]
+    fn infer_clone_root_mismatch_returns_none() {
+        use std::path::PathBuf;
+        let local = PathBuf::from("/Users/me/somewhere/repo-x");
+        let id = RepoId {
+            host: None,
+            owner: "owner".into(),
+            name: "repo-x".into(),
+        };
+        assert!(infer_clone_root(&local, &id).is_none());
+    }
 
     #[test]
     fn test_extract_hostname_ssh() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1263,6 +1263,7 @@ async fn refresh_entries(app: &mut App) {
     if app.sidebar_scroll >= filtered_len && filtered_len > 0 {
         app.sidebar_scroll = filtered_len - 1;
     }
+    app.snap_scroll_to_entry();
 }
 
 async fn load_branches(app: &mut App) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -736,15 +736,7 @@ async fn run(
                             }
                         }
                     }
-                    for pr in &app.local_prs {
-                        app.repos.entry(pr.repo_id.clone()).or_insert_with(|| {
-                            crate::git::types::RepoMeta {
-                                id: pr.repo_id.clone(),
-                                local_path: None,
-                                local_path_resolved: false,
-                            }
-                        });
-                    }
+                    seed_repos_from_prs(&mut app.repos, &app.local_prs);
                     if app.main_filter == MainFilter::Local {
                         let active = app.active_repo.clone().unwrap_or_default();
                         app.entries = merge_entries(
@@ -771,15 +763,7 @@ async fn run(
                             }
                         }
                     }
-                    for pr in &app.my_prs {
-                        app.repos.entry(pr.repo_id.clone()).or_insert_with(|| {
-                            crate::git::types::RepoMeta {
-                                id: pr.repo_id.clone(),
-                                local_path: None,
-                                local_path_resolved: false,
-                            }
-                        });
-                    }
+                    seed_repos_from_prs(&mut app.repos, &app.my_prs);
                     if app.main_filter == MainFilter::MyPr {
                         let active = app.active_repo.clone().unwrap_or_default();
                         app.entries = merge_entries(
@@ -809,15 +793,7 @@ async fn run(
                             }
                         }
                     }
-                    for pr in &app.review_prs {
-                        app.repos.entry(pr.repo_id.clone()).or_insert_with(|| {
-                            crate::git::types::RepoMeta {
-                                id: pr.repo_id.clone(),
-                                local_path: None,
-                                local_path_resolved: false,
-                            }
-                        });
-                    }
+                    seed_repos_from_prs(&mut app.repos, &app.review_prs);
                     if app.main_filter == MainFilter::ReviewRequested {
                         let active = app.active_repo.clone().unwrap_or_default();
                         app.entries = merge_entries(
@@ -1474,6 +1450,24 @@ fn copy_via_osc52(text: &str) {
     if let Ok(mut tty) = std::fs::OpenOptions::new().write(true).open("/dev/tty") {
         let _ = tty.write_all(osc52.as_bytes());
         let _ = tty.flush();
+    }
+}
+
+/// Seed `repos` map with stub entries for every repo referenced by `prs`.
+/// Called after each PR list arrives from the network so that cross-repo
+/// entries have a `RepoMeta` record even before a clone is resolved.
+fn seed_repos_from_prs(
+    repos: &mut std::collections::HashMap<crate::git::types::RepoId, crate::git::types::RepoMeta>,
+    prs: &[PullRequest],
+) {
+    for pr in prs {
+        repos
+            .entry(pr.repo_id.clone())
+            .or_insert_with(|| crate::git::types::RepoMeta {
+                id: pr.repo_id.clone(),
+                local_path: None,
+                local_path_resolved: false,
+            });
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,7 +411,14 @@ async fn run(
     }
     load_branches(&mut app).await;
     let repo_info = active_id;
-    app.entries = merge_entries(&app.branches, &app.worktrees, &[]);
+    let active = app.active_repo.clone().unwrap_or_default();
+    app.entries = merge_entries(
+        &active,
+        &app.branches,
+        &app.worktrees,
+        &[],
+        &app.wt_lists_per_repo,
+    );
     app.entries_loaded = true;
     app.request_details_for_selection();
 
@@ -663,8 +670,14 @@ async fn run(
                         }
                     }
                     if app.main_filter == MainFilter::Local {
-                        app.entries =
-                            merge_entries(&app.branches, &app.worktrees, app.current_prs());
+                        let active = app.active_repo.clone().unwrap_or_default();
+                        app.entries = merge_entries(
+                            &active,
+                            &app.branches,
+                            &app.worktrees,
+                            app.current_prs(),
+                            &app.wt_lists_per_repo,
+                        );
                         let filtered_len = app.filtered_entries().len();
                         if app.sidebar_scroll >= filtered_len && filtered_len > 0 {
                             app.sidebar_scroll = filtered_len - 1;
@@ -683,8 +696,14 @@ async fn run(
                         }
                     }
                     if app.main_filter == MainFilter::MyPr {
-                        app.entries =
-                            merge_entries(&app.branches, &app.worktrees, app.current_prs());
+                        let active = app.active_repo.clone().unwrap_or_default();
+                        app.entries = merge_entries(
+                            &active,
+                            &app.branches,
+                            &app.worktrees,
+                            app.current_prs(),
+                            &app.wt_lists_per_repo,
+                        );
                         let filtered_len = app.filtered_entries().len();
                         if app.sidebar_scroll >= filtered_len && filtered_len > 0 {
                             app.sidebar_scroll = filtered_len - 1;
@@ -706,8 +725,14 @@ async fn run(
                         }
                     }
                     if app.main_filter == MainFilter::ReviewRequested {
-                        app.entries =
-                            merge_entries(&app.branches, &app.worktrees, app.current_prs());
+                        let active = app.active_repo.clone().unwrap_or_default();
+                        app.entries = merge_entries(
+                            &active,
+                            &app.branches,
+                            &app.worktrees,
+                            app.current_prs(),
+                            &app.wt_lists_per_repo,
+                        );
                         let filtered_len = app.filtered_entries().len();
                         if app.sidebar_scroll >= filtered_len && filtered_len > 0 {
                             app.sidebar_scroll = filtered_len - 1;
@@ -1081,7 +1106,14 @@ async fn refresh_entries(app: &mut App) {
             }
         }
     }
-    app.entries = merge_entries(&app.branches, &app.worktrees, app.current_prs());
+    let active = app.active_repo.clone().unwrap_or_default();
+    app.entries = merge_entries(
+        &active,
+        &app.branches,
+        &app.worktrees,
+        app.current_prs(),
+        &app.wt_lists_per_repo,
+    );
     let filtered_len = app.filtered_entries().len();
     if app.sidebar_scroll >= filtered_len && filtered_len > 0 {
         app.sidebar_scroll = filtered_len - 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1543,6 +1543,7 @@ mod tests {
 
     #[test]
     fn test_compute_review_status_no_user() {
+        use crate::git::types::RepoId;
         let pr = PullRequest {
             number: 1,
             title: String::new(),
@@ -1554,13 +1555,14 @@ mod tests {
             is_draft: false,
             latest_reviews: vec![],
             review_status: None,
+            repo_id: RepoId::default(),
         };
         assert_eq!(compute_review_status(&pr, ""), ReviewStatus::NeedsReview);
     }
 
     #[test]
     fn test_compute_review_status_no_matching_review() {
-        use crate::git::types::LatestReview;
+        use crate::git::types::{LatestReview, RepoId};
         let pr = PullRequest {
             number: 1,
             title: String::new(),
@@ -1575,6 +1577,7 @@ mod tests {
                 state: "APPROVED".to_string(),
             }],
             review_status: None,
+            repo_id: RepoId::default(),
         };
         assert_eq!(
             compute_review_status(&pr, "katzkb"),
@@ -1584,7 +1587,7 @@ mod tests {
 
     #[test]
     fn test_compute_review_status_approved() {
-        use crate::git::types::LatestReview;
+        use crate::git::types::{LatestReview, RepoId};
         let pr = PullRequest {
             number: 1,
             title: String::new(),
@@ -1599,13 +1602,14 @@ mod tests {
                 state: "APPROVED".to_string(),
             }],
             review_status: None,
+            repo_id: RepoId::default(),
         };
         assert_eq!(compute_review_status(&pr, "katzkb"), ReviewStatus::Approved);
     }
 
     #[test]
     fn test_compute_review_status_changes_requested() {
-        use crate::git::types::LatestReview;
+        use crate::git::types::{LatestReview, RepoId};
         let pr = PullRequest {
             number: 1,
             title: String::new(),
@@ -1620,6 +1624,7 @@ mod tests {
                 state: "CHANGES_REQUESTED".to_string(),
             }],
             review_status: None,
+            repo_id: RepoId::default(),
         };
         assert_eq!(
             compute_review_status(&pr, "katzkb"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,7 +26,7 @@ use crate::app::MainFilter;
 use crate::app::{OpProgress, OpStep};
 use crate::data::merge_entries;
 use crate::event::{Event, EventHandler};
-use crate::git::command::{run_gh, run_git};
+use crate::git::command::{run_gh, run_git, run_git_in};
 use crate::git::parser::{parse_branches, parse_log, parse_worktrees};
 use crate::git::types::{GitStatus, PrDetail, PullRequest, RepoId, ReviewStatus};
 use crate::ui::notification::Notification;
@@ -63,6 +63,7 @@ enum AsyncResult {
     WtCreated {
         wt_path: String,
         copy_errors: Vec<String>,
+        target_repo: Option<crate::git::types::RepoId>,
     },
     WtCreateError {
         wt_path: String,
@@ -767,6 +768,7 @@ async fn run(
                 AsyncResult::WtCreated {
                     wt_path,
                     copy_errors,
+                    target_repo,
                 } => {
                     app.wt_inflight.remove(&wt_path);
                     if copy_errors.is_empty() {
@@ -783,6 +785,10 @@ async fn run(
                         }
                     }
                     refresh_entries(&mut app).await;
+                    // Cross-repo: invalidate worktree-list cache for target so next selection re-fetches.
+                    if let Some(repo_id) = target_repo {
+                        app.wt_lists_per_repo.remove(&repo_id);
+                    }
                     if app.confirm_dialog.is_none() {
                         app.confirm_dialog = Some(crate::ui::confirm_dialog::ConfirmDialog::new(
                             "Move to Worktree",
@@ -962,39 +968,90 @@ async fn run(
 
         // Create worktree if requested (async, non-blocking)
         if let Some(branch_name) = app.wt_create_requested.take() {
-            let wt_path = app.config.worktree_path(&branch_name);
+            // Resolve target repo (active or cross-repo) and its root path.
+            let entry = app.entries.iter().find(|e| e.name == branch_name).cloned();
+            let Some(entry) = entry else {
+                continue;
+            };
+            let target_repo = entry.repo_id.clone();
+            let active_repo = app.active_repo.clone();
+            let is_active = active_repo.as_ref() == Some(&target_repo);
+
+            let target_root: std::path::PathBuf = if is_active {
+                run_git(&["rev-parse", "--show-toplevel"])
+                    .await
+                    .map(|s| std::path::PathBuf::from(s.trim()))
+                    .unwrap_or_else(|_| std::env::current_dir().unwrap_or_default())
+            } else {
+                // cross-repo: must have resolved local_path
+                match app
+                    .repos
+                    .get(&target_repo)
+                    .and_then(|m| m.local_path.clone())
+                {
+                    Some(p) => p,
+                    None => {
+                        app.notification =
+                            Some(Notification::error(format!("{target_repo} not cloned")));
+                        continue;
+                    }
+                }
+            };
+
+            let wt_path = app.config.worktree_path_for(&target_root, &branch_name);
             app.wt_inflight.insert(wt_path.clone());
             if let Some(parent) = std::path::Path::new(&wt_path).parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
-            let has_local = app.branches.iter().any(|b| b.name == branch_name);
+
+            let is_active_with_local =
+                is_active && app.branches.iter().any(|b| b.name == branch_name);
             let post_create = app.config.worktree.post_create.clone();
+            let target_repo_for_send = if is_active {
+                None
+            } else {
+                Some(target_repo.clone())
+            };
             let tx = tx.clone();
+            let wt_path_arg = wt_path.clone();
+            let branch_arg = branch_name.clone();
+            let target_root_arg = target_root.clone();
+
             tokio::spawn(async move {
-                let result = if has_local {
-                    run_git(&["worktree", "add", &wt_path, &branch_name]).await
+                let result = if is_active_with_local {
+                    run_git_in(
+                        &target_root_arg,
+                        &["worktree", "add", &wt_path_arg, &branch_arg],
+                    )
+                    .await
                 } else {
-                    match run_git(&["fetch", "origin", &branch_name]).await {
-                        Ok(_) => run_git(&["worktree", "add", &wt_path, &branch_name]).await,
+                    match run_git_in(&target_root_arg, &["fetch", "origin", &branch_arg]).await {
+                        Ok(_) => {
+                            run_git_in(
+                                &target_root_arg,
+                                &["worktree", "add", &wt_path_arg, &branch_arg],
+                            )
+                            .await
+                        }
                         Err(e) => Err(e),
                     }
                 };
                 match result {
                     Ok(_) => {
-                        let repo_root = std::env::current_dir().unwrap_or_default();
                         let copy_errors = config::run_post_create(
                             &post_create,
-                            &repo_root,
-                            std::path::Path::new(&wt_path),
+                            &target_root_arg,
+                            std::path::Path::new(&wt_path_arg),
                         );
                         let _ = tx.send(AsyncResult::WtCreated {
-                            wt_path,
+                            wt_path: wt_path_arg,
                             copy_errors,
+                            target_repo: target_repo_for_send,
                         });
                     }
                     Err(e) => {
                         let _ = tx.send(AsyncResult::WtCreateError {
-                            wt_path,
+                            wt_path: wt_path_arg,
                             message: format!("Failed to create worktree: {e}"),
                         });
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,8 +41,15 @@ const LOG_ARGS: &[&str] = &[
 ];
 
 enum AsyncResult {
-    PrDetail(PrDetail),
-    PrDetailError(u64, String),
+    PrDetail {
+        repo_id: crate::git::types::RepoId,
+        detail: PrDetail,
+    },
+    PrDetailError {
+        repo_id: crate::git::types::RepoId,
+        number: u64,
+        error: String,
+    },
     GitStatus {
         wt_path: String,
         status: GitStatus,
@@ -384,7 +391,7 @@ async fn run(
     app.verbose = verbose;
     let mut events = EventHandler::new(Duration::from_millis(80));
     let (tx, mut rx) = mpsc::unbounded_channel::<AsyncResult>();
-    let mut pr_inflight: HashSet<u64> = HashSet::new();
+    let mut pr_inflight: HashSet<(crate::git::types::RepoId, u64)> = HashSet::new();
     let mut status_inflight: HashSet<String> = HashSet::new();
 
     let active_root = run_git(&["rev-parse", "--show-toplevel"])
@@ -487,38 +494,50 @@ async fn run(
         }
 
         // Spawn PR detail load in background (non-blocking, deduplicated)
-        if let Some(number) = app.pr_detail_requested.take()
-            && !pr_inflight.contains(&number)
+        if let Some((repo_id, number)) = app.pr_detail_requested.take()
+            && !pr_inflight.contains(&(repo_id.clone(), number))
         {
-            pr_inflight.insert(number);
+            pr_inflight.insert((repo_id.clone(), number));
             let tx = tx.clone();
+            let repo_arg = format!("{}/{}", repo_id.owner, repo_id.name);
             tokio::spawn(async move {
                 let num_str = number.to_string();
-                let result = run_gh(&[
+                let mut args = vec![
                     "pr",
                     "view",
                     &num_str,
+                    "--repo",
+                    repo_arg.as_str(),
                     "--json",
                     "number,title,author,state,body,additions,deletions,headRefName",
-                ])
-                .await;
+                ];
+                // For GHE hosts, add --hostname
+                let hostname_buf;
+                if let Some(h) = &repo_id.host {
+                    hostname_buf = h.clone();
+                    args.push("--hostname");
+                    args.push(hostname_buf.as_str());
+                }
+                let result = run_gh(&args).await;
                 match result {
                     Ok(output) => match serde_json::from_str::<PrDetail>(&output) {
                         Ok(detail) => {
-                            let _ = tx.send(AsyncResult::PrDetail(detail));
+                            let _ = tx.send(AsyncResult::PrDetail { repo_id, detail });
                         }
                         Err(e) => {
-                            let _ = tx.send(AsyncResult::PrDetailError(
+                            let _ = tx.send(AsyncResult::PrDetailError {
+                                repo_id,
                                 number,
-                                format!("PR #{number} parse error: {e}"),
-                            ));
+                                error: format!("PR #{number} parse error: {e}"),
+                            });
                         }
                     },
                     Err(e) => {
-                        let _ = tx.send(AsyncResult::PrDetailError(
+                        let _ = tx.send(AsyncResult::PrDetailError {
+                            repo_id,
                             number,
-                            format!("PR #{number} fetch failed: {e}"),
-                        ));
+                            error: format!("PR #{number} fetch failed: {e}"),
+                        });
                     }
                 }
             });
@@ -612,16 +631,21 @@ async fn run(
         // Receive completed background results (non-blocking)
         while let Ok(result) = rx.try_recv() {
             match result {
-                AsyncResult::PrDetail(detail) => {
-                    pr_inflight.remove(&detail.number);
-                    app.pr_detail_cache.insert(detail.number, detail);
+                AsyncResult::PrDetail { repo_id, detail } => {
+                    let key = (repo_id.clone(), detail.number);
+                    pr_inflight.remove(&key);
+                    app.pr_detail_cache.insert(key, detail);
                 }
-                AsyncResult::PrDetailError(number, error_msg) => {
-                    pr_inflight.remove(&number);
+                AsyncResult::PrDetailError {
+                    repo_id,
+                    number,
+                    error,
+                } => {
+                    pr_inflight.remove(&(repo_id, number));
                     app.notification =
                         Some(Notification::error(format!("Failed to load PR #{number}")));
-                    if app.verbose && !app.verbose_errors.contains(&error_msg) {
-                        app.verbose_errors.push(error_msg);
+                    if app.verbose && !app.verbose_errors.contains(&error) {
+                        app.verbose_errors.push(error);
                     }
                 }
                 AsyncResult::GitStatus { wt_path, status } => {
@@ -1075,8 +1099,17 @@ async fn run(
         }
 
         // Open PR in browser if requested
-        if let Some(pr_number) = app.open_pr_requested.take() {
-            let _ = run_gh(&["pr", "view", &pr_number.to_string(), "--web"]).await;
+        if let Some((repo_id, pr_number)) = app.open_pr_requested.take() {
+            let repo_arg = format!("{}/{}", repo_id.owner, repo_id.name);
+            let num = pr_number.to_string();
+            let mut args = vec!["pr", "view", &num, "--web", "--repo", repo_arg.as_str()];
+            let hostname_buf;
+            if let Some(h) = &repo_id.host {
+                hostname_buf = h.clone();
+                args.push("--hostname");
+                args.push(hostname_buf.as_str());
+            }
+            let _ = run_gh(&args).await;
         }
 
         // Copy branch name to clipboard if requested

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,10 @@ enum AsyncResult {
         failures: Vec<String>,
         wt_paths_claimed: Vec<String>,
     },
+    WtListLoaded {
+        repo_id: crate::git::types::RepoId,
+        list: Vec<crate::git::types::Worktree>,
+    },
 }
 
 /// Display-friendly label for a worktree path: takes the last path segment.
@@ -544,6 +548,33 @@ async fn run(
             });
         }
 
+        // Spawn cross-repo worktree list load in background (non-blocking, deduplicated)
+        if let Some(repo_id) = app.wt_list_requested.take()
+            && !app.wt_list_inflight.contains(&repo_id)
+            && let Some(path) = app.repos.get(&repo_id).and_then(|m| m.local_path.clone())
+        {
+            app.wt_list_inflight.insert(repo_id.clone());
+            let tx_c = tx.clone();
+            let repo_id_c = repo_id.clone();
+            tokio::spawn(async move {
+                match run_git_in(&path, &["worktree", "list", "--porcelain"]).await {
+                    Ok(out) => {
+                        let list = crate::git::parser::parse_worktrees(&out);
+                        let _ = tx_c.send(AsyncResult::WtListLoaded {
+                            repo_id: repo_id_c,
+                            list,
+                        });
+                    }
+                    Err(_) => {
+                        let _ = tx_c.send(AsyncResult::WtListLoaded {
+                            repo_id: repo_id_c,
+                            list: Vec::new(),
+                        });
+                    }
+                }
+            });
+        }
+
         // Reload branches/worktrees on `r` refresh from Main view
         if app.branches_reload_requested {
             app.branches_reload_requested = false;
@@ -873,6 +904,12 @@ async fn run(
                         format!("{reason}\nForce remove {path}?"),
                     ));
                     app.wt_force_delete_pending_path = Some(path);
+                }
+                AsyncResult::WtListLoaded { repo_id, list } => {
+                    app.wt_list_inflight.remove(&repo_id);
+                    app.wt_lists_per_repo.insert(repo_id, list);
+                    app.rebuild_entries();
+                    app.snap_scroll_to_entry();
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1126,8 +1126,13 @@ async fn run(
             }
             let mut work: Vec<Work> = Vec::with_capacity(selected.len());
             let mut wt_paths_claimed: Vec<String> = Vec::new();
+            let active_repo = app.active_repo.clone();
             for name in selected {
-                let Some(entry) = app.entries.iter().find(|e| e.name == name) else {
+                let Some(entry) = app
+                    .entries
+                    .iter()
+                    .find(|e| e.name == name && active_repo.as_ref() == Some(&e.repo_id))
+                else {
                     continue;
                 };
                 if entry.is_current() || app.is_protected_branch(&entry.name) {

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -197,8 +197,13 @@ fn draw_pr_section(
 
     lines.push(section_header(&format!("PR #{}", pr.number)));
 
-    // Cross-repo: show repo identifier above title.
-    if active_repo != Some(&entry.repo_id) {
+    // Cross-repo: show repo identifier above title only when we know the active
+    // repo and the entry belongs to a different one. When active_repo is None
+    // (e.g. no `origin` remote, detached HEAD) we suppress the label — every
+    // entry would otherwise show it, which is more confusing than helpful.
+    if let Some(active) = active_repo
+        && active != &entry.repo_id
+    {
         lines.push(Line::from(vec![
             Span::styled("  repo: ", Style::default().fg(Color::DarkGray)),
             Span::styled(

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use crate::app::App;
-use crate::git::types::{BranchEntry, PrDetail, ReviewStatus};
+use crate::git::types::{BranchEntry, PrDetail, RepoId, ReviewStatus};
 use crate::ui::markdown;
 
 pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
@@ -27,7 +27,13 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     if let Some(entry) = &entry {
         draw_git_status_section(&mut lines, entry, spinner);
         draw_worktree_section(&mut lines, entry);
-        draw_pr_section(&mut lines, entry, app.selected_pr_detail(), spinner);
+        draw_pr_section(
+            &mut lines,
+            entry,
+            app.selected_pr_detail(),
+            spinner,
+            app.active_repo.as_ref(),
+        );
     } else {
         lines.push(Line::from(Span::styled(
             " No branch selected",
@@ -174,6 +180,7 @@ fn draw_pr_section(
     entry: &BranchEntry,
     pr_detail: Option<&PrDetail>,
     spinner: &str,
+    active_repo: Option<&RepoId>,
 ) {
     let pr = match &entry.pull_request {
         Some(p) => p,
@@ -189,6 +196,19 @@ fn draw_pr_section(
     };
 
     lines.push(section_header(&format!("PR #{}", pr.number)));
+
+    // Cross-repo: show repo identifier above title.
+    if active_repo != Some(&entry.repo_id) {
+        lines.push(Line::from(vec![
+            Span::styled("  repo: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(
+                entry.repo_id.to_string(),
+                Style::default()
+                    .fg(Color::Cyan)
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]));
+    }
 
     // Title
     lines.push(Line::from(Span::styled(

--- a/src/ui/main_view.rs
+++ b/src/ui/main_view.rs
@@ -3,7 +3,7 @@ use ratatui::{
     layout::{Constraint, Flex, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, List, ListItem, ListState},
+    widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
 use crate::app::App;
@@ -28,9 +28,18 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
 }
 
 fn draw_action_menu(frame: &mut Frame, menu: &crate::app::ActionMenu) {
-    let height = (menu.items.len() as u16) + 2; // items + border
-    let area = centered_rect(40, height, frame.area());
+    let footer_height: u16 = if menu.footer.is_some() { 1 } else { 0 };
+    let list_height = (menu.items.len() as u16) + 2; // items + border
+    let total_height = list_height + footer_height;
+    let area = centered_rect(40, total_height, frame.area());
     frame.render_widget(Clear, area);
+
+    // Split the area into list portion and optional footer.
+    let [list_area, footer_area] = Layout::vertical([
+        Constraint::Length(list_height),
+        Constraint::Length(footer_height),
+    ])
+    .areas(area);
 
     let items: Vec<ListItem> = menu
         .items
@@ -59,7 +68,16 @@ fn draw_action_menu(frame: &mut Frame, menu: &crate::app::ActionMenu) {
 
     let mut state = ListState::default();
     state.select(Some(menu.scroll));
-    frame.render_stateful_widget(list, area, &mut state);
+    frame.render_stateful_widget(list, list_area, &mut state);
+
+    if let Some(ref footer) = menu.footer {
+        let footer_line = Line::from(Span::styled(
+            format!("─ {footer}"),
+            Style::default().fg(Color::DarkGray),
+        ));
+        let paragraph = Paragraph::new(footer_line).wrap(Wrap { trim: true });
+        frame.render_widget(paragraph, footer_area);
+    }
 }
 
 fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -66,6 +66,29 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
             };
             spans.push(Span::styled(team_label, Style::default().fg(Color::Cyan)));
         }
+        // Show repo/PR counter when multiple repos are present
+        if matches!(
+            app.main_filter,
+            MainFilter::MyPr | MainFilter::ReviewRequested
+        ) {
+            let repo_count = app
+                .filtered_entries()
+                .iter()
+                .map(|e| e.repo_id.clone())
+                .collect::<std::collections::HashSet<_>>()
+                .len();
+            if repo_count > 1 {
+                let pr_count = app
+                    .filtered_entries()
+                    .iter()
+                    .filter(|e| e.pull_request.is_some())
+                    .count();
+                spans.push(Span::styled(
+                    format!("  {repo_count} repos · {pr_count} PRs"),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+        }
         Line::from(spans)
     };
     frame.render_widget(
@@ -80,15 +103,15 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
 
     // Build items and capture count before mutably borrowing app
     let (items, item_count): (Vec<ListItem>, usize) = {
-        let filtered = app.filtered_entries();
-        let count = filtered.len();
-        let items = if filtered.is_empty() && is_loading {
+        let rows = app.sidebar_rows();
+        let item_count = rows.len();
+        let items = if rows.is_empty() && is_loading {
             let spinner = app.spinner_frame();
             vec![ListItem::new(Line::from(Span::styled(
                 format!("  {spinner} Loading"),
                 Style::default().fg(Color::DarkGray),
             )))]
-        } else if filtered.is_empty() {
+        } else if rows.is_empty() {
             let msg = if !app.search_query.is_empty() {
                 "  No branches match the search"
             } else {
@@ -104,22 +127,31 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
             )))]
         } else {
             let search_query = &app.search_query;
-            filtered
-                .iter()
-                .map(|entry| {
-                    let is_selected = app.branch_selected.contains(&entry.name);
-                    let is_protected = app.is_protected_branch(&entry.name);
-                    ListItem::new(format_entry_line(
-                        entry,
-                        show_checkboxes,
-                        is_selected,
-                        is_protected,
-                        search_query,
-                    ))
+            rows.iter()
+                .map(|row| match row {
+                    crate::app::SidebarRow::Header { repo_id } => {
+                        ListItem::new(Line::from(vec![Span::styled(
+                            format!(" ▾ {repo_id} "),
+                            Style::default()
+                                .fg(Color::Cyan)
+                                .add_modifier(Modifier::DIM | Modifier::BOLD),
+                        )]))
+                    }
+                    crate::app::SidebarRow::Entry(entry) => {
+                        let is_selected = app.branch_selected.contains(&entry.name);
+                        let is_protected = app.is_protected_branch(&entry.name);
+                        ListItem::new(format_entry_line(
+                            entry,
+                            show_checkboxes,
+                            is_selected,
+                            is_protected,
+                            search_query,
+                        ))
+                    }
                 })
                 .collect()
         };
-        (items, count)
+        (items, item_count)
     };
 
     // Adjust viewport offset and clamp scroll/offset to valid ranges

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -71,18 +71,14 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
             app.main_filter,
             MainFilter::MyPr | MainFilter::ReviewRequested
         ) {
-            let repo_count = app
-                .filtered_entries()
+            let filtered = app.filtered_entries();
+            let repo_count = filtered
                 .iter()
                 .map(|e| e.repo_id.clone())
                 .collect::<std::collections::HashSet<_>>()
                 .len();
             if repo_count > 1 {
-                let pr_count = app
-                    .filtered_entries()
-                    .iter()
-                    .filter(|e| e.pull_request.is_some())
-                    .count();
+                let pr_count = filtered.iter().filter(|e| e.pull_request.is_some()).count();
                 spans.push(Span::styled(
                     format!("  {repo_count} repos · {pr_count} PRs"),
                     Style::default().fg(Color::DarkGray),


### PR DESCRIPTION
## Summary

`My PR` (`2`) and `Review` (`3`) modes used to silently filter results to the active repo because they routed through `gh pr list --search`. This branch migrates them to `gh api graphql search` so they genuinely span every repo the user is involved in, then teaches the rest of the app — sidebar, action menu, detail pane, worktree creation — to handle entries from non-active repositories.

The result: a developer juggling a backlog of review requests across multiple repos can keep `gct` open in any one of them and act on the whole queue without ever leaving the TUI.

## Type of Change

- [x] New feature
- [x] Refactoring (data model adds `RepoId` tagging across entries / PRs / caches)

## Changes

**Data model & backend**
- New `RepoId { host, owner, name }` (`Display` formats `owner/name` or `owner/name@host`); replaces the legacy `RepoInfo`.
- `BranchEntry` and `PullRequest` carry `repo_id`; caches (`pr_detail_cache`, `pr_inflight`, `wt_list_inflight`, `wt_lists_per_repo`) keyed by `(RepoId, …)` to prevent cross-repo collisions.
- `fetch_my_prs` / `fetch_review_prs` now use `gh api graphql search` and return PRs tagged with their source repo; `fetch_local_prs` keeps its prior behavior (active-repo-only).
- New `run_git_in` / `run_gh_in` command wrappers run git/gh against a specific clone path; `CommandRecord` gains an optional repo tag for the History view.

**Local clone discovery**
- Auto-infer `clone_root` from the active repo's path (ghq layout: `<root>/<host>/<owner>/<name>`); fall back to a new `[workspace] clone_root` config setting when auto-detection fails.
- `App.repos` is a lazy registry keyed by `RepoId`; \`local_path\` is resolved on first selection (idempotent, never retries on miss).

**UI**
- Sidebar renders tig-style group headers (\`▾ owner/name\`) when entries span more than one repo; flat layout otherwise. Filter bar shows \`N repos · M PRs\` counter.
- \`j\`/\`k\` cursor and search Down/Up skip header rows; initial scroll snaps to the first entry.
- Detail pane shows a \`repo: owner/name\` line when the selected entry is cross-repo.
- Action menu hides Worktree-related items for cross-repo entries without a local clone and adds a footer hint pointing at \`[workspace] clone_root\`.

**Worktree actions**
- \`Create Worktree\` and \`cd into Worktree\` operate against the entry's resolved clone path (\`run_git_in(<clone>, …)\`), not the gct cwd. Cross-repo branches always go through \`git fetch origin <branch>\` then \`git worktree add\`.
- \`post_create\` hooks (\`copy\`, \`symlink\`, \`command\`) now resolve relative to the target repo root, not the gct process cwd.
- \`w\` keybind enforces the same cross-repo guard as the action menu, so it no longer races into a "Creating…" notification followed by a "not cloned" error.
- \`r\` refresh clears \`wt_lists_per_repo\` and \`wt_list_inflight\` so externally deleted cross-repo worktrees disappear without a restart.
- \`gh pr view\` (PR detail and "Open PR in Browser") passes \`--repo\` and \`--hostname\` so cross-repo PRs resolve correctly.

**Backward compatibility**
- Single-repo result sets render exactly as before — no headers, no counter, no behavior change.
- The \`[workspace]\` config section is optional; without it the active repo still works and cross-repo entries gracefully degrade to read-only.
- Bulk delete (\`d\` after \`Space\` selection) remains active-repo-only by design.

**Limitations (v1)**
- Only github.com is searched; PRs on GitHub Enterprise hosts are not aggregated. Cross-repo Worktree on a GHE-cloned repo still works once the entry surfaces (e.g. via Local view), but \`My PR\` / \`Review\` queries don't fan out across hosts.

**Demo / docs**
- \`scripts/demo/gh-stub\` returns a 3-repo fixture for the new GraphQL search query.
- README adds a "Cross-repo Reviews" section.

## Checklist

- [x] \`cargo build\` clean
- [x] \`cargo fmt -- --check\` clean
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\` clean
- [x] \`cargo test\` — 129/129 passing (includes 18 new tests covering RepoId display/equality, GraphQL search PR parsing, lazy clone resolution, sidebar grouping, cursor header-skip, action menu cross-repo gating, cross-repo worktree-list lazy load)

## Test Plan

1. **Single-repo regression** — Inside any repo, run \`cargo run\`. Press \`1\`/\`2\`/\`3\`. The sidebar should look identical to today (no headers, no counter), and all existing keybinds (\`Space\`, \`a\`, \`d\`, \`w\`, \`Enter\`, \`/\`, \`m\`, \`t\`, \`r\`) should behave as before.

2. **Multi-repo Review with the bundled stub** —
   \`\`\`bash
   cd scripts/demo
   ./setup.sh
   PATH=\"\$PWD:\$PATH\" cargo run --manifest-path ../../Cargo.toml
   \`\`\`
   Press \`3\`. The sidebar should show three repo groups (\`katzkb/git-control-tower\`, \`org-x/web\`, \`katzkb/dotfiles\`) with counter \`3 repos · 3 PRs\`. Verify j/k skips header rows, selecting a cross-repo PR shows \`repo: owner/name\` in the detail pane, and an entry without a local clone shows a footer hint instead of \`Create Worktree\`.

3. **Cross-repo Worktree creation (real backend)** — In a ghq layout (\`~/<root>/<host>/<owner>/<repo>\`), run \`gct\` from one repo, switch to \`Review\`, select a PR from another already-cloned repo, press \`Enter\` → \`Create Worktree\`. The worktree should be created under the selected repo's parent (not the active repo's), and post-create hooks should run with \`repo_root = <selected clone>\`.

4. **\`r\` refresh hygiene** — After a successful cross-repo Worktree creation, press \`r\`. The \`wt_lists_per_repo\` cache is invalidated, so reselecting the entry re-fetches the worktree list.