### PR TITLE
fix(data): aggregate My PR / My Review across every local-repo host

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,9 @@ For cross-repo PRs, `Create Worktree` and `cd into Worktree` operate on the loca
 
 If neither path resolves, cross-repo entries remain visible but `Create Worktree` is greyed out with a one-line hint pointing at the expected clone location.
 
-**Limitations (v1):** Only github.com is searched (PRs on GitHub Enterprise hosts are not aggregated). Bulk delete (`d` after Space-selection) still operates on active-repo branches only.
+**Cross-host coverage:** My PR / My Review fan out across every host present in the repos gct has discovered locally (origin remotes), so a workspace mixing github.com clones with GitHub Enterprise clones surfaces PRs from both. Hosts you are authenticated to but have never cloned from are skipped — clone any one repo from that host (or `cd` into one) so gct can pick it up.
+
+**Limitations (v1):** Bulk delete (`d` after Space-selection) still operates on active-repo branches only.
 
 ### Worktree Settings
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -1652,10 +1652,11 @@ mod known_hosts_tests {
                 meta(),
             );
         }
-        let mut hosts = app.known_hosts();
-        hosts.sort();
+        // `known_hosts` collects via BTreeSet, so the output is already sorted
+        // with `None` (= github.com) before any `Some(host)` entries — the
+        // sort here would be a no-op and is intentionally omitted.
         assert_eq!(
-            hosts,
+            app.known_hosts(),
             vec![
                 None,
                 Some("ghe.example.com".to_string()),

--- a/src/app.rs
+++ b/src/app.rs
@@ -1263,6 +1263,22 @@ impl App {
         self.config.protected_branches.iter().any(|b| b == name)
     }
 
+    /// Hosts the user can reasonably be expected to have PRs on, derived from
+    /// the origin remotes of every repo we have metadata for. Empty repo map
+    /// falls back to `[None]` (default host = github.com) so cross-repo
+    /// aggregation behaves identically to the single-host case before any
+    /// repo metadata is collected. The output is unique-by-host and sorted
+    /// (None first) for deterministic ordering.
+    pub fn known_hosts(&self) -> Vec<Option<String>> {
+        use std::collections::BTreeSet;
+        let set: BTreeSet<Option<String>> = self.repos.keys().map(|id| id.host.clone()).collect();
+        if set.is_empty() {
+            vec![None]
+        } else {
+            set.into_iter().collect()
+        }
+    }
+
     /// Resolve a repo's local clone path under `clone_root`. Idempotent: only
     /// hits the filesystem once per repo. Sets `local_path_resolved = true`
     /// regardless of outcome to prevent re-tries.
@@ -1576,6 +1592,76 @@ mod pr_detail_cache_tests {
         assert_eq!(app.pr_detail_cache.len(), 2);
         assert_eq!(app.pr_detail_cache.get(&(id_a, 1)).unwrap().title, "A");
         assert_eq!(app.pr_detail_cache.get(&(id_b, 1)).unwrap().title, "B");
+    }
+}
+
+#[cfg(test)]
+mod known_hosts_tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::git::types::{RepoId, RepoMeta};
+
+    fn meta() -> RepoMeta {
+        RepoMeta {
+            local_path: None,
+            local_path_resolved: false,
+        }
+    }
+
+    #[test]
+    fn known_hosts_empty_repos_returns_default_host() {
+        // Without any repo metadata we still want a single-host search against
+        // the default host (github.com) so My PR / My Review behave as before.
+        let app = App::new(Config::default());
+        assert_eq!(app.known_hosts(), vec![None]);
+    }
+
+    #[test]
+    fn known_hosts_dedups_multiple_repos_per_host() {
+        let mut app = App::new(Config::default());
+        for (owner, name) in [("a", "x"), ("b", "y"), ("c", "z")] {
+            app.repos.insert(
+                RepoId {
+                    host: None,
+                    owner: owner.into(),
+                    name: name.into(),
+                },
+                meta(),
+            );
+        }
+        assert_eq!(app.known_hosts(), vec![None]);
+    }
+
+    #[test]
+    fn known_hosts_returns_unique_hosts_across_mixed_repos() {
+        let mut app = App::new(Config::default());
+        // Two github.com repos and two GHES repos on the same host.
+        for (host, owner, name) in [
+            (None, "katzkb", "gct"),
+            (None, "katzkb", "dotfiles"),
+            (Some("ghe.example.com"), "team", "svc"),
+            (Some("ghe.example.com"), "team", "infra"),
+            (Some("ghe.other.com"), "alice", "tools"),
+        ] {
+            app.repos.insert(
+                RepoId {
+                    host: host.map(|s| s.to_string()),
+                    owner: owner.into(),
+                    name: name.into(),
+                },
+                meta(),
+            );
+        }
+        let mut hosts = app.known_hosts();
+        hosts.sort();
+        assert_eq!(
+            hosts,
+            vec![
+                None,
+                Some("ghe.example.com".to_string()),
+                Some("ghe.other.com".to_string()),
+            ]
+        );
     }
 }
 

