### PR TITLE
feat(config): per-repo worktree config — {repo} placeholder, deep-merge, and cross-repo overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ For cross-repo PRs, `Create Worktree` and `cd into Worktree` operate on the loca
 
 If neither path resolves, cross-repo entries remain visible but `Create Worktree` is greyed out with a one-line hint pointing at the expected clone location.
 
+**Per-repo config for cross-repo worktrees:** when you create a worktree for another repo, gct applies that **target repo's** `.gct.toml` (merged on top of your global config), not the `.gct.toml` of the repo you launched gct from. So each repo's `worktree.dir` and `post_create` hooks take effect even when created from elsewhere.
+
 **Cross-host coverage:** My PR / My Review fan out across every host present in the repos gct has discovered locally (origin remotes), so a workspace mixing github.com clones with GitHub Enterprise clones surfaces PRs from both. Hosts you are authenticated to but have never cloned from are skipped — clone any one repo from that host (or `cd` into one) so gct can pick it up.
 
 **Limitations (v1):** Bulk delete (`d` after Space-selection) still operates on active-repo branches only.

--- a/README.md
+++ b/README.md
@@ -130,13 +130,38 @@ gct --verbose
 
 ## Configuration
 
-gct reads configuration from the first file found in this order:
+gct deep-merges every config file it finds, from lowest to highest priority:
 
-1. `.gct.toml` in the repository root (project-local)
+1. `~/.gct.toml` (global, lowest priority)
 2. `~/.config/gct/config.toml` (global)
-3. `~/.gct.toml` (global)
+3. `.gct.toml` in the repository root (project-local, highest priority)
 
