### PR TITLE
fix(data): paginate GraphQL PR search and cap page size at 100 (#223)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy, rustfmt
+      # `rustup show` installs the toolchain pinned in rust-toolchain.toml
+      # (including its rustfmt/clippy components), keeping CI on the same
+      # compiler as local builds and the release pipeline.
+      - name: Install Rust toolchain
+        run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Format
         run: cargo fmt -- --check

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -46,7 +46,10 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "Releasing: ${VERSION}"
 
-      - uses: dtolnay/rust-toolchain@stable
+      # `rustup show` installs the toolchain pinned in rust-toolchain.toml,
+      # matching CI and the release build.
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Update Cargo.toml version
         run: |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1314,6 +1314,16 @@ impl App {
         }
     }
 
+    /// Remember a background-operation error for the error list shown in
+    /// `--verbose` mode. Deduplicated, and recorded regardless of verbosity
+    /// so the details are already there when the user relaunches with
+    /// `--verbose` after seeing an error toast.
+    pub fn record_error(&mut self, error: String) {
+        if !self.verbose_errors.contains(&error) {
+            self.verbose_errors.push(error);
+        }
+    }
+
     /// Effective config for a specific repo root: the global layers overlaid
     /// with `<repo_root>/.gct.toml`. Used for cross-repo worktree operations so
     /// the target repo's own `.gct.toml` applies (not the launching repo's).

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,33 +242,57 @@ fn run_command(command: &str, work_dir: &Path) -> std::io::Result<()> {
 /// except `worktree.post_create`, which is additive like gitignore: entries
 /// from every layer run, lowest priority (global) first.
 ///
-/// Must be called before TUI initialization (eprintln warnings).
+/// Convenience wrapper for callers that only report via stderr (CLI
+/// subcommands run before/without the TUI, so eprintln is visible there).
 pub fn load_config() -> Config {
-    resolve_config(&load_global_layers(), git_repo_root().as_deref())
+    let (config, warnings) = load_config_with_warnings();
+    for w in &warnings {
+        eprintln!("Warning: {w}");
+    }
+    config
+}
+
+/// Like [`load_config`] but returns the warnings instead of printing them,
+/// so the TUI can surface them in a notification (stderr is invisible once
+/// the alternate screen is active).
+pub fn load_config_with_warnings() -> (Config, Vec<String>) {
+    let mut warnings = Vec::new();
+    let mut merged = toml::Table::new();
+    if let Some(home) = home_dir() {
+        // config_paths_for_home() is ordered high→low; reverse to apply low→high.
+        for path in config_paths_for_home(&home).into_iter().rev() {
+            read_and_merge(&path, &mut merged, &mut warnings);
+        }
+    }
+    let config = resolve_config_into(&merged, git_repo_root().as_deref(), &mut warnings);
+    (config, warnings)
 }
 
 /// Read a TOML file and deep-merge it into `merged`. A missing file is ignored;
-/// read/parse errors are warned about and skipped.
-fn read_and_merge(path: &Path, merged: &mut toml::Table) {
+/// read/parse errors are recorded in `warnings` and the layer is skipped.
+fn read_and_merge(path: &Path, merged: &mut toml::Table, warnings: &mut Vec<String>) {
     match fs::read_to_string(path) {
         Ok(content) => match toml::from_str::<toml::Table>(&content) {
             Ok(t) => merge_tables(merged, t),
-            Err(e) => eprintln!("Warning: failed to parse {}: {e}", path.display()),
+            Err(e) => warnings.push(format!("failed to parse {}: {e}", path.display())),
         },
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
-        Err(e) => eprintln!("Warning: failed to read {}: {e}", path.display()),
+        Err(e) => warnings.push(format!("failed to read {}: {e}", path.display())),
     }
 }
 
 /// Deep-merge only the global (home-dir) config files into a raw table.
 /// Order: `~/.gct.toml` (low) then `~/.config/gct/config.toml` (high).
 /// The result is the base onto which any repo-local `.gct.toml` is overlaid.
+/// Layer read/parse warnings are dropped here — startup already reported
+/// them via [`load_config_with_warnings`], which reads the same files.
 pub fn load_global_layers() -> toml::Table {
     let mut merged = toml::Table::new();
+    let mut warnings = Vec::new();
     if let Some(home) = home_dir() {
         // config_paths_for_home() is ordered high→low; reverse to apply low→high.
         for path in config_paths_for_home(&home).into_iter().rev() {
-            read_and_merge(&path, &mut merged);
+            read_and_merge(&path, &mut merged, &mut warnings);
         }
     }
     merged
@@ -279,15 +303,85 @@ pub fn load_global_layers() -> toml::Table {
 /// yields the global-only config. This is what cross-repo worktree operations
 /// use so the target repo's own `.gct.toml` applies (the launching repo's
 /// project-local config does not leak into other repos).
+///
+/// Warnings go to the debug log only — this runs mid-TUI, where stderr would
+/// scribble over the interface. Startup uses [`load_config_with_warnings`].
 pub fn resolve_config(global: &toml::Table, repo_root: Option<&Path>) -> Config {
+    let mut warnings = Vec::new();
+    let config = resolve_config_into(global, repo_root, &mut warnings);
+    for w in &warnings {
+        crate::git::command::debug_log(&format!("config warning: {w}"));
+    }
+    config
+}
+
+fn resolve_config_into(
+    global: &toml::Table,
+    repo_root: Option<&Path>,
+    warnings: &mut Vec<String>,
+) -> Config {
     let mut merged = global.clone();
     if let Some(root) = repo_root {
-        read_and_merge(&root.join(".gct.toml"), &mut merged);
+        read_and_merge(&root.join(".gct.toml"), &mut merged, warnings);
     }
-    toml::Value::Table(merged).try_into().unwrap_or_else(|e| {
-        eprintln!("Warning: invalid merged config: {e}");
-        Config::default()
-    })
+    config_from_table(merged, warnings)
+}
+
+/// Keys accepted at each level, kept in sync with the serde structs above
+/// (plus merge-layer directives like `disable_post_create` that are consumed
+/// by [`merge_tables`] rather than deserialized). Anything else is a likely
+/// typo and gets a warning instead of being silently ignored.
+const KNOWN_TOP_KEYS: &[&str] = &["worktree", "protected_branches", "workspace"];
+const KNOWN_WORKTREE_KEYS: &[&str] = &["dir", "post_create", "disable_post_create"];
+const KNOWN_WORKSPACE_KEYS: &[&str] = &["clone_root"];
+
+fn warn_unknown_keys(
+    table: &toml::Table,
+    known: &[&str],
+    prefix: &str,
+    warnings: &mut Vec<String>,
+) {
+    for key in table.keys() {
+        if !known.contains(&key.as_str()) {
+            warnings.push(format!("unknown config key: {prefix}{key} (ignored)"));
+        }
+    }
+}
+
+/// Deserialize the merged table section-by-section so one bad value only
+/// drops that section to its default (with a warning naming the offending
+/// key) instead of silently discarding every valid setting, and so typo'd
+/// keys warn instead of being silently ignored.
+fn config_from_table(mut merged: toml::Table, warnings: &mut Vec<String>) -> Config {
+    warn_unknown_keys(&merged, KNOWN_TOP_KEYS, "", warnings);
+    let mut config = Config::default();
+
+    if let Some(value) = merged.remove("worktree") {
+        if let Some(table) = value.as_table() {
+            warn_unknown_keys(table, KNOWN_WORKTREE_KEYS, "worktree.", warnings);
+        }
+        match value.try_into::<WorktreeConfig>() {
+            Ok(wt) => config.worktree = wt,
+            Err(e) => warnings.push(format!("invalid [worktree] config (section ignored): {e}")),
+        }
+    }
+    if let Some(value) = merged.remove("protected_branches") {
+        match value.try_into::<Vec<String>>() {
+            Ok(v) => config.protected_branches = v,
+            Err(e) => warnings.push(format!("invalid protected_branches (using default): {e}")),
+        }
+    }
+    if let Some(value) = merged.remove("workspace") {
+        if let Some(table) = value.as_table() {
+            warn_unknown_keys(table, KNOWN_WORKSPACE_KEYS, "workspace.", warnings);
+        }
+        match value.try_into::<WorkspaceConfig>() {
+            Ok(ws) => config.workspace = ws,
+            Err(e) => warnings.push(format!("invalid [workspace] config (section ignored): {e}")),
+        }
+    }
+
+    config
 }
 
 /// Key whose array entries accumulate across config layers instead of being
@@ -1111,5 +1205,86 @@ to = ".env"
         assert_eq!(config.worktree.dir, "../custom");
         // clone_root is inherited from the global layers.
         assert_eq!(config.workspace.clone_root.as_deref(), Some("~/workspace"));
+    }
+
+    // --- config_from_table (typo warnings / per-section fallback) ---
+
+    fn from_table_str(s: &str) -> (Config, Vec<String>) {
+        let table: toml::Table = toml::from_str(s).unwrap();
+        let mut warnings = Vec::new();
+        let config = config_from_table(table, &mut warnings);
+        (config, warnings)
+    }
+
+    #[test]
+    fn unknown_top_level_key_warns_and_rest_still_applies() {
+        // "protected_branchs" is a typo of "protected_branches".
+        let (config, warnings) =
+            from_table_str("protected_branchs = [\"x\"]\n[worktree]\ndir = \"wt\"\n");
+        assert_eq!(
+            warnings,
+            vec!["unknown config key: protected_branchs (ignored)"]
+        );
+        assert_eq!(config.worktree.dir, "wt");
+        // The typo'd key never applied, so the default list stays.
+        assert_eq!(config.protected_branches, default_protected_branches());
+    }
+
+    #[test]
+    fn unknown_nested_key_warns_with_section_prefix() {
+        let (config, warnings) =
+            from_table_str("[worktree]\ndirr = \"wt\"\n\n[workspace]\nclone_rot = \"~/w\"\n");
+        assert!(
+            warnings.contains(&"unknown config key: worktree.dirr (ignored)".to_string()),
+            "warnings: {warnings:?}"
+        );
+        assert!(
+            warnings.contains(&"unknown config key: workspace.clone_rot (ignored)".to_string()),
+            "warnings: {warnings:?}"
+        );
+        assert_eq!(config.worktree.dir, DEFAULT_WORKTREE_DIR);
+    }
+
+    #[test]
+    fn disable_post_create_is_a_known_key() {
+        // The merge-layer directive must not be flagged as a typo.
+        let (_, warnings) = from_table_str("[worktree]\ndisable_post_create = [\"h\"]\n");
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+    }
+
+    #[test]
+    fn bad_typed_section_falls_back_alone() {
+        // One bad value must not discard the other (valid) sections.
+        let (config, warnings) =
+            from_table_str("protected_branches = [\"x\"]\n[worktree]\ndir = 5\n");
+        assert_eq!(config.protected_branches, vec!["x".to_string()]);
+        assert_eq!(config.worktree.dir, DEFAULT_WORKTREE_DIR);
+        assert!(
+            warnings.iter().any(|w| w.contains("invalid [worktree]")),
+            "warnings: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn bad_protected_branches_falls_back_to_default_keeps_rest() {
+        let (config, warnings) =
+            from_table_str("protected_branches = \"main\"\n[worktree]\ndir = \"wt\"\n");
+        assert_eq!(config.protected_branches, default_protected_branches());
+        assert_eq!(config.worktree.dir, "wt");
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("invalid protected_branches")),
+            "warnings: {warnings:?}"
+        );
+    }
+
+    #[test]
+    fn valid_config_produces_no_warnings() {
+        let (config, warnings) = from_table_str(
+            "protected_branches = [\"main\"]\n[worktree]\ndir = \"wt\"\n\n[[worktree.post_create]]\ntype = \"command\"\ncommand = \"echo hi\"\n\n[workspace]\nclone_root = \"~/w\"\n",
+        );
+        assert!(warnings.is_empty(), "warnings: {warnings:?}");
+        assert_eq!(config.worktree.post_create.len(), 1);
     }
 }

--- a/src/data.rs
+++ b/src/data.rs
@@ -192,7 +192,7 @@ pub async fn fetch_local_prs(
         let mut aliases = String::new();
         for (i, name) in chunk.iter().enumerate() {
             let alias = graphql_alias(i);
-            let escaped_name = name.replace('\\', "\\\\").replace('"', "\\\"");
+            let escaped_name = escape_graphql_string(name);
             aliases.push_str(&format!(
                 r#"{alias}: pullRequests(first: 2, headRefName: "{escaped_name}", states: [OPEN, MERGED], orderBy: {{field: UPDATED_AT, direction: DESC}}) {{
   nodes {{ number title state headRefName updatedAt isDraft author {{ login }}
@@ -360,104 +360,158 @@ fn dedup_hosts(hosts: &[Option<String>]) -> Vec<Option<String>> {
 
 /// Merge per-host search results: concatenate PRs in input order, prefix
 /// per-host failures with `[<label>] ` so the caller can attribute errors
-/// to the originating host.
+/// to the originating host. A host can contribute both PRs and an error
+/// (pages fetched before a mid-pagination failure are kept).
 fn merge_search_results(
-    results: Vec<(String, Result<Vec<PullRequest>, String>)>,
+    results: Vec<(String, Vec<PullRequest>, Option<String>)>,
 ) -> (Vec<PullRequest>, Vec<String>) {
     let mut prs: Vec<PullRequest> = Vec::new();
     let mut errors: Vec<String> = Vec::new();
-    for (label, result) in results {
-        match result {
-            Ok(host_prs) => prs.extend(host_prs),
-            Err(msg) => errors.push(format!("[{label}] {msg}")),
+    for (label, host_prs, error) in results {
+        prs.extend(host_prs);
+        if let Some(msg) = error {
+            errors.push(format!("[{label}] {msg}"));
         }
     }
     (prs, errors)
 }
 
+/// GitHub's GraphQL `search(first:)` page-size ceiling; larger values make
+/// the API reject the whole query.
+const SEARCH_PAGE_SIZE: u32 = 100;
+/// GitHub's search index returns at most 1000 results per query, so
+/// pagination past this point can never yield more data.
+const SEARCH_MAX_RESULTS: usize = 1000;
+
+/// Escape a string for embedding in a double-quoted GraphQL string literal.
+fn escape_graphql_string(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Build one page of the cross-repo PR search query. `escaped_query` must
+/// already be escaped via `escape_graphql_string`; `cursor` is the previous
+/// page's `endCursor` (`None` for the first page).
+fn build_search_query(escaped_query: &str, cursor: Option<&str>) -> String {
+    let after = match cursor {
+        Some(c) => format!(r#", after: "{}""#, escape_graphql_string(c)),
+        None => String::new(),
+    };
+    format!(
+        r#"{{ search(query: "{escaped_query}", type: ISSUE, first: {SEARCH_PAGE_SIZE}{after}) {{ pageInfo {{ hasNextPage endCursor }} nodes {{ ... on PullRequest {{ number title state headRefName updatedAt isDraft author {{ login }} repository {{ name url owner {{ login }} }} reviewRequests(first: 10) {{ nodes {{ requestedReviewer {{ ... on User {{ login }} }} }} }} latestReviews(first: 20) {{ nodes {{ author {{ login }} state }} }} }} }} }} }}"#
+    )
+}
+
+/// Extract one search page from a GraphQL response: the parsed PRs plus
+/// pagination state. A missing or malformed `pageInfo` (e.g. from a stub
+/// that predates pagination) is treated as "no next page".
+fn extract_search_page(json: &serde_json::Value) -> (Vec<PullRequest>, bool, Option<String>) {
+    let mut prs = Vec::new();
+    if let Some(arr) = json["data"]["search"]["nodes"].as_array() {
+        for node in arr {
+            if let Some(pr) = parse_graphql_search_pr(node) {
+                prs.push(pr);
+            }
+        }
+    }
+    let page_info = &json["data"]["search"]["pageInfo"];
+    let has_next = page_info["hasNextPage"].as_bool().unwrap_or(false);
+    let end_cursor = page_info["endCursor"].as_str().map(str::to_string);
+    (prs, has_next, end_cursor)
+}
+
 // Hosts to search are supplied by the caller; an empty slice falls back to
 // the default host (github.com) via dedup_hosts.
-// TODO(future): GitHub's search index supports up to 1000 results; if very active
-// reviewers report missing PRs, paginate via search.pageInfo.endCursor.
 async fn fetch_search_prs(
     query_str: &str,
-    limit: u32,
     hosts: &[Option<String>],
 ) -> (Vec<PullRequest>, Vec<String>) {
-    let escaped_query = query_str.replace('\\', "\\\\").replace('"', "\\\"");
-    let query = format!(
-        r#"{{ search(query: "{escaped_query}", type: ISSUE, first: {limit}) {{ nodes {{ ... on PullRequest {{ number title state headRefName updatedAt isDraft author {{ login }} repository {{ name url owner {{ login }} }} reviewRequests(first: 10) {{ nodes {{ requestedReviewer {{ ... on User {{ login }} }} }} }} latestReviews(first: 20) {{ nodes {{ author {{ login }} state }} }} }} }} }} }}"#
-    );
-    let query_arg = format!("query={query}");
+    let escaped_query = escape_graphql_string(query_str);
 
     // Run one search per host in parallel. Hosts are deduplicated and an
     // empty list falls back to a single default-host (github.com) query so
     // the previous single-host behaviour is preserved when no repo metadata
     // has been collected yet.
     let unique_hosts = dedup_hosts(hosts);
-    // Keep `(label, JoinHandle<Result<...>>)` pairs so that the host label is
+    // Keep `(label, JoinHandle<...>)` pairs so that the host label is
     // attached to errors regardless of whether they originate inside the task
-    // (Err returned from the closure) or from the join itself (panic / cancel).
+    // (error returned from the closure) or from the join itself (panic / cancel).
     type SearchHandle = (
         String,
-        tokio::task::JoinHandle<Result<Vec<PullRequest>, String>>,
+        tokio::task::JoinHandle<(Vec<PullRequest>, Option<String>)>,
     );
     let mut handles: Vec<SearchHandle> = Vec::with_capacity(unique_hosts.len());
     for host in unique_hosts {
-        let query_arg = query_arg.clone();
+        let escaped_query = escaped_query.clone();
         let label = host.as_deref().unwrap_or("github.com").to_string();
         let handle = tokio::spawn(async move {
-            let mut args: Vec<String> = vec![
-                "api".to_string(),
-                "graphql".to_string(),
-                "-f".to_string(),
-                query_arg,
-            ];
-            if let Some(h) = host.as_deref() {
-                args.push("--hostname".to_string());
-                args.push(h.to_string());
-            }
-            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-            match run_gh(&arg_refs).await {
-                Ok(output) => match serde_json::from_str::<serde_json::Value>(&output) {
-                    Ok(json) => {
-                        let mut host_prs = Vec::new();
-                        if let Some(arr) = json["data"]["search"]["nodes"].as_array() {
-                            for node in arr {
-                                if let Some(pr) = parse_graphql_search_pr(node) {
-                                    host_prs.push(pr);
-                                }
-                            }
-                        }
-                        Ok(host_prs)
+            let mut host_prs: Vec<PullRequest> = Vec::new();
+            let mut cursor: Option<String> = None;
+            // Paginate up to GitHub's search cap. Most queries finish on the
+            // first page (hasNextPage=false); an error mid-pagination returns
+            // the pages collected so far alongside the error message.
+            loop {
+                let query_arg = format!(
+                    "query={}",
+                    build_search_query(&escaped_query, cursor.as_deref())
+                );
+                let mut args: Vec<String> = vec![
+                    "api".to_string(),
+                    "graphql".to_string(),
+                    "-f".to_string(),
+                    query_arg,
+                ];
+                if let Some(h) = host.as_deref() {
+                    args.push("--hostname".to_string());
+                    args.push(h.to_string());
+                }
+                let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                let output = match run_gh(&arg_refs).await {
+                    Ok(output) => output,
+                    Err(e) => {
+                        debug_log(&format!("  → GraphQL search fetch error: {e}"));
+                        return (host_prs, Some(format!("search fetch failed: {e}")));
                     }
+                };
+                let json = match serde_json::from_str::<serde_json::Value>(&output) {
+                    Ok(json) => json,
                     Err(e) => {
                         debug_log(&format!("  → GraphQL search parse error: {e}"));
-                        Err(format!("search parse error: {e}"))
+                        return (host_prs, Some(format!("search parse error: {e}")));
                     }
-                },
-                Err(e) => {
-                    debug_log(&format!("  → GraphQL search fetch error: {e}"));
-                    Err(format!("search fetch failed: {e}"))
+                };
+                let (page_prs, has_next, end_cursor) = extract_search_page(&json);
+                host_prs.extend(page_prs);
+                if !has_next || host_prs.len() >= SEARCH_MAX_RESULTS {
+                    return (host_prs, None);
+                }
+                match end_cursor {
+                    Some(next) => cursor = Some(next),
+                    // hasNextPage without a cursor should not happen; stop
+                    // rather than refetch the first page forever.
+                    None => return (host_prs, None),
                 }
             }
         });
         handles.push((label, handle));
     }
 
-    let mut collected: Vec<(String, Result<Vec<PullRequest>, String>)> =
+    let mut collected: Vec<(String, Vec<PullRequest>, Option<String>)> =
         Vec::with_capacity(handles.len());
     for (label, handle) in handles {
-        let result = match handle.await {
-            Ok(r) => r,
+        let entry = match handle.await {
+            Ok((prs, error)) => (label, prs, error),
             Err(e) => {
                 debug_log(&format!(
                     "  → GraphQL search task join error ({label}): {e}"
                 ));
-                Err(format!("search task join failed: {e}"))
+                (
+                    label,
+                    Vec::new(),
+                    Some(format!("search task join failed: {e}")),
+                )
             }
         };
-        collected.push((label, result));
+        collected.push(entry);
     }
 
     // PRs from multiple hosts naturally cannot collide because parse_graphql_search_pr
@@ -477,12 +531,7 @@ pub async fn fetch_my_prs(
     if !show_merged {
         q.push_str(" is:open");
     }
-    // When show_merged is on we lose the OPEN-only narrowing, so widen the limit
-    // to compensate (the previous fetch_pr_list returned 100 open + 50 merged).
-    // TODO(future): GitHub's search index supports up to 1000 results; if very active
-    // reviewers report missing PRs, paginate via search.pageInfo.endCursor.
-    let limit = if show_merged { 150 } else { 100 };
-    let (mut prs, errors) = fetch_search_prs(&q, limit, hosts).await;
+    let (mut prs, errors) = fetch_search_prs(&q, hosts).await;
     prs.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
     (prs, errors)
 }
@@ -522,7 +571,7 @@ pub async fn fetch_review_prs(
     const REVIEWED_BY_INDEX: usize = 1;
     for (idx, query) in queries.iter().enumerate() {
         let is_reviewed = idx == REVIEWED_BY_INDEX;
-        let (prs, errors) = fetch_search_prs(query, 100, hosts).await;
+        let (prs, errors) = fetch_search_prs(query, hosts).await;
         all_errors.extend(errors);
         for pr in prs {
             let key = (pr.repo_id.clone(), pr.number);
@@ -1088,14 +1137,16 @@ mod tests {
         let results = vec![
             (
                 "github.com".to_string(),
-                Ok(vec![pr_with_id(1, None, "katzkb", "gct")]),
+                vec![pr_with_id(1, None, "katzkb", "gct")],
+                None,
             ),
             (
                 "ghe.example.com".to_string(),
-                Ok(vec![
+                vec![
                     pr_with_id(2, Some("ghe.example.com"), "team", "svc"),
                     pr_with_id(3, Some("ghe.example.com"), "team", "svc"),
-                ]),
+                ],
+                None,
             ),
         ];
         let (prs, errors) = merge_search_results(results);
@@ -1108,14 +1159,16 @@ mod tests {
 
     #[test]
     fn merge_search_results_labels_errors_with_host() {
-        let results: Vec<(String, Result<Vec<PullRequest>, String>)> = vec![
+        let results = vec![
             (
                 "github.com".to_string(),
-                Ok(vec![pr_with_id(1, None, "katzkb", "gct")]),
+                vec![pr_with_id(1, None, "katzkb", "gct")],
+                None,
             ),
             (
                 "ghe.example.com".to_string(),
-                Err("auth expired".to_string()),
+                Vec::new(),
+                Some("auth expired".to_string()),
             ),
         ];
         let (prs, errors) = merge_search_results(results);
@@ -1126,9 +1179,17 @@ mod tests {
 
     #[test]
     fn merge_search_results_all_failures() {
-        let results: Vec<(String, Result<Vec<PullRequest>, String>)> = vec![
-            ("github.com".to_string(), Err("network".to_string())),
-            ("ghe.example.com".to_string(), Err("auth".to_string())),
+        let results = vec![
+            (
+                "github.com".to_string(),
+                Vec::new(),
+                Some("network".to_string()),
+            ),
+            (
+                "ghe.example.com".to_string(),
+                Vec::new(),
+                Some("auth".to_string()),
+            ),
         ];
         let (prs, errors) = merge_search_results(results);
         assert!(prs.is_empty());
@@ -1142,10 +1203,105 @@ mod tests {
     }
 
     #[test]
+    fn merge_search_results_keeps_partial_pages_alongside_error() {
+        // A mid-pagination failure keeps the pages already fetched.
+        let results = vec![(
+            "github.com".to_string(),
+            vec![pr_with_id(1, None, "katzkb", "gct")],
+            Some("search fetch failed: timeout".to_string()),
+        )];
+        let (prs, errors) = merge_search_results(results);
+        assert_eq!(prs.len(), 1);
+        assert_eq!(
+            errors,
+            vec!["[github.com] search fetch failed: timeout".to_string()]
+        );
+    }
+
+    #[test]
     fn merge_search_results_empty_input() {
-        let results: Vec<(String, Result<Vec<PullRequest>, String>)> = vec![];
+        let results: Vec<(String, Vec<PullRequest>, Option<String>)> = vec![];
         let (prs, errors) = merge_search_results(results);
         assert!(prs.is_empty());
         assert!(errors.is_empty());
+    }
+
+    // ----- build_search_query / extract_search_page -----
+
+    #[test]
+    fn build_search_query_first_page_has_no_after_and_caps_at_100() {
+        let q = build_search_query("is:pr author:@me", None);
+        assert!(q.contains("first: 100"), "query: {q}");
+        assert!(!q.contains("after:"), "query: {q}");
+        assert!(
+            q.contains("pageInfo { hasNextPage endCursor }"),
+            "query: {q}"
+        );
+    }
+
+    #[test]
+    fn build_search_query_next_page_includes_cursor() {
+        let q = build_search_query("is:pr author:@me", Some("Y3Vyc29yOjEwMA=="));
+        assert!(q.contains(r#"after: "Y3Vyc29yOjEwMA==""#), "query: {q}");
+    }
+
+    #[test]
+    fn build_search_query_escapes_cursor_quotes() {
+        let q = build_search_query("is:pr", Some(r#"cu"rsor"#));
+        assert!(q.contains(r#"after: "cu\"rsor""#), "query: {q}");
+    }
+
+    fn search_node(number: u64) -> serde_json::Value {
+        serde_json::json!({
+            "number": number,
+            "title": format!("PR {number}"),
+            "state": "OPEN",
+            "headRefName": format!("feature-{number}"),
+            "updatedAt": "2024-01-15T00:00:00Z",
+            "isDraft": false,
+            "author": {"login": "alice"},
+            "repository": {"name": "gct", "url": "https://github.com/katzkb/gct", "owner": {"login": "katzkb"}},
+        })
+    }
+
+    #[test]
+    fn extract_search_page_reads_nodes_and_page_info() {
+        let json = serde_json::json!({
+            "data": {"search": {
+                "pageInfo": {"hasNextPage": true, "endCursor": "CURSOR1"},
+                "nodes": [search_node(1), search_node(2)],
+            }}
+        });
+        let (prs, has_next, cursor) = extract_search_page(&json);
+        assert_eq!(prs.len(), 2);
+        assert_eq!(prs[0].number, 1);
+        assert!(has_next);
+        assert_eq!(cursor.as_deref(), Some("CURSOR1"));
+    }
+
+    #[test]
+    fn extract_search_page_last_page() {
+        let json = serde_json::json!({
+            "data": {"search": {
+                "pageInfo": {"hasNextPage": false, "endCursor": null},
+                "nodes": [search_node(1)],
+            }}
+        });
+        let (prs, has_next, cursor) = extract_search_page(&json);
+        assert_eq!(prs.len(), 1);
+        assert!(!has_next);
+        assert_eq!(cursor, None);
+    }
+
+    #[test]
+    fn extract_search_page_missing_page_info_means_no_next_page() {
+        // Stubs and fixtures that predate pagination omit pageInfo entirely.
+        let json = serde_json::json!({
+            "data": {"search": {"nodes": [search_node(1)]}}
+        });
+        let (prs, has_next, cursor) = extract_search_page(&json);
+        assert_eq!(prs.len(), 1);
+        assert!(!has_next);
+        assert_eq!(cursor, None);
     }
 }

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -45,7 +45,11 @@ async fn run_with_timeout_for(
         // Defense in depth: even with stdin closed, make sure git/gh don't
         // themselves attempt an interactive prompt.
         .env("GIT_TERMINAL_PROMPT", "0")
-        .env("GH_PROMPT_DISABLED", "1");
+        .env("GH_PROMPT_DISABLED", "1")
+        // Pin the locale so human-facing output we parse (e.g. the tracking
+        // brackets in `git branch -vv`) is never translated. LC_ALL overrides
+        // LANG and every LC_* category.
+        .env("LC_ALL", "C");
     match tokio::time::timeout(timeout_duration, cmd.output()).await {
         Ok(result) => result,
         Err(_) => Err(std::io::Error::new(

--- a/src/main.rs
+++ b/src/main.rs
@@ -403,7 +403,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Startup checks and config loading before TUI init (eprintln is safe here)
     check_prerequisites().await;
-    let config = config::load_config();
+    let (config, config_warnings) = config::load_config_with_warnings();
+    for w in &config_warnings {
+        eprintln!("Warning: {w}");
+    }
 
     // Render TUI to /dev/tty so shell wrapper stdout capture doesn't interfere
     let mut tty = OpenOptions::new()
@@ -427,7 +430,7 @@ async fn main() -> anyhow::Result<()> {
     let backend = CrosstermBackend::new(tty);
     let mut terminal = Terminal::new(backend)?;
 
-    let (result, cd_path) = run(&mut terminal, config, verbose).await;
+    let (result, cd_path) = run(&mut terminal, config, config_warnings, verbose).await;
 
     // Restore terminal — always disable raw mode even if LeaveAlternateScreen fails
     let _ = execute!(terminal.backend_mut(), LeaveAlternateScreen);
@@ -796,10 +799,26 @@ fn first_line(s: &str) -> String {
 async fn run(
     terminal: &mut Terminal<CrosstermBackend<std::fs::File>>,
     config: config::Config,
+    config_warnings: Vec<String>,
     verbose: bool,
 ) -> (anyhow::Result<()>, Option<String>) {
     let mut app = App::new(config);
     app.verbose = verbose;
+    // Config problems were already printed to stderr, but that's invisible
+    // once the TUI takes over — surface them in-app too.
+    if let Some(first) = config_warnings.first() {
+        let more = config_warnings.len() - 1;
+        let suffix = if more > 0 {
+            format!(" (+{more} more)")
+        } else {
+            String::new()
+        };
+        app.notification = Some(Notification::error(format!(
+            "Config warning: {first}{suffix}"
+        )));
+        app.verbose_errors
+            .extend(config_warnings.iter().map(|w| format!("config: {w}")));
+    }
     // Global (home-dir) config layers, used to resolve a per-target-repo
     // effective config for cross-repo worktree operations.
     app.global_layers = config::load_global_layers();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1129,9 +1129,7 @@ async fn run(
                     pr_inflight.remove(&(repo_id, number));
                     app.notification =
                         Some(Notification::error(format!("Failed to load PR #{number}")));
-                    if app.verbose && !app.verbose_errors.contains(&error) {
-                        app.verbose_errors.push(error);
-                    }
+                    app.record_error(error);
                 }
                 AsyncResult::GitStatus { wt_path, status } => {
                     status_inflight.remove(&wt_path);
@@ -1145,12 +1143,9 @@ async fn run(
                 }
                 AsyncResult::GitStatusError(wt_path) => {
                     status_inflight.remove(&wt_path);
-                    if app.verbose {
-                        let msg = format!("git status failed for {wt_path}");
-                        if !app.verbose_errors.contains(&msg) {
-                            app.verbose_errors.push(msg);
-                        }
-                    }
+                    let msg = format!("git status failed for {wt_path}");
+                    app.notification = Some(Notification::error(msg.clone()));
+                    app.record_error(msg);
                 }
                 AsyncResult::UserLogin(user) => {
                     app.gh_user = user;
@@ -1164,20 +1159,15 @@ async fn run(
                 }
                 AsyncResult::UserLoginError(error_msg) => {
                     app.gh_user_load_failed = true;
-                    if app.verbose && !app.verbose_errors.contains(&error_msg) {
-                        app.verbose_errors.push(error_msg);
-                    }
+                    app.notification = Some(Notification::error(
+                        "Failed to load GitHub user — is `gh` authenticated?".to_string(),
+                    ));
+                    app.record_error(error_msg);
                 }
                 AsyncResult::LocalPrList(prs, errors) => {
                     app.local_prs = prs;
                     app.local_prs_loaded = true;
-                    if app.verbose {
-                        for e in errors {
-                            if !app.verbose_errors.contains(&e) {
-                                app.verbose_errors.push(e);
-                            }
-                        }
-                    }
+                    report_fetch_errors(&mut app, "PR fetch failed", errors);
                     seed_repos_from_prs(&mut app.repos, &app.local_prs);
                     if app.main_filter == MainFilter::Local {
                         let active = app.active_repo.clone().unwrap_or_default();
@@ -1198,13 +1188,7 @@ async fn run(
                 AsyncResult::MyPrList(prs, errors) => {
                     app.my_prs = prs;
                     app.my_prs_loaded = true;
-                    if app.verbose {
-                        for e in errors {
-                            if !app.verbose_errors.contains(&e) {
-                                app.verbose_errors.push(e);
-                            }
-                        }
-                    }
+                    report_fetch_errors(&mut app, "PR fetch failed", errors);
                     seed_repos_from_prs(&mut app.repos, &app.my_prs);
                     if app.main_filter == MainFilter::MyPr {
                         let active = app.active_repo.clone().unwrap_or_default();
@@ -1228,13 +1212,7 @@ async fn run(
                     }
                     app.review_prs = prs;
                     app.review_prs_loaded = true;
-                    if app.verbose {
-                        for e in errors {
-                            if !app.verbose_errors.contains(&e) {
-                                app.verbose_errors.push(e);
-                            }
-                        }
-                    }
+                    report_fetch_errors(&mut app, "PR fetch failed", errors);
                     seed_repos_from_prs(&mut app.repos, &app.review_prs);
                     if app.main_filter == MainFilter::ReviewRequested {
                         let active = app.active_repo.clone().unwrap_or_default();
@@ -1267,8 +1245,8 @@ async fn run(
                             "Worktree created: {wt_path} (copy errors: {})",
                             copy_errors.len()
                         )));
-                        if app.verbose {
-                            app.verbose_errors.extend(copy_errors);
+                        for e in copy_errors {
+                            app.record_error(e);
                         }
                     }
                     app.branches_reload_requested = true;
@@ -1341,12 +1319,8 @@ async fn run(
                             )
                         };
                         app.notification = Some(Notification::error(summary));
-                        if app.verbose {
-                            for err in &failures {
-                                if !app.verbose_errors.contains(err) {
-                                    app.verbose_errors.push(err.clone());
-                                }
-                            }
+                        for err in failures {
+                            app.record_error(err);
                         }
                     }
                     app.progress.clear();
@@ -1375,13 +1349,7 @@ async fn run(
                     if let Some(worktrees) = data.worktrees {
                         app.worktrees = worktrees;
                     }
-                    if app.verbose {
-                        for e in data.errors {
-                            if !app.verbose_errors.contains(&e) {
-                                app.verbose_errors.push(e);
-                            }
-                        }
-                    }
+                    report_fetch_errors(&mut app, "Branch reload failed", data.errors);
                     let active = app.active_repo.clone().unwrap_or_default();
                     app.entries = merge_entries(
                         &active,
@@ -1411,9 +1379,7 @@ async fn run(
                 AsyncResult::BranchCreateError(err_str) => {
                     let short = err_str.lines().next().unwrap_or(&err_str).to_string();
                     app.notification = Some(Notification::error(short));
-                    if app.verbose && !app.verbose_errors.contains(&err_str) {
-                        app.verbose_errors.push(err_str);
-                    }
+                    app.record_error(err_str);
                 }
             }
         }
@@ -1729,16 +1695,38 @@ async fn run(
     (Ok(()), cd_path)
 }
 
+/// Surface background fetch failures: a short error toast (first line of the
+/// first failure, plus a count of the rest) and the full messages recorded
+/// for the `--verbose` error list.
+fn report_fetch_errors(app: &mut App, context: &str, errors: Vec<String>) {
+    if errors.is_empty() {
+        return;
+    }
+    let first = errors
+        .first()
+        .and_then(|e| e.lines().next())
+        .unwrap_or("unknown error");
+    let suffix = if errors.len() > 1 {
+        format!(" (+{} more)", errors.len() - 1)
+    } else {
+        String::new()
+    };
+    let toast = format!("{context}: {first}{suffix}");
+    app.notification = Some(Notification::error(toast));
+    for e in errors {
+        app.record_error(e);
+    }
+}
+
 async fn load_branches(app: &mut App) {
     let branch_output = match run_git(&["branch", "-vv"]).await {
         Ok(output) => output,
         Err(e) => {
-            if app.verbose {
-                let msg = format!("git branch -vv failed: {e}");
-                if !app.verbose_errors.contains(&msg) {
-                    app.verbose_errors.push(msg);
-                }
-            }
+            report_fetch_errors(
+                app,
+                "Branch list failed",
+                vec![format!("git branch -vv failed: {e}")],
+            );
             return;
         }
     };
@@ -1746,24 +1734,16 @@ async fn load_branches(app: &mut App) {
     let merged_output = match run_git(&["branch", "--merged", &default_branch]).await {
         Ok(output) => output,
         Err(e) => {
-            if app.verbose {
-                let msg = format!("git branch --merged failed: {e}");
-                if !app.verbose_errors.contains(&msg) {
-                    app.verbose_errors.push(msg);
-                }
-            }
+            // Non-fatal: only the merged-marker annotations are lost.
+            app.record_error(format!("git branch --merged failed: {e}"));
             String::new()
         }
     };
     let base_hash = match run_git(&["rev-parse", &default_branch]).await {
         Ok(output) => output,
         Err(e) => {
-            if app.verbose {
-                let msg = format!("git rev-parse {default_branch} failed: {e}");
-                if !app.verbose_errors.contains(&msg) {
-                    app.verbose_errors.push(msg);
-                }
-            }
+            // Non-fatal: only the merged-marker annotations are lost.
+            app.record_error(format!("git rev-parse {default_branch} failed: {e}"));
             String::new()
         }
     };
@@ -1804,7 +1784,7 @@ USAGE:
 OPTIONS:
     -h, --help        Print this help message and exit
     -v, --version     Print version and exit
-        --verbose     Surface silenced errors for troubleshooting
+        --verbose     Show collected error details in the detail pane
 
 SUBCOMMANDS:
     cd <BRANCH>

--- a/tests/cli_integration.rs
+++ b/tests/cli_integration.rs
@@ -199,6 +199,59 @@ fn git_bin_override_nonexistent_path_causes_failure() {
     );
 }
 
+/// Proves git subprocesses run with a pinned `LC_ALL=C`, so output we parse
+/// (e.g. `git branch -vv` tracking brackets) can never come back translated.
+/// The stub only answers when it sees `LC_ALL=C`; the parent sets a
+/// conflicting locale to prove the pin overrides the inherited environment.
+#[test]
+#[cfg(unix)]
+fn git_subprocess_locale_is_pinned_to_c() {
+    let repo = init_repo();
+    let stub_dir = tempfile::tempdir().expect("failed to create stub dir");
+    let stub_path = stub_dir.path().join("fake-git");
+    std::fs::write(
+        &stub_path,
+        r#"#!/bin/sh
+if [ "$LC_ALL" != "C" ]; then
+  echo "fake-git: LC_ALL is '$LC_ALL', expected 'C'" >&2
+  exit 1
+fi
+if [ "$1" = "rev-parse" ] && [ "$2" = "--git-dir" ]; then
+  echo ".git"
+  exit 0
+fi
+if [ "$1" = "worktree" ] && [ "$2" = "list" ]; then
+  printf 'worktree /fake/stub/path\nHEAD 1111111111111111111111111111111111111111\nbranch refs/heads/stub-branch\n\n'
+  exit 0
+fi
+echo "fake-git: unsupported args: $*" >&2
+exit 1
+"#,
+    )
+    .expect("write stub script");
+    let mut perms = std::fs::metadata(&stub_path).unwrap().permissions();
+    std::os::unix::fs::PermissionsExt::set_mode(&mut perms, 0o755);
+    std::fs::set_permissions(&stub_path, perms).expect("chmod stub script");
+
+    let output = Command::new(gct_bin())
+        .args(["ls", "worktrees"])
+        .current_dir(repo.path())
+        .env("GCT_GIT_BIN", stub_path.to_str().unwrap())
+        .env_remove("GCT_GH_BIN")
+        // A conflicting inherited locale must not leak through to git.
+        .env("LC_ALL", "ja_JP.UTF-8")
+        .env("LANG", "ja_JP.UTF-8")
+        .output()
+        .expect("failed to run gct binary");
+    assert!(
+        output.status.success(),
+        "stub git rejected the locale — stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(stdout.trim(), "stub-branch\t/fake/stub/path");
+}
+
 /// Proves `GCT_GIT_BIN` can substitute a *working* stub binary: a fake `git`
 /// script that always reports one canned worktree, regardless of the real
 /// repo state, mirroring the approach `scripts/demo/gh-stub` uses for `gh`.


### PR DESCRIPTION
The cross-repo PR search requested first: 150 when show_merged was on,
exceeding GitHub's GraphQL page maximum of 100 — the API rejected the
whole query and the My PR list silently came back empty. Queries with
more than 100 matches were also silently truncated because pageInfo was
never read.

Cap the page size at SEARCH_PAGE_SIZE (100) and follow
pageInfo.endCursor up to SEARCH_MAX_RESULTS (1000, GitHub's search
cap). A mid-pagination failure now returns the pages collected so far
together with the error instead of dropping them. Missing pageInfo
(older stubs/fixtures) is treated as "no next page".

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KpxzgM1vQaDAxxcjQzZypq