### PR TITLE
feat(worktree): support {repo} placeholder in worktree.dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ If neither path resolves, cross-repo entries remain visible but `Create Worktree
 [worktree]
 # Base directory for new worktrees (default: "..")
 # Branch name becomes the subdirectory: feature/auth → ../feature/auth
+#
+# The `{repo}` token expands to the repository name, so a single global
+# config can keep every repo's worktrees apart, e.g.:
+#   dir = "../wt/{repo}"   # feature/auth → ../wt/<repo-name>/feature/auth
+# A `dir` without `{repo}` behaves exactly as before (backward compatible).
 dir = ".."
 
 # Post-create hooks run automatically after worktree creation.

--- a/src/app.rs
+++ b/src/app.rs
@@ -895,11 +895,14 @@ impl App {
                     return;
                 }
                 let wt_path = if is_active {
-                    self.config.worktree_path(&entry.name)
+                    self.config.worktree_path(&entry.repo_id.name, &entry.name)
                 } else {
                     // unwrap is safe: cross_repo_no_clone is false above
-                    self.config
-                        .worktree_path_for(clone_path.as_ref().unwrap(), &entry.name)
+                    self.config.worktree_path_for(
+                        clone_path.as_ref().unwrap(),
+                        &entry.repo_id.name,
+                        &entry.name,
+                    )
                 };
                 if self.wt_inflight.contains(&wt_path) {
                     return;
@@ -1045,9 +1048,12 @@ impl App {
         let wt_path_for_inflight: Option<String> = if cross_repo_no_clone {
             None
         } else if is_active_repo {
-            Some(self.config.worktree_path(&entry.name))
+            Some(self.config.worktree_path(&entry.repo_id.name, &entry.name))
         } else if let Some(ref root) = clone_path {
-            Some(self.config.worktree_path_for(root, &entry.name))
+            Some(
+                self.config
+                    .worktree_path_for(root, &entry.repo_id.name, &entry.name),
+            )
         } else {
             None
         };

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,18 +78,29 @@ impl Default for WorktreeConfig {
 }
 
 impl Config {
-    /// Build the worktree path for a given branch name.
-    /// Default produces `../{branch_name}` (e.g. `../feature/auth`).
-    /// Custom dir produces `{dir}/{branch_name}`.
-    /// Slashes in branch names become directory separators.
-    pub fn worktree_path(&self, branch_name: &str) -> String {
+    /// Resolve the configured base dir, substituting the `{repo}` placeholder.
+    /// Trims whitespace; empty (or whitespace-only) falls back to
+    /// `DEFAULT_WORKTREE_DIR`. When `{repo}` is absent the string is returned
+    /// unchanged, so existing configs behave exactly as before.
+    fn resolved_base(&self, repo_name: &str) -> String {
         let dir = self.worktree.dir.trim();
         let base = if dir.is_empty() {
             DEFAULT_WORKTREE_DIR
         } else {
             dir
         };
-        Path::new(base)
+        base.replace("{repo}", repo_name)
+    }
+
+    /// Build the worktree path for a given branch name.
+    /// Default produces `../{branch_name}` (e.g. `../feature/auth`).
+    /// Custom dir produces `{dir}/{branch_name}`.
+    /// The `{repo}` token in `dir` expands to the repository name, so
+    /// `dir = "../wt/{repo}"` produces `../wt/{repo}/{branch_name}`.
+    /// Slashes in branch names become directory separators.
+    pub fn worktree_path(&self, repo_name: &str, branch_name: &str) -> String {
+        let base = self.resolved_base(repo_name);
+        Path::new(&base)
             .join(branch_name)
             .to_string_lossy()
             .to_string()
@@ -97,15 +108,17 @@ impl Config {
 
     /// Build a worktree path relative to a specific repo root.
     /// `dir = ".."` produces `<repo_root>/../<branch>` (= sibling of repo).
-    pub fn worktree_path_for(&self, repo_root: &Path, branch_name: &str) -> String {
-        let dir = self.worktree.dir.trim();
-        let base = if dir.is_empty() {
-            DEFAULT_WORKTREE_DIR
-        } else {
-            dir
-        };
+    /// The `{repo}` token in `dir` expands to the repository name, so
+    /// `dir = "../wt/{repo}"` produces `<repo_root>/../wt/{repo}/<branch>`.
+    pub fn worktree_path_for(
+        &self,
+        repo_root: &Path,
+        repo_name: &str,
+        branch_name: &str,
+    ) -> String {
+        let base = self.resolved_base(repo_name);
         repo_root
-            .join(base)
+            .join(&base)
             .join(branch_name)
             .to_string_lossy()
             .to_string()
@@ -300,7 +313,10 @@ mod tests {
     #[test]
     fn test_default_worktree_path() {
         let config = Config::default();
-        assert_eq!(config.worktree_path("feature/auth"), "../feature/auth");
+        assert_eq!(
+            config.worktree_path("name", "feature/auth"),
+            "../feature/auth"
+        );
     }
 
     #[test]
@@ -314,7 +330,71 @@ mod tests {
         };
         let expected = Path::new("../wt").join("feature/auth");
         assert_eq!(
-            config.worktree_path("feature/auth"),
+            config.worktree_path("name", "feature/auth"),
+            expected.to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn test_worktree_path_repo_placeholder() {
+        let config = Config {
+            worktree: WorktreeConfig {
+                dir: "../wt/{repo}".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let expected = Path::new("../wt/myrepo").join("feature/auth");
+        assert_eq!(
+            config.worktree_path("myrepo", "feature/auth"),
+            expected.to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn test_worktree_path_no_placeholder_ignores_repo_name() {
+        let config = Config {
+            worktree: WorktreeConfig {
+                dir: "../wt".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        // Passing any repo name must not change a dir without `{repo}`.
+        let expected = Path::new("../wt").join("feature/auth");
+        assert_eq!(
+            config.worktree_path("anything", "feature/auth"),
+            expected.to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn test_worktree_path_empty_dir_with_repo_name() {
+        let config = Config {
+            worktree: WorktreeConfig {
+                dir: "  ".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert_eq!(
+            config.worktree_path("myrepo", "feature/auth"),
+            "../feature/auth"
+        );
+    }
+
+    #[test]
+    fn test_worktree_path_placeholder_only() {
+        let config = Config {
+            worktree: WorktreeConfig {
+                dir: "{repo}".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let expected = Path::new("myrepo").join("br");
+        assert_eq!(
+            config.worktree_path("myrepo", "br"),
             expected.to_string_lossy()
         );
     }
@@ -366,7 +446,10 @@ dir = "../wt"
             },
             ..Default::default()
         };
-        assert_eq!(config.worktree_path("feature/auth"), "../feature/auth");
+        assert_eq!(
+            config.worktree_path("name", "feature/auth"),
+            "../feature/auth"
+        );
     }
 
     #[test]
@@ -638,7 +721,7 @@ clone_root = "~/workspace"
     fn worktree_path_for_default_dir() {
         let config = Config::default();
         let root = Path::new("/repos/owner/name");
-        let p = config.worktree_path_for(root, "feature/auth");
+        let p = config.worktree_path_for(root, "name", "feature/auth");
         let expected = Path::new("/repos/owner/name")
             .join("..")
             .join("feature/auth");
@@ -655,8 +738,25 @@ clone_root = "~/workspace"
             ..Default::default()
         };
         let root = Path::new("/repos/owner/name");
-        let p = config.worktree_path_for(root, "feature/x");
+        let p = config.worktree_path_for(root, "name", "feature/x");
         let expected = Path::new("/repos/owner/name").join("wt").join("feature/x");
+        assert_eq!(p, expected.to_string_lossy().to_string());
+    }
+
+    #[test]
+    fn test_worktree_path_for_repo_placeholder() {
+        let config = Config {
+            worktree: WorktreeConfig {
+                dir: "../wt/{repo}".to_string(),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let root = Path::new("/repos/owner/name");
+        let p = config.worktree_path_for(root, "name", "feature/x");
+        let expected = Path::new("/repos/owner/name")
+            .join("../wt/name")
+            .join("feature/x");
         assert_eq!(p, expected.to_string_lossy().to_string());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1050,7 +1050,9 @@ async fn run(
                 }
             };
 
-            let wt_path = app.config.worktree_path_for(&target_root, &branch_name);
+            let wt_path =
+                app.config
+                    .worktree_path_for(&target_root, &entry.repo_id.name, &branch_name);
             app.wt_inflight.insert(wt_path.clone());
             if let Some(parent) = std::path::Path::new(&wt_path).parent() {
                 let _ = std::fs::create_dir_all(parent);


### PR DESCRIPTION
Allow `worktree.dir` to contain a `{repo}` token that expands to the
repository name, so a single global ~/.config/gct/config.toml can place
every repo's worktrees under e.g. ../wt/<repo>/<branch> without collisions.

A `dir` without `{repo}` is unchanged (backward compatible). The repo name
comes from RepoId.name and is threaded into worktree_path/worktree_path_for
at all call sites.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QAuvfDxCVSMn82cx3gtwgB