--- a/src/data.rs
+++ b/src/data.rs
@@ -339,44 +339,128 @@ fn host_from_url(url: &str) -> Option<String> {
     }
 }
 
-// gh api graphql does not accept --hostname here; v1 supports github.com only.
-// Cross-host (GHE) PR aggregation will require routing through per-host gh config.
+/// Deduplicate a host list while preserving first-occurrence order.
+/// Empty input falls back to `[None]` so callers always run at least one
+/// search query against the default host (github.com).
+fn dedup_hosts(hosts: &[Option<String>]) -> Vec<Option<String>> {
+    let mut seen: HashSet<Option<String>> = HashSet::new();
+    let mut out: Vec<Option<String>> = Vec::with_capacity(hosts.len());
+    for h in hosts {
+        if seen.insert(h.clone()) {
+            out.push(h.clone());
+        }
+    }
+    if out.is_empty() { vec![None] } else { out }
+}
+
+/// Merge per-host search results: concatenate PRs in input order, prefix
+/// per-host failures with `[<label>] ` so the caller can attribute errors
+/// to the originating host.
+fn merge_search_results(
+    results: Vec<(String, Result<Vec<PullRequest>, String>)>,
+) -> (Vec<PullRequest>, Vec<String>) {
+    let mut prs: Vec<PullRequest> = Vec::new();
+    let mut errors: Vec<String> = Vec::new();
+    for (label, result) in results {
+        match result {
+            Ok(host_prs) => prs.extend(host_prs),
+            Err(msg) => errors.push(format!("[{label}] {msg}")),
+        }
+    }
+    (prs, errors)
+}
+
+// Hosts to search are supplied by the caller; an empty slice falls back to
+// the default host (github.com) via dedup_hosts.
 // TODO(future): GitHub's search index supports up to 1000 results; if very active
 // reviewers report missing PRs, paginate via search.pageInfo.endCursor.
