### PR TITLE
test(git): add injection seam + integration tests for the CLI-shelling layer

### DIFF
--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -14,6 +14,19 @@ use tokio::process::Command;
 /// none of which should ever freeze the app indefinitely.
 const CMD_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Injection seam: resolves the actual binary spawned for `git`/`gh` calls,
+/// letting tests substitute a stub executable (a fake `git`/`gh` script) via
+/// `GCT_GIT_BIN` / `GCT_GH_BIN` without touching production call sites, which
+/// always pass the logical name (`"git"` or `"gh"`).
+fn resolve_executable(executable: &'static str) -> String {
+    let env_var = match executable {
+        "git" => "GCT_GIT_BIN",
+        "gh" => "GCT_GH_BIN",
+        _ => return executable.to_string(),
+    };
+    std::env::var(env_var).unwrap_or_else(|_| executable.to_string())
+}
+
 /// Runs `cmd` to completion, enforcing [`CMD_TIMEOUT`] and closing stdin so a
 /// stray interactive prompt (credential/auth/pager/editor) can't block on
 /// input that will never arrive. Shared by every code path that spawns
@@ -220,7 +233,7 @@ async fn run_cmd_tagged(
     let started_at = Instant::now();
     let owned_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
 
-    let mut cmd = Command::new(executable);
+    let mut cmd = Command::new(resolve_executable(executable));
     cmd.args(args);
     let output = match run_with_timeout(&mut cmd).await {
         Ok(o) => o,
@@ -290,7 +303,7 @@ async fn run_cmd_in_dir_tagged(
     let started_at = Instant::now();
     let owned_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
 
-    let mut cmd = Command::new(executable);
+    let mut cmd = Command::new(resolve_executable(executable));
     cmd.args(args).current_dir(cwd);
     let output = match run_with_timeout(&mut cmd).await {
         Ok(o) => o,
@@ -370,9 +383,17 @@ mod plumbing_tests {
             &["--version"],
         )
         .await;
+        // `COMMAND_HISTORY` is a global buffer shared by every test in this
+        // binary running concurrently, so this test's record isn't
+        // guaranteed to be the most recent one by the time we read it back
+        // — find it by its distinguishing feature (repo set) instead of
+        // assuming order.
         let history = command_history_snapshot();
-        let last = history.first().expect("history should have an entry");
-        assert!(last.repo.is_some());
+        let recorded = history.iter().find(|r| r.repo.is_some());
+        assert!(
+            recorded.is_some(),
+            "expected a recorded command with repo set"
+        );
     }
 
     #[cfg(unix)]

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -1,0 +1,247 @@
+//! Black-box integration tests for gct's non-TUI CLI subcommands.
+//!
+//! These drive the compiled `gct` binary as a real subprocess against a
+//! temp git repo created with the real `git` CLI (via `tempfile`), so they
+//! exercise the actual command/exec/parse round-trip that unit tests can't
+//! reach. `gct` is a binary-only crate (no `[lib]` target), so this is the
+//! only way to test it as a black box rather than reaching into internals.
+//!
+//! A couple of tests also exercise the `GCT_GIT_BIN` injection seam
+//! (`src/git/command.rs`), proving that overriding it actually substitutes
+//! a different executable rather than being silently ignored.
+
+use std::path::Path;
+use std::process::{Command, Output};
+
+fn gct_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_gct")
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .expect("git should be installed and on PATH");
+    assert!(status.success(), "git {args:?} failed in {dir:?}");
+}
+
+/// Initializes a temp repo with one commit on `main`, so it looks like a
+/// normal small local repository from gct's point of view.
+///
+/// Sets `worktree.dir = "wt"` via a repo-local `.gct.toml` so any worktree
+/// `gct wt` creates lands inside this same temp dir (and is cleaned up when
+/// it drops), rather than the default `../<branch>` — which, since every
+/// `tempfile::tempdir()` repo is a sibling under `/tmp`, would make separate
+/// test repos collide on the same `/tmp/<branch>` path.
+fn init_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    run_git(dir.path(), &["init", "-q", "-b", "main"]);
+    run_git(
+        dir.path(),
+        &["config", "user.email", "gct-test@example.com"],
+    );
+    run_git(dir.path(), &["config", "user.name", "gct-test"]);
+    std::fs::write(dir.path().join(".gct.toml"), "[worktree]\ndir = \"wt\"\n")
+        .expect("write .gct.toml");
+    std::fs::write(dir.path().join("README.md"), "hello\n").expect("write README");
+    run_git(dir.path(), &["add", "."]);
+    run_git(dir.path(), &["commit", "-q", "-m", "init"]);
+    dir
+}
+
+fn run_gct(dir: &Path, args: &[&str]) -> Output {
+    Command::new(gct_bin())
+        .args(args)
+        .current_dir(dir)
+        // Never inherit an override from the outer test-runner environment.
+        .env_remove("GCT_GIT_BIN")
+        .env_remove("GCT_GH_BIN")
+        .output()
+        .expect("failed to run gct binary")
+}
+
+fn run_gct_with_git_bin(dir: &Path, args: &[&str], git_bin: &str) -> Output {
+    Command::new(gct_bin())
+        .args(args)
+        .current_dir(dir)
+        .env("GCT_GIT_BIN", git_bin)
+        .env_remove("GCT_GH_BIN")
+        .output()
+        .expect("failed to run gct binary")
+}
+
+#[test]
+fn ls_branches_lists_created_branches() {
+    let repo = init_repo();
+    run_git(repo.path(), &["branch", "feature/foo"]);
+
+    let output = run_gct(repo.path(), &["ls", "branches"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let names: Vec<&str> = stdout.lines().collect();
+    assert!(names.contains(&"main"), "expected 'main' in {names:?}");
+    assert!(
+        names.contains(&"feature/foo"),
+        "expected 'feature/foo' in {names:?}"
+    );
+}
+
+#[test]
+fn ls_worktrees_lists_main_worktree() {
+    let repo = init_repo();
+
+    let output = run_gct(repo.path(), &["ls", "worktrees"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.lines().count(),
+        1,
+        "expected exactly one worktree: {stdout:?}"
+    );
+    assert!(
+        stdout.starts_with("main\t"),
+        "expected main branch worktree: {stdout:?}"
+    );
+}
+
+#[test]
+fn version_flag_prints_version() {
+    let output = Command::new(gct_bin())
+        .arg("--version")
+        .output()
+        .expect("failed to run gct binary");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.trim().starts_with("gct v"),
+        "unexpected version output: {stdout:?}"
+    );
+}
+
+#[test]
+fn cd_reports_error_for_unknown_branch() {
+    let repo = init_repo();
+
+    let output = run_gct(repo.path(), &["cd", "does-not-exist"]);
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("no worktree for branch 'does-not-exist'"),
+        "unexpected stderr: {stderr:?}"
+    );
+}
+
+#[test]
+fn wt_creates_worktree_and_prints_path() {
+    let repo = init_repo();
+    run_git(repo.path(), &["branch", "feature/bar"]);
+
+    let output = run_gct(repo.path(), &["wt", "feature/bar"]);
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let printed_path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    assert!(
+        !printed_path.is_empty(),
+        "expected a worktree path on stdout"
+    );
+    assert!(
+        Path::new(&printed_path).is_dir(),
+        "worktree path {printed_path:?} should exist after `gct wt` (real `git worktree add` should have run)"
+    );
+
+    // Idempotent: re-running for the same branch reuses the existing worktree
+    // instead of erroring, and points at the same directory. The two calls
+    // aren't guaranteed to print byte-identical strings (the create path is
+    // built from the config template, e.g. with a literal `..`, while the
+    // reused path comes back from `git worktree list --porcelain`, which
+    // reports git's own normalized form) — compare canonicalized paths.
+    let output2 = run_gct(repo.path(), &["wt", "feature/bar"]);
+    assert!(output2.status.success());
+    let printed_path2 = String::from_utf8_lossy(&output2.stdout).trim().to_string();
+    assert_eq!(
+        std::fs::canonicalize(&printed_path).unwrap(),
+        std::fs::canonicalize(&printed_path2).unwrap(),
+    );
+}
+
+/// Proves the `GCT_GIT_BIN` injection seam actually changes which binary gets
+/// spawned, rather than being silently ignored: pointing it at a path that
+/// doesn't exist must break a command that would otherwise succeed against
+/// the perfectly valid repo `init_repo()` set up.
+#[test]
+fn git_bin_override_nonexistent_path_causes_failure() {
+    let repo = init_repo();
+
+    // Sanity check: without the override, this succeeds.
+    let baseline = run_gct(repo.path(), &["ls", "branches"]);
+    assert!(baseline.status.success());
+
+    let overridden = run_gct_with_git_bin(
+        repo.path(),
+        &["ls", "branches"],
+        "/nonexistent/gct-test-fake-git",
+    );
+    assert!(
+        !overridden.status.success(),
+        "expected failure once GCT_GIT_BIN points at a nonexistent binary"
+    );
+}
+
+/// Proves `GCT_GIT_BIN` can substitute a *working* stub binary: a fake `git`
+/// script that always reports one canned worktree, regardless of the real
+/// repo state, mirroring the approach `scripts/demo/gh-stub` uses for `gh`.
+#[test]
+#[cfg(unix)]
+fn git_bin_override_stub_script_is_used() {
+    let repo = init_repo();
+    let stub_dir = tempfile::tempdir().expect("failed to create stub dir");
+    let stub_path = stub_dir.path().join("fake-git");
+    std::fs::write(
+        &stub_path,
+        r#"#!/bin/sh
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-dir" ]; then
+  echo ".git"
+  exit 0
+fi
+if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then
+  printf 'worktree /fake/stub/path\nHEAD 1111111111111111111111111111111111111111\nbranch refs/heads/stub-branch\n\n'
+  exit 0
+fi
+echo "fake-git: unsupported args: $*" >&2
+exit 1
+"#,
+    )
+    .expect("write stub script");
+    let mut perms = std::fs::metadata(&stub_path).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&stub_path, perms).expect("chmod stub script");
+
+    let output = run_gct_with_git_bin(
+        repo.path(),
+        &["ls", "worktrees"],
+        stub_path.to_str().unwrap(),
+    );
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(
+        stdout.trim(),
+        "stub-branch\t/fake/stub/path",
+        "expected the stub's canned worktree, not the real repo's: {stdout:?}"
+    );
+}


### PR DESCRIPTION
## Summary

The subprocess layer (`src/git/command.rs`) had only 2 tests, no seam to substitute a fake `git`/`gh` binary, and no `tests/` integration suite — so the actual command/exec/parse round-trip (the riskiest, most behavior-bearing part of the app) was essentially uncovered.

## Related Issues

Closes #218

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactoring
- [x] Testing / CI

## Changes

- Add `resolve_executable()` to `command.rs`: an injection seam that reads `GCT_GIT_BIN` / `GCT_GH_BIN` to override which binary actually gets spawned, while every production call site keeps passing the logical `"git"`/`"gh"` name unchanged.
- Add `tests/cli_integration.rs`, driving the compiled `gct` binary as a real subprocess against real temp git repos (this crate is binary-only, so this is the only black-box test surface available — reaching into internals isn't possible without a `[lib]` target, which felt out of scope to add here):
  - `ls branches`, `ls worktrees`, `--version`, `cd`'s error path, and `wt` worktree creation (including an idempotent re-run check)
  - Two tests specifically prove the new injection seam works: pointing `GCT_GIT_BIN` at a nonexistent path breaks a command that would otherwise succeed, and a small working stub script (mirroring `scripts/demo/gh-stub`'s approach) is actually substituted in and its canned output is what gets parsed
- Fix a flaky pre-existing unit test (`run_git_in_records_repo_when_provided`) discovered while adding the above: it assumed its own record was always the most recent entry in the global command-history buffer, but under parallel test execution another test's record can land after it. It now searches for its own record (by the fact that it's the only one with `repo` set) instead of assuming order.

## Deliberately out of scope

`event.rs` (the crossterm event-polling loop) is left untested — it's a thin wrapper around real terminal polling with no pure logic to exercise without an actual tty, and meaningfully testing it would need an `EventSource` trait refactor disproportionate to this issue.

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy`, `cargo fmt`)
- [x] Tests pass (178 unit + 7 new integration tests, ran 5x back-to-back to confirm the flaky test fix holds)

## Test Plan

1. `cargo test` — 178 unit tests + 7 integration tests, all pass
2. Ran `cargo test` 5 times in a row to confirm `run_git_in_records_repo_when_provided` no longer flakes under parallel execution
3. `cargo clippy --all-targets -- -D warnings` — clean (covers `tests/` too via `--all-targets`)
4. `cargo fmt -- --check` — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01GGx3AbCBmRcTo3N3CR22cf)_