-Project-local config is useful for per-repo worktree hooks (e.g. copying `.env`, running `npm ci`).
+Higher-priority files override lower ones **key by key**: nested tables
+(`[worktree]`, `[workspace]`) are merged, so a project-local `.gct.toml` can
+override individual settings while inheriting the rest from your global config.
+Scalars and arrays (e.g. `worktree.dir`, `protected_branches`) are replaced
+wholesale by the highest-priority file that sets them.
+
+For example, with a global `~/.config/gct/config.toml`:
+
+```toml
+[workspace]
+clone_root = "~/workspace"
+
+[worktree]
+dir = "../wt/{repo}"
+```
+
+a repo-specific `.gct.toml` containing only:
+
+```toml
+[worktree]
+dir = "../custom"
+```
+
+uses `../custom` for that repo's worktrees while still inheriting `clone_root`
+from the global config. Project-local config is also useful for per-repo
+worktree hooks (e.g. copying `.env`, running `npm ci`).
 
 ### Cross-repo Reviews
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -281,8 +281,12 @@ pub struct App {
     // Spinner animation
     spinner_tick: usize,
 
-    // Loaded TOML config (protected_branches, worktree, …)
+    // Loaded TOML config (protected_branches, worktree, …) for the active repo.
     pub config: crate::config::Config,
+
+    // Merged global config layers (home-dir files only), used to resolve a
+    // per-repo effective config for cross-repo worktree operations.
+    pub global_layers: toml::Table,
 
     // Cross-repo context (set at startup)
     pub active_repo: Option<crate::git::types::RepoId>,
@@ -359,6 +363,7 @@ impl App {
             commits_reload_requested: false,
             spinner_tick: 0,
             config,
+            global_layers: toml::Table::new(),
             active_repo: None,
             clone_root: None,
             repos: HashMap::new(),
@@ -898,8 +903,11 @@ impl App {
                     self.config.worktree_path(&entry.repo_id.name, &entry.name)
                 } else {
                     // unwrap is safe: cross_repo_no_clone is false above
-                    self.config.worktree_path_for(
-                        clone_path.as_ref().unwrap(),
+                    let root = clone_path.as_ref().unwrap();
+                    // Cross-repo: resolve the target repo's own config so its
+                    // `.gct.toml` applies (must match main.rs's creation path).
+                    self.resolve_repo_config(root).worktree_path_for(
+                        root,
                         &entry.repo_id.name,
                         &entry.name,
                     )
@@ -1050,10 +1058,12 @@ impl App {
         } else if is_active_repo {
             Some(self.config.worktree_path(&entry.repo_id.name, &entry.name))
         } else if let Some(ref root) = clone_path {
-            Some(
-                self.config
-                    .worktree_path_for(root, &entry.repo_id.name, &entry.name),
-            )
+            // Cross-repo: resolve the target repo's own config (matches main.rs).
+            Some(self.resolve_repo_config(root).worktree_path_for(
+                root,
+                &entry.repo_id.name,
+                &entry.name,
+            ))
         } else {
             None
         };
@@ -1302,6 +1312,13 @@ impl App {
         } else {
             set.into_iter().collect()
         }
+    }
+
+    /// Effective config for a specific repo root: the global layers overlaid
+    /// with `<repo_root>/.gct.toml`. Used for cross-repo worktree operations so
+    /// the target repo's own `.gct.toml` applies (not the launching repo's).
+    pub fn resolve_repo_config(&self, repo_root: &std::path::Path) -> crate::config::Config {
+        crate::config::resolve_config(&self.global_layers, Some(repo_root))
     }
 
     /// Resolve a repo's local clone path under `clone_root`. Idempotent: only

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,8 +228,10 @@ fn run_command(command: &str, work_dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Load config by deep-merging every existing config file in priority order
-/// (later layers override earlier ones key-by-key):
+/// Load the effective config for the current directory's repository:
+/// global layers overlaid with the repo-local `.gct.toml` (if any).
+///
+/// Layers are deep-merged in priority order (later overrides earlier):
 /// 1. `~/.gct.toml` (global, lowest priority)
 /// 2. `~/.config/gct/config.toml` (global)
 /// 3. `.gct.toml` at the git repository root (project-local, highest priority)
@@ -240,31 +242,45 @@ fn run_command(command: &str, work_dir: &Path) -> std::io::Result<()> {
 ///
 /// Must be called before TUI initialization (eprintln warnings).
 pub fn load_config() -> Config {
-    // `config_paths()` is ordered highest → lowest priority; reverse it so we
-    // apply lowest first and let higher-priority layers override.
-    let mut layers = Vec::new();
-    for path in config_paths().into_iter().rev() {
-        match fs::read_to_string(&path) {
-            Ok(content) => layers.push((path, content)),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => {
-                eprintln!("Warning: failed to read {}: {e}", path.display());
-                continue;
-            }
-        }
-    }
-    merge_layers(&layers)
+    resolve_config(&load_global_layers(), git_repo_root().as_deref())
 }
 
-/// Parse TOML layers in increasing priority order and deep-merge them.
-/// Invalid layers are skipped with a warning; serde defaults fill the rest.
-fn merge_layers(layers: &[(PathBuf, String)]) -> Config {
-    let mut merged = toml::Table::new();
-    for (path, content) in layers {
-        match toml::from_str::<toml::Table>(content) {
-            Ok(t) => merge_tables(&mut merged, t),
+/// Read a TOML file and deep-merge it into `merged`. A missing file is ignored;
+/// read/parse errors are warned about and skipped.
+fn read_and_merge(path: &Path, merged: &mut toml::Table) {
+    match fs::read_to_string(path) {
+        Ok(content) => match toml::from_str::<toml::Table>(&content) {
+            Ok(t) => merge_tables(merged, t),
             Err(e) => eprintln!("Warning: failed to parse {}: {e}", path.display()),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => eprintln!("Warning: failed to read {}: {e}", path.display()),
+    }
+}
+
+/// Deep-merge only the global (home-dir) config files into a raw table.
+/// Order: `~/.gct.toml` (low) then `~/.config/gct/config.toml` (high).
+/// The result is the base onto which any repo-local `.gct.toml` is overlaid.
+pub fn load_global_layers() -> toml::Table {
+    let mut merged = toml::Table::new();
+    if let Some(home) = home_dir() {
+        // config_paths_for_home() is ordered high→low; reverse to apply low→high.
+        for path in config_paths_for_home(&home).into_iter().rev() {
+            read_and_merge(&path, &mut merged);
         }
+    }
+    merged
+}
+
+/// Resolve the effective Config for a specific repository: the global layers
+/// overlaid with `<repo_root>/.gct.toml` (if present). `repo_root = None`
+/// yields the global-only config. This is what cross-repo worktree operations
+/// use so the target repo's own `.gct.toml` applies (the launching repo's
+/// project-local config does not leak into other repos).
+pub fn resolve_config(global: &toml::Table, repo_root: Option<&Path>) -> Config {
+    let mut merged = global.clone();
+    if let Some(root) = repo_root {
+        read_and_merge(&root.join(".gct.toml"), &mut merged);
     }
     toml::Value::Table(merged).try_into().unwrap_or_else(|e| {
         eprintln!("Warning: invalid merged config: {e}");
@@ -285,18 +301,7 @@ fn merge_tables(base: &mut toml::Table, overlay: toml::Table) {
     }
 }
 
-fn config_paths() -> Vec<PathBuf> {
-    let mut paths = Vec::new();
-    if let Some(root) = git_repo_root() {
-        paths.push(root.join(".gct.toml"));
-    }
-    if let Some(home) = home_dir() {
-        paths.extend(config_paths_for_home(&home));
-    }
-    paths
-}
-
-fn git_repo_root() -> Option<PathBuf> {
+pub fn git_repo_root() -> Option<PathBuf> {
     std::process::Command::new("git")
         .args(["rev-parse", "--show-toplevel"])
         .output()
@@ -452,19 +457,6 @@ dir = "../wt"
         assert_eq!(paths.len(), 2);
         assert_eq!(paths[0], home.join(".config/gct/config.toml"));
         assert_eq!(paths[1], home.join(".gct.toml"));
-    }
-
-    #[test]
-    fn test_config_paths_includes_local() {
-        let paths = config_paths();
-        // When run inside a git repo, first entry should be .gct.toml at repo root
-        if git_repo_root().is_some() {
-            assert!(paths[0].ends_with(".gct.toml"));
-        }
-        // Global paths should be present if home is available
-        if home_dir().is_some() {
-            assert!(paths.len() >= 2);
-        }
     }
 
     #[test]
@@ -792,24 +784,35 @@ clone_root = "~/workspace"
 
     // --- config merge ---
 
-    fn layer(content: &str) -> (PathBuf, String) {
-        (PathBuf::from("test.toml"), content.to_string())
+    /// Deep-merge TOML source layers (low→high priority) into a Config,
+    /// mirroring `read_and_merge` semantics (invalid layers are skipped).
+    fn merge_strs(layers: &[&str]) -> Config {
+        let mut merged = toml::Table::new();
+        for content in layers {
+            if let Ok(t) = toml::from_str::<toml::Table>(content) {
+                merge_tables(&mut merged, t);
+            }
+        }
+        toml::Value::Table(merged)
+            .try_into()
+            .unwrap_or_else(|_| Config::default())
     }
 
     #[test]
     fn merge_local_overrides_global_scalar() {
-        let global = layer("[worktree]\ndir = \"..\"\n");
-        let local = layer("[worktree]\ndir = \"../wt\"\n");
-        let config = merge_layers(&[global, local]);
+        let config = merge_strs(&[
+            "[worktree]\ndir = \"..\"\n",
+            "[worktree]\ndir = \"../wt\"\n",
+        ]);
         assert_eq!(config.worktree.dir, "../wt");
     }
 
     #[test]
     fn merge_keeps_global_when_local_absent() {
-        let global =
-            layer("[workspace]\nclone_root = \"~/workspace\"\n\n[worktree]\ndir = \"..\"\n");
-        let local = layer("[worktree]\ndir = \"../wt\"\n");
-        let config = merge_layers(&[global, local]);
+        let config = merge_strs(&[
+            "[workspace]\nclone_root = \"~/workspace\"\n\n[worktree]\ndir = \"..\"\n",
+            "[worktree]\ndir = \"../wt\"\n",
+        ]);
         // local overrides dir, but global's clone_root is preserved.
         assert_eq!(config.worktree.dir, "../wt");
         assert_eq!(config.workspace.clone_root.as_deref(), Some("~/workspace"));
@@ -817,11 +820,10 @@ clone_root = "~/workspace"
 
     #[test]
     fn merge_nested_table_preserves_sibling_keys() {
-        let global = layer(
+        let config = merge_strs(&[
             "[worktree]\ndir = \"..\"\n\n[[worktree.post_create]]\ntype = \"command\"\ncommand = \"npm ci\"\n",
-        );
-        let local = layer("[worktree]\ndir = \"../wt\"\n");
-        let config = merge_layers(&[global, local]);
+            "[worktree]\ndir = \"../wt\"\n",
+        ]);
         assert_eq!(config.worktree.dir, "../wt");
         // post_create from global survives because local only set `dir`.
         assert_eq!(config.worktree.post_create.len(), 1);
@@ -829,9 +831,10 @@ clone_root = "~/workspace"
 
     #[test]
     fn merge_local_array_replaces_global() {
-        let global = layer("protected_branches = [\"main\"]\n");
-        let local = layer("protected_branches = [\"x\", \"y\"]\n");
-        let config = merge_layers(&[global, local]);
+        let config = merge_strs(&[
+            "protected_branches = [\"main\"]\n",
+            "protected_branches = [\"x\", \"y\"]\n",
+        ]);
         assert_eq!(
             config.protected_branches,
             vec!["x".to_string(), "y".to_string()]
@@ -840,7 +843,7 @@ clone_root = "~/workspace"
 
     #[test]
     fn merge_empty_layers_is_default() {
-        let config = merge_layers(&[]);
+        let config = merge_strs(&[]);
         let default = Config::default();
         assert_eq!(config.worktree.dir, default.worktree.dir);
         assert_eq!(config.protected_branches, default.protected_branches);
@@ -849,8 +852,7 @@ clone_root = "~/workspace"
 
     #[test]
     fn merge_single_layer_applies_defaults() {
-        let local = layer("[worktree]\ndir = \"../wt\"\n");
-        let config = merge_layers(&[local]);
+        let config = merge_strs(&["[worktree]\ndir = \"../wt\"\n"]);
         assert_eq!(config.worktree.dir, "../wt");
         // Unspecified fields fall back to serde defaults.
         assert_eq!(config.protected_branches, default_protected_branches());
@@ -858,9 +860,10 @@ clone_root = "~/workspace"
 
     #[test]
     fn merge_skips_invalid_layer() {
-        let bad = layer("this is = not = valid toml\n");
-        let good = layer("[worktree]\ndir = \"../wt\"\n");
-        let config = merge_layers(&[bad, good]);
+        let config = merge_strs(&[
+            "this is = not = valid toml\n",
+            "[worktree]\ndir = \"../wt\"\n",
+        ]);
         assert_eq!(config.worktree.dir, "../wt");
     }
 
@@ -874,5 +877,55 @@ clone_root = "~/workspace"
         assert_eq!(a["y"].as_integer(), Some(9)); // overridden
         // array replaced wholesale, not appended
         assert_eq!(a["arr"].as_array().unwrap().len(), 1);
+    }
+
+    // --- resolve_config (per-repo overlay) ---
+
+    #[test]
+    fn resolve_config_repo_root_none() {
+        let global: toml::Table = toml::from_str("[worktree]\ndir = \"../g\"\n").unwrap();
+        let config = resolve_config(&global, None);
+        assert_eq!(config.worktree.dir, "../g");
+    }
+
+    #[test]
+    fn resolve_config_no_local_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let global: toml::Table = toml::from_str("[worktree]\ndir = \"../g\"\n").unwrap();
+        // No .gct.toml in tmp dir → global values stay.
+        let config = resolve_config(&global, Some(tmp.path()));
+        assert_eq!(config.worktree.dir, "../g");
+    }
+
+    #[test]
+    fn resolve_config_overlays_repo_local() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(
+            tmp.path().join(".gct.toml"),
+            "[worktree]\ndir = \"../custom\"\n",
+        )
+        .unwrap();
+        let global: toml::Table = toml::from_str("[worktree]\ndir = \"..\"\n").unwrap();
+        let config = resolve_config(&global, Some(tmp.path()));
+        assert_eq!(config.worktree.dir, "../custom");
+    }
+
+    #[test]
+    fn resolve_config_inherits_global_when_key_absent() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Repo-local only overrides worktree.dir.
+        fs::write(
+            tmp.path().join(".gct.toml"),
+            "[worktree]\ndir = \"../custom\"\n",
+        )
+        .unwrap();
+        let global: toml::Table = toml::from_str(
+            "[workspace]\nclone_root = \"~/workspace\"\n\n[worktree]\ndir = \"..\"\n",
+        )
+        .unwrap();
+        let config = resolve_config(&global, Some(tmp.path()));
+        assert_eq!(config.worktree.dir, "../custom");
+        // clone_root is inherited from the global layers.
+        assert_eq!(config.workspace.clone_root.as_deref(), Some("~/workspace"));
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -228,23 +228,24 @@ fn run_command(command: &str, work_dir: &Path) -> std::io::Result<()> {
     Ok(())
 }
 
-/// Load config from the first valid file found:
-/// 1. `.gct.toml` (project-local, git repository root via `git rev-parse --show-toplevel`)
+/// Load config by deep-merging every existing config file in priority order
+/// (later layers override earlier ones key-by-key):
+/// 1. `~/.gct.toml` (global, lowest priority)
 /// 2. `~/.config/gct/config.toml` (global)
-/// 3. `~/.gct.toml` (global)
+/// 3. `.gct.toml` at the git repository root (project-local, highest priority)
+///
+/// Nested tables (`[worktree]`, `[workspace]`) are merged key-by-key, so a
+/// project-local file can override individual settings while inheriting the
+/// rest from the global config. Scalars and arrays are replaced wholesale.
 ///
 /// Must be called before TUI initialization (eprintln warnings).
 pub fn load_config() -> Config {
-    let candidates = config_paths();
-    for path in &candidates {
-        match fs::read_to_string(path) {
-            Ok(content) => match toml::from_str::<Config>(&content) {
-                Ok(config) => return config,
-                Err(e) => {
-                    eprintln!("Warning: failed to parse {}: {e}", path.display());
-                    continue;
-                }
-            },
+    // `config_paths()` is ordered highest → lowest priority; reverse it so we
+    // apply lowest first and let higher-priority layers override.
+    let mut layers = Vec::new();
+    for path in config_paths().into_iter().rev() {
+        match fs::read_to_string(&path) {
+            Ok(content) => layers.push((path, content)),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
             Err(e) => {
                 eprintln!("Warning: failed to read {}: {e}", path.display());
@@ -252,7 +253,36 @@ pub fn load_config() -> Config {
             }
         }
     }
-    Config::default()
+    merge_layers(&layers)
+}
+
+/// Parse TOML layers in increasing priority order and deep-merge them.
+/// Invalid layers are skipped with a warning; serde defaults fill the rest.
+fn merge_layers(layers: &[(PathBuf, String)]) -> Config {
+    let mut merged = toml::Table::new();
+    for (path, content) in layers {
+        match toml::from_str::<toml::Table>(content) {
+            Ok(t) => merge_tables(&mut merged, t),
+            Err(e) => eprintln!("Warning: failed to parse {}: {e}", path.display()),
+        }
+    }
+    toml::Value::Table(merged).try_into().unwrap_or_else(|e| {
+        eprintln!("Warning: invalid merged config: {e}");
+        Config::default()
+    })
+}
+
+/// Deep-merge `overlay` into `base`. Nested tables are merged key-by-key;
+/// scalars and arrays from `overlay` replace those in `base`.
+fn merge_tables(base: &mut toml::Table, overlay: toml::Table) {
+    for (k, v) in overlay {
+        match (base.get_mut(&k), v) {
+            (Some(toml::Value::Table(bt)), toml::Value::Table(ot)) => merge_tables(bt, ot),
+            (_, v) => {
+                base.insert(k, v);
+            }
+        }
+    }
 }
 
 fn config_paths() -> Vec<PathBuf> {
@@ -758,5 +788,91 @@ clone_root = "~/workspace"
             .join("../wt/name")
             .join("feature/x");
         assert_eq!(p, expected.to_string_lossy().to_string());
+    }
+
+    // --- config merge ---
+
+    fn layer(content: &str) -> (PathBuf, String) {
+        (PathBuf::from("test.toml"), content.to_string())
+    }
+
+    #[test]
+    fn merge_local_overrides_global_scalar() {
+        let global = layer("[worktree]\ndir = \"..\"\n");
+        let local = layer("[worktree]\ndir = \"../wt\"\n");
+        let config = merge_layers(&[global, local]);
+        assert_eq!(config.worktree.dir, "../wt");
+    }
+
+    #[test]
+    fn merge_keeps_global_when_local_absent() {
+        let global =
+            layer("[workspace]\nclone_root = \"~/workspace\"\n\n[worktree]\ndir = \"..\"\n");
+        let local = layer("[worktree]\ndir = \"../wt\"\n");
+        let config = merge_layers(&[global, local]);
+        // local overrides dir, but global's clone_root is preserved.
+        assert_eq!(config.worktree.dir, "../wt");
+        assert_eq!(config.workspace.clone_root.as_deref(), Some("~/workspace"));
+    }
+
+    #[test]
+    fn merge_nested_table_preserves_sibling_keys() {
+        let global = layer(
+            "[worktree]\ndir = \"..\"\n\n[[worktree.post_create]]\ntype = \"command\"\ncommand = \"npm ci\"\n",
+        );
+        let local = layer("[worktree]\ndir = \"../wt\"\n");
+        let config = merge_layers(&[global, local]);
+        assert_eq!(config.worktree.dir, "../wt");
+        // post_create from global survives because local only set `dir`.
+        assert_eq!(config.worktree.post_create.len(), 1);
+    }
+
+    #[test]
+    fn merge_local_array_replaces_global() {
+        let global = layer("protected_branches = [\"main\"]\n");
+        let local = layer("protected_branches = [\"x\", \"y\"]\n");
+        let config = merge_layers(&[global, local]);
+        assert_eq!(
+            config.protected_branches,
+            vec!["x".to_string(), "y".to_string()]
+        );
+    }
+
+    #[test]
+    fn merge_empty_layers_is_default() {
+        let config = merge_layers(&[]);
+        let default = Config::default();
+        assert_eq!(config.worktree.dir, default.worktree.dir);
+        assert_eq!(config.protected_branches, default.protected_branches);
+        assert!(config.workspace.clone_root.is_none());
+    }
+
+    #[test]
+    fn merge_single_layer_applies_defaults() {
+        let local = layer("[worktree]\ndir = \"../wt\"\n");
+        let config = merge_layers(&[local]);
+        assert_eq!(config.worktree.dir, "../wt");
+        // Unspecified fields fall back to serde defaults.
+        assert_eq!(config.protected_branches, default_protected_branches());
+    }
+
+    #[test]
+    fn merge_skips_invalid_layer() {
+        let bad = layer("this is = not = valid toml\n");
+        let good = layer("[worktree]\ndir = \"../wt\"\n");
+        let config = merge_layers(&[bad, good]);
+        assert_eq!(config.worktree.dir, "../wt");
+    }
+
+    #[test]
+    fn merge_tables_recurses_and_replaces_arrays() {
+        let mut base: toml::Table = toml::from_str("[a]\nx = 1\ny = 2\narr = [1, 2]\n").unwrap();
+        let overlay: toml::Table = toml::from_str("[a]\ny = 9\narr = [3]\n").unwrap();
+        merge_tables(&mut base, overlay);
+        let a = base["a"].as_table().unwrap();
+        assert_eq!(a["x"].as_integer(), Some(1)); // untouched sibling kept
+        assert_eq!(a["y"].as_integer(), Some(9)); // overridden
+        // array replaced wholesale, not appended
+        assert_eq!(a["arr"].as_array().unwrap().len(), 1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -394,6 +394,9 @@ async fn run(
 ) -> (anyhow::Result<()>, Option<String>) {
     let mut app = App::new(config);
     app.verbose = verbose;
+    // Global (home-dir) config layers, used to resolve a per-target-repo
+    // effective config for cross-repo worktree operations.
+    app.global_layers = config::load_global_layers();
     let mut events = EventHandler::new(Duration::from_millis(80));
     let (tx, mut rx) = mpsc::unbounded_channel::<AsyncResult>();
     let mut pr_inflight: HashSet<(crate::git::types::RepoId, u64)> = HashSet::new();
@@ -1050,9 +1053,15 @@ async fn run(
                 }
             };
 
-            let wt_path =
-                app.config
-                    .worktree_path_for(&target_root, &entry.repo_id.name, &branch_name);
+            // Active repo uses the launch config; cross-repo resolves the
+            // target repo's own config (global layers + <target_root>/.gct.toml).
+            let cfg = if is_active {
+                app.config.clone()
+            } else {
+                config::resolve_config(&app.global_layers, Some(&target_root))
+            };
+
+            let wt_path = cfg.worktree_path_for(&target_root, &entry.repo_id.name, &branch_name);
             app.wt_inflight.insert(wt_path.clone());
             if let Some(parent) = std::path::Path::new(&wt_path).parent() {
                 let _ = std::fs::create_dir_all(parent);
@@ -1060,7 +1069,7 @@ async fn run(
 
             let is_active_with_local =
                 is_active && app.branches.iter().any(|b| b.name == branch_name);
-            let post_create = app.config.worktree.post_create.clone();
+            let post_create = cfg.worktree.post_create.clone();
             let target_repo_for_send = if is_active {
                 None
             } else {


### PR DESCRIPTION
## Summary

Makes gct's configuration usable for multi-repo workflows. Three related changes to worktree/config handling:

1. **`{repo}` placeholder in `worktree.dir`** — a single global `~/.config/gct/config.toml` can place every repo's worktrees apart, e.g. `dir = "../wt/{repo}"` → `<repo_root>/../wt/<repo-name>/<branch>`. The repo name comes from `RepoId.name`. A `dir` without `{repo}` is unchanged (backward compatible).

2. **Deep-merge config files instead of first-wins** — `load_config` now layers every existing config file in priority order (`~/.gct.toml` < `~/.config/gct/config.toml` < `<repo>/.gct.toml`) and deep-merges them. Nested tables (`[worktree]`, `[workspace]`) merge key-by-key; scalars/arrays are replaced by the highest-priority file that sets them. A project-local `.gct.toml` can now override individual settings while inheriting the rest from the global config, instead of fully replacing it.

3. **Per-target-repo config for cross-repo worktrees** — config loading is split into global layers (home-dir files) and a per-repo overlay via `config::resolve_config(global, repo_root)`. When creating a worktree for another repo (e.g. from Review mode), gct now applies the **target repo's** `.gct.toml` (merged on top of the global config) for `worktree.dir` and `post_create` — not the launching repo's. The launching repo's project-local config no longer leaks into other repos. The active repo keeps using `app.config`.

## Notes

- `protected_branches` (active-repo-only deletion) and `workspace.clone_root` (global discovery setting) intentionally stay on the global/active config.
- Cross-repo inflight dedup keys stay consistent: app.rs and main.rs both resolve the same per-repo config from the same clone path.

## Files

- `src/config.rs` — `{repo}` substitution, `load_global_layers`, `resolve_config`, `merge_tables`; tests
- `src/app.rs` — `global_layers` field, `resolve_repo_config`, cross-repo inflight path resolution
- `src/main.rs` — set `global_layers` at startup; per-repo config at worktree creation
- `README.md` — Configuration and Cross-repo sections

## Verification

- `cargo fmt`, `cargo clippy --all-targets -- -D warnings` — pass
- `cargo test` — 164 passed (incl. new `{repo}`, merge, and `resolve_config` tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QAuvfDxCVSMn82cx3gtwgB)_