-async fn fetch_search_prs(query_str: &str, limit: u32) -> (Vec<PullRequest>, Vec<String>) {
+async fn fetch_search_prs(
+    query_str: &str,
+    limit: u32,
+    hosts: &[Option<String>],
+) -> (Vec<PullRequest>, Vec<String>) {
     let escaped_query = query_str.replace('\\', "\\\\").replace('"', "\\\"");
     let query = format!(
         r#"{{ search(query: "{escaped_query}", type: ISSUE, first: {limit}) {{ nodes {{ ... on PullRequest {{ number title state headRefName updatedAt isDraft author {{ login }} repository {{ name url owner {{ login }} }} reviewRequests(first: 10) {{ nodes {{ requestedReviewer {{ ... on User {{ login }} }} }} }} latestReviews(first: 20) {{ nodes {{ author {{ login }} state }} }} }} }} }} }}"#
     );
     let query_arg = format!("query={query}");
-    let args = vec!["api", "graphql", "-f", &query_arg];
-    match run_gh(&args).await {
-        Ok(output) => match serde_json::from_str::<serde_json::Value>(&output) {
-            Ok(json) => {
-                let mut prs = Vec::new();
-                if let Some(arr) = json["data"]["search"]["nodes"].as_array() {
-                    for node in arr {
-                        if let Some(pr) = parse_graphql_search_pr(node) {
-                            prs.push(pr);
+
+    // Run one search per host in parallel. Hosts are deduplicated and an
+    // empty list falls back to a single default-host (github.com) query so
+    // the previous single-host behaviour is preserved when no repo metadata
+    // has been collected yet.
+    let unique_hosts = dedup_hosts(hosts);
+    let mut handles = Vec::with_capacity(unique_hosts.len());
+    for host in unique_hosts {
+        let query_arg = query_arg.clone();
+        let label = host.as_deref().unwrap_or("github.com").to_string();
+        handles.push(tokio::spawn(async move {
+            let mut args: Vec<String> = vec![
+                "api".to_string(),
+                "graphql".to_string(),
+                "-f".to_string(),
+                query_arg,
+            ];
+            if let Some(h) = host.as_deref() {
+                args.push("--hostname".to_string());
+                args.push(h.to_string());
+            }
+            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let result: Result<Vec<PullRequest>, String> = match run_gh(&arg_refs).await {
+                Ok(output) => match serde_json::from_str::<serde_json::Value>(&output) {
+                    Ok(json) => {
+                        let mut host_prs = Vec::new();
+                        if let Some(arr) = json["data"]["search"]["nodes"].as_array() {
+                            for node in arr {
+                                if let Some(pr) = parse_graphql_search_pr(node) {
+                                    host_prs.push(pr);
+                                }
+                            }
                         }
+                        Ok(host_prs)
                     }
+                    Err(e) => {
+                        debug_log(&format!("  → GraphQL search parse error: {e}"));
+                        Err(format!("search parse error: {e}"))
+                    }
+                },
+                Err(e) => {
+                    debug_log(&format!("  → GraphQL search fetch error: {e}"));
+                    Err(format!("search fetch failed: {e}"))
                 }
-                (prs, Vec::new())
-            }
+            };
+            (label, result)
+        }));
+    }
+
+    let mut collected: Vec<(String, Result<Vec<PullRequest>, String>)> =
+        Vec::with_capacity(handles.len());
+    for handle in handles {
+        match handle.await {
+            Ok(pair) => collected.push(pair),
             Err(e) => {
-                debug_log(&format!("  → GraphQL search parse error: {e}"));
-                (Vec::new(), vec![format!("search parse error: {e}")])
+                debug_log(&format!("  → GraphQL search task join error: {e}"));
+                collected.push((
+                    "task".to_string(),
+                    Err(format!("search task join failed: {e}")),
+                ));
             }
-        },
-        Err(e) => {
-            debug_log(&format!("  → GraphQL search fetch error: {e}"));
-            (Vec::new(), vec![format!("search fetch failed: {e}")])
         }
     }
+
+    // PRs from multiple hosts naturally cannot collide because parse_graphql_search_pr
+    // tags each PR with the host extracted from repository.url, and downstream merging
+    // is keyed by (RepoId, head_ref) where RepoId.host disambiguates.
+    merge_search_results(collected)
 }
 
-/// Fetch PRs authored by the current user via cross-repo GraphQL search.
-pub async fn fetch_my_prs(show_merged: bool) -> (Vec<PullRequest>, Vec<String>) {
+/// Fetch PRs authored by the current user via cross-repo GraphQL search,
+/// fanning out across every host in `hosts` (an empty slice falls back to
+/// the default host).
+pub async fn fetch_my_prs(
+    show_merged: bool,
+    hosts: &[Option<String>],
+) -> (Vec<PullRequest>, Vec<String>) {
     let mut q = String::from("is:pr author:@me");
     if !show_merged {
         q.push_str(" is:open");
@@ -386,7 +470,7 @@ pub async fn fetch_my_prs(show_merged: bool) -> (Vec<PullRequest>, Vec<String>) 
     // TODO(future): GitHub's search index supports up to 1000 results; if very active
     // reviewers report missing PRs, paginate via search.pageInfo.endCursor.
     let limit = if show_merged { 150 } else { 100 };
-    let (mut prs, errors) = fetch_search_prs(&q, limit).await;
+    let (mut prs, errors) = fetch_search_prs(&q, limit, hosts).await;
     prs.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     (prs, errors)
 }
@@ -398,6 +482,7 @@ pub async fn fetch_review_prs(
     show_merged: bool,
     include_team: bool,
     gh_user: &str,
+    hosts: &[Option<String>],
 ) -> (Vec<PullRequest>, Vec<String>) {
     let mut queries: Vec<String> = vec![
         "is:pr review-requested:@me".into(),
@@ -425,7 +510,7 @@ pub async fn fetch_review_prs(
     const REVIEWED_BY_INDEX: usize = 1;
     for (idx, query) in queries.iter().enumerate() {
         let is_reviewed = idx == REVIEWED_BY_INDEX;
-        let (prs, errors) = fetch_search_prs(query, 100).await;
+        let (prs, errors) = fetch_search_prs(query, 100, hosts).await;
         all_errors.extend(errors);
         for pr in prs {
             let key = (pr.repo_id.clone(), pr.number);
@@ -923,5 +1008,132 @@ mod tests {
         assert_eq!(prs[0].review_requests.len(), 2);
         assert_eq!(prs[0].review_requests[0].login.as_deref(), Some("bob"));
         assert_eq!(prs[0].review_requests[1].login, None);
+    }
+
+    // ----- dedup_hosts -----
+
+    #[test]
+    fn dedup_hosts_empty_falls_back_to_default_host() {
+        // Empty input must fall back to a single default-host (None = github.com)
+        // entry so callers that have no repo metadata yet still get one query.
+        assert_eq!(dedup_hosts(&[]), vec![None]);
+    }
+
+    #[test]
+    fn dedup_hosts_preserves_first_occurrence_order() {
+        let input = vec![
+            Some("ghe.example.com".to_string()),
+            None,
+            Some("ghe.example.com".to_string()),
+            None,
+            Some("ghe.other.com".to_string()),
+        ];
+        assert_eq!(
+            dedup_hosts(&input),
+            vec![
+                Some("ghe.example.com".to_string()),
+                None,
+                Some("ghe.other.com".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn dedup_hosts_single_none_preserved() {
+        assert_eq!(dedup_hosts(&[None]), vec![None]);
+    }
+
+    #[test]
+    fn dedup_hosts_single_some_preserved() {
+        let h = Some("ghe.example.com".to_string());
+        assert_eq!(dedup_hosts(std::slice::from_ref(&h)), vec![h]);
+    }
+
+    // ----- merge_search_results -----
+
+    fn pr_with_id(number: u64, host: Option<&str>, owner: &str, name: &str) -> PullRequest {
+        PullRequest {
+            number,
+            title: format!("PR {number}"),
+            author: "alice".into(),
+            state: "OPEN".into(),
+            head_ref: format!("feature-{number}"),
+            updated_at: "2024-01-15T00:00:00Z".into(),
+            is_draft: false,
+            review_requests: vec![],
+            latest_reviews: vec![],
+            review_status: None,
+            repo_id: crate::git::types::RepoId {
+                host: host.map(|s| s.to_string()),
+                owner: owner.into(),
+                name: name.into(),
+            },
+        }
+    }
+
+    #[test]
+    fn merge_search_results_concatenates_successes() {
+        let results = vec![
+            (
+                "github.com".to_string(),
+                Ok(vec![pr_with_id(1, None, "katzkb", "gct")]),
+            ),
+            (
+                "ghe.example.com".to_string(),
+                Ok(vec![
+                    pr_with_id(2, Some("ghe.example.com"), "team", "svc"),
+                    pr_with_id(3, Some("ghe.example.com"), "team", "svc"),
+                ]),
+            ),
+        ];
+        let (prs, errors) = merge_search_results(results);
+        assert_eq!(prs.len(), 3);
+        assert_eq!(prs[0].number, 1);
+        assert_eq!(prs[1].number, 2);
+        assert_eq!(prs[2].number, 3);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn merge_search_results_labels_errors_with_host() {
+        let results: Vec<(String, Result<Vec<PullRequest>, String>)> = vec![
+            (
+                "github.com".to_string(),
+                Ok(vec![pr_with_id(1, None, "katzkb", "gct")]),
+            ),
+            (
+                "ghe.example.com".to_string(),
+                Err("auth expired".to_string()),
+            ),
+        ];
+        let (prs, errors) = merge_search_results(results);
+        assert_eq!(prs.len(), 1);
+        assert_eq!(prs[0].number, 1);
+        assert_eq!(errors, vec!["[ghe.example.com] auth expired".to_string()]);
+    }
+
+    #[test]
+    fn merge_search_results_all_failures() {
+        let results: Vec<(String, Result<Vec<PullRequest>, String>)> = vec![
+            ("github.com".to_string(), Err("network".to_string())),
+            ("ghe.example.com".to_string(), Err("auth".to_string())),
+        ];
+        let (prs, errors) = merge_search_results(results);
+        assert!(prs.is_empty());
+        assert_eq!(
+            errors,
+            vec![
+                "[github.com] network".to_string(),
+                "[ghe.example.com] auth".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn merge_search_results_empty_input() {
+        let results: Vec<(String, Result<Vec<PullRequest>, String>)> = vec![];
+        let (prs, errors) = merge_search_results(results);
+        assert!(prs.is_empty());
+        assert!(errors.is_empty());
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -342,6 +342,11 @@ fn host_from_url(url: &str) -> Option<String> {
 /// Deduplicate a host list while preserving first-occurrence order.
 /// Empty input falls back to `[None]` so callers always run at least one
 /// search query against the default host (github.com).
+///
+/// Defence-in-depth: callers in this crate (notably `App::known_hosts`)
+/// already produce a unique list, but `fetch_search_prs` runs this guard
+/// regardless so any future caller that forwards a raw list still gets
+/// the empty-input fallback and dedup behaviour for free.
 fn dedup_hosts(hosts: &[Option<String>]) -> Vec<Option<String>> {
     let mut seen: HashSet<Option<String>> = HashSet::new();
     let mut out: Vec<Option<String>> = Vec::with_capacity(hosts.len());
@@ -390,11 +395,18 @@ async fn fetch_search_prs(
     // the previous single-host behaviour is preserved when no repo metadata
     // has been collected yet.
     let unique_hosts = dedup_hosts(hosts);
-    let mut handles = Vec::with_capacity(unique_hosts.len());
+    // Keep `(label, JoinHandle<Result<...>>)` pairs so that the host label is
+    // attached to errors regardless of whether they originate inside the task
+    // (Err returned from the closure) or from the join itself (panic / cancel).
+    type SearchHandle = (
+        String,
+        tokio::task::JoinHandle<Result<Vec<PullRequest>, String>>,
+    );
+    let mut handles: Vec<SearchHandle> = Vec::with_capacity(unique_hosts.len());
     for host in unique_hosts {
         let query_arg = query_arg.clone();
         let label = host.as_deref().unwrap_or("github.com").to_string();
-        handles.push(tokio::spawn(async move {
+        let handle = tokio::spawn(async move {
             let mut args: Vec<String> = vec![
                 "api".to_string(),
                 "graphql".to_string(),
@@ -406,7 +418,7 @@ async fn fetch_search_prs(
                 args.push(h.to_string());
             }
             let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-            let result: Result<Vec<PullRequest>, String> = match run_gh(&arg_refs).await {
+            match run_gh(&arg_refs).await {
                 Ok(output) => match serde_json::from_str::<serde_json::Value>(&output) {
                     Ok(json) => {
                         let mut host_prs = Vec::new();
@@ -428,24 +440,24 @@ async fn fetch_search_prs(
                     debug_log(&format!("  → GraphQL search fetch error: {e}"));
                     Err(format!("search fetch failed: {e}"))
                 }
-            };
-            (label, result)
-        }));
+            }
+        });
+        handles.push((label, handle));
     }
 
     let mut collected: Vec<(String, Result<Vec<PullRequest>, String>)> =
         Vec::with_capacity(handles.len());
-    for handle in handles {
-        match handle.await {
-            Ok(pair) => collected.push(pair),
+    for (label, handle) in handles {
+        let result = match handle.await {
+            Ok(r) => r,
             Err(e) => {
-                debug_log(&format!("  → GraphQL search task join error: {e}"));
-                collected.push((
-                    "task".to_string(),
-                    Err(format!("search task join failed: {e}")),
+                debug_log(&format!(
+                    "  → GraphQL search task join error ({label}): {e}"
                 ));
+                Err(format!("search task join failed: {e}"))
             }
-        }
+        };
+        collected.push((label, result));
     }
 
     // PRs from multiple hosts naturally cannot collide because parse_graphql_search_pr

--- a/src/main.rs
+++ b/src/main.rs
@@ -639,8 +639,9 @@ async fn run(
                 }
                 MainFilter::MyPr => {
                     let show_merged = app.show_merged;
+                    let hosts = app.known_hosts();
                     tokio::spawn(async move {
-                        let (prs, errors) = data::fetch_my_prs(show_merged).await;
+                        let (prs, errors) = data::fetch_my_prs(show_merged, &hosts).await;
                         let _ = tx.send(AsyncResult::MyPrList(prs, errors));
                     });
                 }
@@ -660,9 +661,11 @@ async fn run(
                         let show_merged = app.show_merged;
                         let include_team = app.include_team_reviews;
                         let gh_user = app.gh_user.clone();
+                        let hosts = app.known_hosts();
                         tokio::spawn(async move {
                             let (prs, errors) =
-                                data::fetch_review_prs(show_merged, include_team, &gh_user).await;
+                                data::fetch_review_prs(show_merged, include_team, &gh_user, &hosts)
+                                    .await;
                             let _ = tx.send(AsyncResult::ReviewPrList(prs, errors));
                         });
                     }


### PR DESCRIPTION
## Summary

In a workspace mixing `github.com` and GitHub Enterprise (GHES) clones, My Review (and My PR) silently omitted every GHES PR. The cross-repo search introduced in #197 ran `gh api graphql` exactly once with no `--hostname`, so only the default host was queried. This PR fans out one query per host (derived from `app.repos` keys) in parallel via `tokio::spawn`, applying `--hostname` for non-default hosts.

The inline comment claiming `gh api graphql` does not accept `--hostname` was wrong — `fetch_local_prs` has been using `--hostname` with the same sub-command since #197. The real cause was always "only one query."

## Related Issues

Closes #202

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [ ] Documentation
- [ ] CI / Build

## Changes

- `src/data.rs`: thread `hosts: &[Option<String>]` through `fetch_search_prs`, `fetch_my_prs`, `fetch_review_prs`. Run one search per unique host concurrently via `tokio::spawn`. On per-host failure, append `[<host>] <message>` to the existing `errors: Vec<String>` so other hosts still render.
- `src/data.rs`: extract `dedup_hosts` and `merge_search_results` as pure helpers; remove the misleading "graphql does not accept --hostname" comment.
- `src/app.rs`: add `App::known_hosts()`, returning the unique sorted host list derived from `app.repos`. Empty repo map falls back to `[None]` so single-host behaviour is preserved before any repo metadata is collected.
- `src/main.rs`: pass `app.known_hosts()` at the `MainFilter::MyPr` and `MainFilter::ReviewRequested` call sites.
- `README.md`: drop the "Only github.com is searched" v1 limitation; describe cross-host coverage and the "must have at least one local clone per host" caveat.

## Out of Scope

Tracked separately for follow-up:

- Discovering hosts the user is logged into but has not cloned from yet (would require parsing `gh auth status`).
- Multi-host support in `scripts/demo/gh-stub`.
- Per-host `gh_user` for the Review tab self-exclusion filter.
- Pagination beyond 100/150 search results per host.

## Checklist

- [x] Code compiles without warnings
- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test --bin gct` — 141 passed (including 11 new tests for `dedup_hosts`, `merge_search_results`, `App::known_hosts`)

## Test Plan

Unit coverage:

- `dedup_hosts`: empty input falls back to `[None]`; preserves first-occurrence order across duplicates; single-host inputs preserved.
- `merge_search_results`: concatenates Ok results in order; labels Err results with `[<host>] <msg>`; mixed and empty cases.
- `App::known_hosts`: empty repos returns `[None]`; multiple repos on the same host dedup to one entry; mixed-host repos return the unique sorted host set.

Manual verification (recommended in a workspace with both hosts authenticated and at least one local clone of each):

1. \`cargo run\`, switch to \`2\` (My Review). Confirm GHES and \`github.com\` PRs appear together; sidebar repo group headers separate them.
2. \`1\` (My PR): confirm self-authored GHES PRs appear.
3. \`gh auth logout --hostname <ghes-host>\`, then re-open \`2\`: github.com PRs still render and an error labelled \`[<ghes-host>] search fetch failed: …\` is recorded (visible with \`--verbose\`); no crash.
4. Single-host environment (\`github.com\` only): behaviour unchanged from prior release.