### PR TITLE
fix: build gh pr view --repo with [HOST/]OWNER/REPO so GHE works

### DIFF
--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -19,6 +19,18 @@ impl fmt::Display for RepoId {
     }
 }
 
+impl RepoId {
+    /// `[HOST/]OWNER/REPO` form accepted by `gh --repo`.
+    /// Use this whenever building a `gh` command — `gh pr <sub>` does not
+    /// accept `--hostname`, so the host must be embedded in `--repo` instead.
+    pub fn repo_arg(&self) -> String {
+        match &self.host {
+            Some(h) => format!("{h}/{}/{}", self.owner, self.name),
+            None => format!("{}/{}", self.owner, self.name),
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct RepoMeta {
     /// Resolved lazily on first selection. `None` after `local_path_resolved == true`
@@ -210,6 +222,26 @@ mod repo_id_tests {
             name: "repo".into(),
         };
         assert_eq!(id.to_string(), "org/repo@ghe.company.com");
+    }
+
+    #[test]
+    fn repo_arg_omits_host_for_github_com() {
+        let id = RepoId {
+            host: None,
+            owner: "katzkb".into(),
+            name: "git-control-tower".into(),
+        };
+        assert_eq!(id.repo_arg(), "katzkb/git-control-tower");
+    }
+
+    #[test]
+    fn repo_arg_includes_host_for_ghe() {
+        let id = RepoId {
+            host: Some("ghe.company.com".into()),
+            owner: "org".into(),
+            name: "repo".into(),
+        };
+        assert_eq!(id.repo_arg(), "ghe.company.com/org/repo");
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -514,10 +514,12 @@ async fn run(
         {
             pr_inflight.insert((repo_id.clone(), number));
             let tx = tx.clone();
-            let repo_arg = format!("{}/{}", repo_id.owner, repo_id.name);
+            // `gh pr view` doesn't accept --hostname; the host (if any) is
+            // embedded into --repo as `[HOST/]OWNER/REPO`.
+            let repo_arg = repo_id.repo_arg();
             tokio::spawn(async move {
                 let num_str = number.to_string();
-                let mut args = vec![
+                let args = vec![
                     "pr",
                     "view",
                     &num_str,
@@ -526,13 +528,6 @@ async fn run(
                     "--json",
                     "number,title,author,state,body,additions,deletions,headRefName",
                 ];
-                // For GHE hosts, add --hostname
-                let hostname_buf;
-                if let Some(h) = &repo_id.host {
-                    hostname_buf = h.clone();
-                    args.push("--hostname");
-                    args.push(hostname_buf.as_str());
-                }
                 let result = run_gh(&args).await;
                 match result {
                     Ok(output) => match serde_json::from_str::<PrDetail>(&output) {
@@ -1219,15 +1214,10 @@ async fn run(
 
         // Open PR in browser if requested
         if let Some((repo_id, pr_number)) = app.open_pr_requested.take() {
-            let repo_arg = format!("{}/{}", repo_id.owner, repo_id.name);
+            // `gh pr view --web` doesn't accept --hostname; embed host into --repo.
+            let repo_arg = repo_id.repo_arg();
             let num = pr_number.to_string();
-            let mut args = vec!["pr", "view", &num, "--web", "--repo", repo_arg.as_str()];
-            let hostname_buf;
-            if let Some(h) = &repo_id.host {
-                hostname_buf = h.clone();
-                args.push("--hostname");
-                args.push(hostname_buf.as_str());
-            }
+            let args = vec!["pr", "view", &num, "--web", "--repo", repo_arg.as_str()];
             let _ = run_gh(&args).await;
         }
 


### PR DESCRIPTION
## Summary

GitHub Enterprise users couldn't see PR details or open PRs in the browser from `gct`. The right detail pane stayed empty and the "open in browser" action did nothing, with `--verbose` showing `unknown flag: --hostname` from `gh pr view`. This PR embeds the host into `--repo` (the documented `[HOST/]OWNER/REPO` form) and centralizes the format in a new `RepoId::repo_arg()` helper.

## Related Issues

Closes #205

## Type of Change

- [x] Bug fix

## Root Cause

`gh pr view` does not accept `--hostname` — only `gh api` does. The two `gh pr view` call sites in `src/main.rs` were pushing `--hostname <host>` whenever `repo_id.host` was `Some(_)`, so every PR detail fetch and "open in browser" action failed on GHE.

Commit `6b74003` previously fixed the same `unknown flag: --hostname` symptom for `gh pr list` by simply removing the flag — but that worked only because `pr list` runs in cwd and auto-detects the host from the local git remote. The two `pr view` call sites pass an explicit `--repo owner/name` to support cross-repo lookups, so without the host `gh` queries github.com (or the user's default `gh auth` host) and fails on Enterprise. The host has to travel with the repo arg.

## Changes

- Add `RepoId::repo_arg()` returning `[HOST/]OWNER/REPO` (`src/git/types.rs`).
- Switch the PR-detail fetch (`src/main.rs:517`) and the open-in-browser action (`src/main.rs:1217`) to call `repo_id.repo_arg()` and drop the `--hostname` push.
- Add unit tests covering host-omitted and host-included cases.

## Checklist

- [x] `cargo build` succeeds
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 143 passed (incl. 2 new `repo_arg_*` tests)

## Test Plan

Automated:
1. `cargo test repo_arg` — both new unit tests pass.
2. `cargo test` — full suite passes.
3. `cargo clippy --all-targets -- -D warnings` — no warnings.

Manual (on a GHE repo):
1. `gct --verbose` in a GHE local repo.
2. Select a branch row whose PR lives on the GHE host — detail pane renders body, additions/deletions, and head ref.
3. Press the "open PR in browser" key — the GHE PR page opens.
4. `tail -n 50 ~/.config/gct/debug.log` shows `gh pr view ... --repo <host>/<owner>/<name> --json ...` with no `unknown flag: --hostname` failures.
5. Repeat 2–3 in a github.com repo — behavior unchanged.