### PR TITLE
Fix elapsed timer continuing after per-op deletion completes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -91,6 +91,8 @@ pub struct OpProgress {
     pub label: String,
     pub current_step: OpStep,
     pub op_started_at: Instant,
+    /// Set when the op reaches `Done`; freezes the elapsed-time display.
+    pub finished_at: Option<Instant>,
     pub last_command: Option<String>,
     pub error: Option<String>,
 }
@@ -101,6 +103,7 @@ impl OpProgress {
             label,
             current_step: OpStep::RunningWtRemove, // overwritten by first OpStepBegin
             op_started_at: Instant::now(),
+            finished_at: None,
             last_command: None,
             error: None,
         }
@@ -155,6 +158,9 @@ impl ProgressTracker {
         if let Some(op) = self.ops.get_mut(&op_id) {
             op.current_step = OpStep::Done { success };
             op.error = error;
+            if op.finished_at.is_none() {
+                op.finished_at = Some(Instant::now());
+            }
         }
     }
 
@@ -164,6 +170,7 @@ impl ProgressTracker {
         for op in self.ops.values_mut() {
             if !op.is_done() {
                 op.current_step = OpStep::Done { success: false };
+                op.finished_at = Some(Instant::now());
                 if op.error.is_none() {
                     op.error = Some("interrupted".to_string());
                 }

--- a/src/ui/progress_panel.rs
+++ b/src/ui/progress_panel.rs
@@ -85,7 +85,9 @@ fn format_op_line(op: &OpProgress, now: Instant) -> Line<'static> {
         .clone()
         .or_else(|| op.error.clone())
         .unwrap_or_else(|| "starting…".to_string());
-    let elapsed = now
+    // Freeze the timer at finished_at for completed ops; live ops keep ticking.
+    let end = op.finished_at.unwrap_or(now);
+    let elapsed = end
         .saturating_duration_since(op.op_started_at)
         .as_secs_f32();
     let row_style = if matches!(op.current_step, OpStep::Done { success: true }) {
@@ -193,6 +195,25 @@ mod tests {
         let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
         assert!(txt.contains("✓"));
         assert!(txt.contains("git worktree remove /wt/a"));
+    }
+
+    #[test]
+    fn format_op_line_elapsed_frozen_after_finish() {
+        let mut op = OpProgress::new("a".into());
+        op.current_step = OpStep::Done { success: true };
+        op.finished_at = Some(op.op_started_at + Duration::from_secs(2));
+        // Render long after completion: timer must stay at the finish time.
+        let line = format_op_line(&op, op.op_started_at + Duration::from_secs(100));
+        let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(txt.contains("2.0s"), "expected frozen elapsed, got: {txt}");
+    }
+
+    #[test]
+    fn format_op_line_elapsed_ticks_while_running() {
+        let op = OpProgress::new("a".into());
+        let line = format_op_line(&op, op.op_started_at + Duration::from_secs(5));
+        let txt: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(txt.contains("5.0s"), "expected live elapsed, got: {txt}");
     }
 
     #[test]


### PR DESCRIPTION
During bulk branch/worktree deletion, the per-item elapsed time kept
counting up until all operations finished, because the renderer always
computed `now - op_started_at` regardless of completion state.

Record `finished_at` on OpProgress when an op reaches Done (both in
finish() and sweep_unfinished()) and use it as the end point in
format_op_line(), freezing the displayed time at the moment each op
completes. The header's overall elapsed time is unchanged.

https://claude.ai/code/session_01F8LsyXy3mQqxwsoDsXZniP