### PR TITLE
feat: add `gct mcp` subcommand — MCP server exposing worktree tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +46,17 @@ name = "arrayvec"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "atomic"
@@ -129,6 +149,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.2.66"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -145,6 +175,18 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
 
 [[package]]
 name = "compact_str"
@@ -168,6 +210,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -346,6 +394,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,6 +464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
 name = "finl_unicode"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -434,10 +494,69 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -451,8 +570,13 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -510,6 +634,8 @@ dependencies = [
  "crossterm",
  "portable-pty",
  "ratatui",
+ "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "shellexpand",
@@ -552,6 +678,30 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "ident_case"
@@ -894,6 +1044,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pest"
 version = "2.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1193,6 +1349,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1220,6 +1396,41 @@ name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
+name = "rmcp"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "rustc_version"
@@ -1254,6 +1465,32 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "scopeguard"
@@ -1291,6 +1528,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1365,6 +1613,12 @@ checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"
@@ -1659,6 +1913,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "toml"
 version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1696,6 +1963,37 @@ name = "toml_writer"
 version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
 
 [[package]]
 name = "typenum"
@@ -1965,10 +2263,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ serde_json = "1"
 toml = "1.1"
 base64 = "0.22.1"
 shellexpand = "3"
+rmcp = { version = "2.1", features = ["server", "macros", "transport-io", "schemars"] }
+schemars = "1.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ gct prune --yes     # actually delete
 
 # Shell completion
 eval "$(gct completions zsh)"
+
+# Run as an MCP server for AI agents (see the MCP server section)
+gct mcp
 ```
 
 These subcommands run without launching the TUI:
@@ -128,6 +131,39 @@ These subcommands run without launching the TUI:
 
 > `cd` and `wt` emit a bare worktree path that the shell wrapper cd's into; `ls`
 > and `prune` print informational output and never change your directory.
+
+## MCP server
+
+`gct mcp` runs a [Model Context Protocol](https://modelcontextprotocol.io) server
+over stdio, exposing gct's convention-aware worktree operations as tools for AI
+agents. When an agent creates a worktree through gct instead of running
+`git worktree add` itself, it gets the configured path layout (`worktree.dir`,
+`{repo}` placeholder) and the `post_create` hooks (copying `.env` files, setup
+commands) for free — so the branch↔directory mapping stays consistent and new
+worktrees are immediately usable.
+
+Tools: `create_worktree` (config-driven path + post-create hooks, idempotent),
+`list_worktrees`, and `list_branches`. All are local-only; `gh` is not required.
+
+With Claude Code:
+
+```bash
+claude mcp add gct -- gct mcp
+```
+
+Or in `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "gct": { "command": "gct", "args": ["mcp"] }
+  }
+}
+```
+
+The server operates on the repository at its working directory (MCP clients
+spawn it in the project root). Clients invoke the installed `gct` binary
+directly, so the shell-init wrapper from [Setup](#setup) is not involved.
 
 ## Keybindings
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,8 @@ mod config;
 mod data;
 mod event;
 mod git;
+mod mcp;
+mod ops;
 mod ui;
 
 use anyhow::Context;
@@ -116,13 +118,13 @@ struct BranchesReloadData {
 }
 
 /// Fetches branches + worktrees without touching `App`, so it can run inside
-/// `tokio::spawn` without blocking the event loop. Reuses `load_branches_cli`,
+/// `tokio::spawn` without blocking the event loop. Reuses `ops::list_branches`,
 /// which already performs the same branch/default-branch/merged/rev-parse
 /// sequence for the `gct ls` command.
 async fn fetch_branches_and_worktrees() -> BranchesReloadData {
     let mut errors = Vec::new();
 
-    let branches = match load_branches_cli().await {
+    let branches = match ops::list_branches().await {
         Ok(b) => Some(b),
         Err(e) => {
             errors.push(format!("git branch -vv failed: {e}"));
@@ -394,6 +396,13 @@ async fn main() -> anyhow::Result<()> {
             print_completions(args.get(2).map(|s| s.as_str()).unwrap_or("zsh"));
             return Ok(());
         }
+        Some("mcp") => {
+            // stdout is the JSON-RPC channel here; debug logging (GCT_DEBUG=1)
+            // goes to a file, and notices/errors go to stderr only.
+            crate::git::command::init_debug_log(false);
+            let code = mcp::run_mcp_server().await;
+            process::exit(code);
+        }
         _ => {}
     }
 
@@ -464,18 +473,6 @@ async fn check_prerequisites() {
     }
 }
 
-/// Find the worktree checked out for `branch` and return its path.
-/// Pure helper over an already-parsed worktree list so it can be unit-tested.
-fn worktree_path_for_branch(
-    worktrees: &[crate::git::types::Worktree],
-    branch: &str,
-) -> Option<String> {
-    worktrees
-        .iter()
-        .find(|wt| wt.branch.as_deref() == Some(branch))
-        .map(|wt| wt.path.clone())
-}
-
 /// Implements `gct cd <branch>`: print the branch's worktree path to stdout (the
 /// shell wrapper cd's into it) and return an exit code. On any failure nothing is
 /// written to stdout and a non-zero code is returned so the wrapper does not cd.
@@ -501,7 +498,7 @@ async fn run_cd(branch: Option<&str>) -> i32 {
         }
     };
 
-    match worktree_path_for_branch(&parse_worktrees(&output), branch) {
+    match ops::worktree_path_for_branch(&parse_worktrees(&output), branch) {
         Some(path) => {
             println!("{path}");
             0
@@ -515,25 +512,11 @@ async fn run_cd(branch: Option<&str>) -> i32 {
     }
 }
 
-/// Resolve the active repo's name for the `{repo}` token in `worktree_path_for`.
-/// Prefers the origin remote's repo name, falling back to the toplevel dir name.
-async fn active_repo_name(repo_root: &std::path::Path) -> String {
-    if let Ok(url) = run_git(&["remote", "get-url", "origin"]).await
-        && let Some(info) = extract_repo_info(url.trim())
-    {
-        return info.name;
-    }
-    repo_root
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("repo")
-        .to_string()
-}
-
 /// Implements `gct wt <branch>`: reuse the branch's existing worktree or create one,
 /// then print its path (the shell wrapper cd's into it). The create-side complement
 /// to `cd`. On any failure nothing is written to stdout and a non-zero code is
-/// returned so the wrapper does not cd.
+/// returned so the wrapper does not cd. Thin printer over `ops::ensure_worktree`,
+/// which is shared with the MCP server.
 async fn run_wt(branch: Option<&str>) -> i32 {
     let branch = match branch {
         Some(b) if !b.is_empty() => b,
@@ -543,66 +526,20 @@ async fn run_wt(branch: Option<&str>) -> i32 {
         }
     };
 
-    if run_git(&["rev-parse", "--git-dir"]).await.is_err() {
-        eprintln!("Error: not a git repository.");
-        return 1;
-    }
-
-    // Idempotent: if a worktree already exists for the branch, just print it.
-    if let Ok(output) = run_git(&["worktree", "list", "--porcelain"]).await
-        && let Some(path) = worktree_path_for_branch(&parse_worktrees(&output), branch)
-    {
-        println!("{path}");
-        return 0;
-    }
-
-    let repo_root = match run_git(&["rev-parse", "--show-toplevel"]).await {
-        Ok(s) => std::path::PathBuf::from(s.trim()),
-        Err(e) => {
-            eprintln!("Error: failed to resolve repository root: {e}");
-            return 1;
+    match ops::ensure_worktree(branch).await {
+        Ok(outcome) => {
+            // Post-create hook failures are non-fatal, matching TUI semantics.
+            for err in &outcome.hook_errors {
+                eprintln!("Warning: post-create hook failed: {err}");
+            }
+            println!("{}", outcome.path);
+            0
         }
-    };
-
-    let cfg = config::load_config();
-    let repo_name = active_repo_name(&repo_root).await;
-    let wt_path = cfg.worktree_path_for(&repo_root, &repo_name, branch);
-    if let Some(parent) = std::path::Path::new(&wt_path).parent() {
-        let _ = std::fs::create_dir_all(parent);
+        Err(e) => {
+            eprintln!("Error: {e}");
+            1
+        }
     }
-
-    // Mirror the TUI creation logic: check out a local branch directly, otherwise
-    // fetch from origin first and let `git worktree add` create a tracking branch.
-    let has_local = run_git(&[
-        "rev-parse",
-        "--verify",
-        "--quiet",
-        &format!("refs/heads/{branch}"),
-    ])
-    .await
-    .is_ok();
-    if !has_local && let Err(e) = run_git(&["fetch", "origin", branch]).await {
-        eprintln!("Error: failed to fetch '{branch}' from origin: {e}");
-        return 1;
-    }
-
-    if let Err(e) = run_git(&["worktree", "add", &wt_path, branch]).await {
-        eprintln!("Error: failed to create worktree: {e}");
-        return 1;
-    }
-
-    // Post-create hooks are non-fatal, matching TUI semantics.
-    let errors = config::run_post_create(
-        &cfg.worktree.post_create,
-        &repo_root,
-        std::path::Path::new(&wt_path),
-    );
-    for err in errors {
-        eprintln!("Warning: post-create hook failed: {err}");
-    }
-
-    println!("{wt_path}");
-    0
 }
 
 /// Implements `gct ls [worktrees|branches]`: print a plain-text, pipe-friendly
@@ -629,7 +566,7 @@ async fn run_ls(subject: Option<&str>) -> i32 {
             0
         }
         "branches" | "branch" => {
-            let branches = match load_branches_cli().await {
+            let branches = match ops::list_branches().await {
                 Ok(b) => b,
                 Err(e) => {
                     eprintln!("Error: failed to list branches: {e}");
@@ -660,24 +597,6 @@ fn format_worktree_list(worktrees: &[crate::git::types::Worktree]) -> Vec<String
         .collect()
 }
 
-/// Load the active repo's branches for CLI commands (no App state). Mirrors the
-/// git calls in `load_branches` but returns a plain `Vec<Branch>` or an error.
-async fn load_branches_cli() -> anyhow::Result<Vec<crate::git::types::Branch>> {
-    let branch_output = run_git(&["branch", "-vv"]).await?;
-    let default_branch = detect_default_branch().await;
-    let merged_output = run_git(&["branch", "--merged", &default_branch])
-        .await
-        .unwrap_or_default();
-    let base_hash = run_git(&["rev-parse", &default_branch])
-        .await
-        .unwrap_or_default();
-    Ok(parse_branches(
-        &branch_output,
-        &merged_output,
-        base_hash.trim(),
-    ))
-}
-
 /// A branch eligible for pruning, paired with its worktree path (if any).
 struct PruneCandidate {
     branch: String,
@@ -695,7 +614,7 @@ fn prune_candidates(
         .filter(|b| b.is_merged && !b.is_current && !protected.iter().any(|p| p == &b.name))
         .map(|b| PruneCandidate {
             branch: b.name.clone(),
-            wt_path: worktree_path_for_branch(worktrees, &b.name),
+            wt_path: ops::worktree_path_for_branch(worktrees, &b.name),
         })
         .collect()
 }
@@ -720,7 +639,7 @@ async fn run_prune(flags: &[String]) -> i32 {
         return 1;
     }
 
-    let branches = match load_branches_cli().await {
+    let branches = match ops::list_branches().await {
         Ok(b) => b,
         Err(e) => {
             eprintln!("Error: failed to list branches: {e}");
@@ -1778,6 +1697,7 @@ USAGE:
     gct wt <BRANCH>
     gct ls [worktrees|branches]
     gct prune [--dry-run] [--yes] [--force]
+    gct mcp
     gct completions <SHELL>
     gct shell-init <SHELL>
 
@@ -1807,6 +1727,12 @@ SUBCOMMANDS:
         Delete merged branches and their worktrees (protected/current branches
         are skipped). Lists candidates only unless --yes is given. --force uses
         `worktree remove --force` and `branch -D`.
+
+    mcp
+        Run a Model Context Protocol server over stdio, exposing worktree
+        tools (create_worktree, list_worktrees, list_branches) to MCP
+        clients such as Claude Code. For client configuration, not
+        interactive use. Does not require gh.
 
     completions <SHELL>
         Print a shell completion script. SHELL is one of: zsh, bash, fish.
@@ -1876,7 +1802,7 @@ fn print_completions(shell: &str) {
     cur="${{COMP_WORDS[COMP_CWORD]}}"
     prev="${{COMP_WORDS[COMP_CWORD-1]}}"
     if [ "$COMP_CWORD" -eq 1 ]; then
-        COMPREPLY=($(compgen -W "cd wt ls prune completions shell-init --help --version" -- "$cur"))
+        COMPREPLY=($(compgen -W "cd wt ls prune mcp completions shell-init --help --version" -- "$cur"))
         return
     fi
     case "$prev" in
@@ -1893,7 +1819,7 @@ complete -F _gct gct
             print!(
                 r#"_gct() {{
     if (( CURRENT == 2 )); then
-        compadd -- cd wt ls prune completions shell-init --help --version
+        compadd -- cd wt ls prune mcp completions shell-init --help --version
         return
     fi
     case "${{words[2]}}" in
@@ -1909,7 +1835,7 @@ compdef _gct gct
         "fish" => {
             print!(
                 r#"complete -c gct -f
-complete -c gct -n '__fish_use_subcommand' -a 'cd wt ls prune completions shell-init'
+complete -c gct -n '__fish_use_subcommand' -a 'cd wt ls prune mcp completions shell-init'
 complete -c gct -n '__fish_seen_subcommand_from cd wt' -a '(command gct ls branches 2>/dev/null)'
 complete -c gct -n '__fish_seen_subcommand_from ls' -a 'worktrees branches'
 complete -c gct -n '__fish_seen_subcommand_from completions shell-init' -a 'zsh bash fish'
@@ -2138,34 +2064,6 @@ mod tests {
             branch: branch.map(|s| s.to_string()),
             is_bare,
         }
-    }
-
-    #[test]
-    fn worktree_path_for_branch_found() {
-        let wts = vec![
-            wt("/repo", Some("main"), false),
-            wt("/repo-feature", Some("feature/x"), false),
-        ];
-        assert_eq!(
-            worktree_path_for_branch(&wts, "feature/x").as_deref(),
-            Some("/repo-feature")
-        );
-    }
-
-    #[test]
-    fn worktree_path_for_branch_not_found() {
-        let wts = vec![wt("/repo", Some("main"), false)];
-        assert!(worktree_path_for_branch(&wts, "feature/x").is_none());
-    }
-
-    #[test]
-    fn worktree_path_for_branch_ignores_detached_and_bare() {
-        // A detached/bare worktree has no branch and must never match.
-        let wts = vec![
-            wt("/repo-bare", None, true),
-            wt("/repo-detached", None, false),
-        ];
-        assert!(worktree_path_for_branch(&wts, "feature/x").is_none());
     }
 
     fn branch(name: &str, is_current: bool, is_merged: bool) -> crate::git::types::Branch {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,230 @@
+//! `gct mcp` — a Model Context Protocol server over stdio.
+//!
+//! Exposes gct's convention-aware worktree operations as MCP tools so AI
+//! agents create worktrees through gct (config-driven path layout +
+//! post-create hooks) instead of running `git worktree add` directly.
+//!
+//! stdout is the JSON-RPC channel: nothing in this module (or in `ops`,
+//! which it delegates to) may print to stdout. Diagnostics go to stderr or
+//! the GCT_DEBUG file log.
+
+use rmcp::{
+    ErrorData as McpError, ServerHandler, ServiceExt,
+    handler::server::{
+        router::tool::ToolRouter,
+        wrapper::{Json, Parameters},
+    },
+    tool, tool_handler, tool_router,
+    transport::stdio,
+};
+
+use crate::ops;
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct CreateWorktreeParams {
+    /// Branch name to create or reuse a worktree for (e.g. "feature/login").
+    /// If the branch does not exist locally it is fetched from origin first.
+    pub branch: String,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct CreateWorktreeResult {
+    /// The branch the worktree is checked out on.
+    pub branch: String,
+    /// Path of the worktree (existing or newly created).
+    pub path: String,
+    /// False when an existing worktree was reused (idempotent hit).
+    pub created: bool,
+    /// The branch was fetched from origin because it did not exist locally.
+    pub fetched_from_origin: bool,
+    /// Non-fatal post-create hook failures. The worktree itself was created.
+    pub hook_errors: Vec<String>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct WorktreeInfo {
+    /// Absolute path of the worktree.
+    pub path: String,
+    /// Commit hash of the worktree's HEAD.
+    pub head: String,
+    /// Checked-out branch; null when detached or bare.
+    pub branch: Option<String>,
+    /// True for the bare repository entry.
+    pub is_bare: bool,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct ListWorktreesResult {
+    pub worktrees: Vec<WorktreeInfo>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct BranchInfo {
+    /// Local branch name.
+    pub name: String,
+    /// True for the currently checked-out branch.
+    pub is_current: bool,
+    /// Upstream tracking ref (e.g. "origin/main"); null when none.
+    pub upstream: Option<String>,
+    /// True when the branch is merged into the default branch.
+    pub is_merged: bool,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+pub struct ListBranchesResult {
+    pub branches: Vec<BranchInfo>,
+}
+
+#[derive(Clone)]
+pub struct GctMcpServer {
+    tool_router: ToolRouter<Self>,
+}
+
+impl Default for GctMcpServer {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn tool_error(e: impl std::fmt::Display) -> McpError {
+    McpError::internal_error(e.to_string(), None)
+}
+
+#[tool_router]
+impl GctMcpServer {
+    pub fn new() -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+        }
+    }
+
+    #[tool(
+        description = "Create a git worktree for a branch in this repository, or return the existing one. THIS is the correct way to create worktrees here — do not run `git worktree add` directly. This tool resolves the worktree path from the project's gct configuration (`worktree.dir`, with `{repo}` placeholder support), fetches the branch from origin when it does not exist locally, and runs the project's post-create hooks (e.g. copying or symlinking .env files, running setup commands) so the new worktree is immediately usable. Idempotent: if a worktree for the branch already exists, its path is returned with created=false instead of failing. Returns the worktree path, whether it was newly created, whether the branch was fetched from origin, and any non-fatal hook errors."
+    )]
+    async fn create_worktree(
+        &self,
+        Parameters(params): Parameters<CreateWorktreeParams>,
+    ) -> Result<Json<CreateWorktreeResult>, McpError> {
+        let outcome = ops::ensure_worktree(&params.branch)
+            .await
+            .map_err(tool_error)?;
+        Ok(Json(CreateWorktreeResult {
+            branch: params.branch,
+            path: outcome.path,
+            created: outcome.created,
+            fetched_from_origin: outcome.fetched_from_origin,
+            hook_errors: outcome.hook_errors,
+        }))
+    }
+
+    #[tool(
+        description = "List all git worktrees of the current repository as structured JSON (path, checked-out branch, HEAD commit, bare flag). Prefer this over parsing `git worktree list` output."
+    )]
+    async fn list_worktrees(&self) -> Result<Json<ListWorktreesResult>, McpError> {
+        let worktrees = ops::list_worktrees().await.map_err(tool_error)?;
+        Ok(Json(ListWorktreesResult {
+            worktrees: worktrees
+                .into_iter()
+                .map(|wt| WorktreeInfo {
+                    path: wt.path,
+                    head: wt.head,
+                    branch: wt.branch,
+                    is_bare: wt.is_bare,
+                })
+                .collect(),
+        }))
+    }
+
+    #[tool(
+        description = "List local git branches of the current repository as structured JSON (name, is_current, upstream, is_merged into the default branch). Local-only; requires no network or GitHub access."
+    )]
+    async fn list_branches(&self) -> Result<Json<ListBranchesResult>, McpError> {
+        let branches = ops::list_branches().await.map_err(tool_error)?;
+        Ok(Json(ListBranchesResult {
+            branches: branches
+                .into_iter()
+                .map(|b| BranchInfo {
+                    name: b.name,
+                    is_current: b.is_current,
+                    upstream: b.upstream,
+                    is_merged: b.is_merged,
+                })
+                .collect(),
+        }))
+    }
+}
+
+#[tool_handler(
+    router = self.tool_router,
+    name = "gct",
+    instructions = "gct exposes convention-aware git worktree operations for the repository in the current working directory. Always use create_worktree instead of running `git worktree add` yourself: it applies the project's configured worktree path layout and runs its post-create setup hooks (such as copying .env files), so the branch↔directory mapping stays consistent and the worktree is immediately usable."
+)]
+impl ServerHandler for GctMcpServer {}
+
+/// Entry point called from main's subcommand dispatch. Returns a process
+/// exit code; all failure detail goes to stderr, never stdout.
+pub async fn run_mcp_server() -> i32 {
+    match serve().await {
+        Ok(()) => 0,
+        Err(e) => {
+            eprintln!("Error: MCP server failed: {e}");
+            1
+        }
+    }
+}
+
+async fn serve() -> anyhow::Result<()> {
+    let service = GctMcpServer::new().serve(stdio()).await?;
+    service.waiting().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_worktree_result_serializes_expected_fields() {
+        let v = serde_json::to_value(CreateWorktreeResult {
+            branch: "feature/x".into(),
+            path: "/repos/wt/feature/x".into(),
+            created: true,
+            fetched_from_origin: false,
+            hook_errors: vec![],
+        })
+        .unwrap();
+        assert_eq!(v["branch"], "feature/x");
+        assert_eq!(v["path"], "/repos/wt/feature/x");
+        assert_eq!(v["created"], true);
+        assert_eq!(v["fetched_from_origin"], false);
+        assert!(v["hook_errors"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn list_results_wrap_arrays_in_objects() {
+        // MCP structuredContent must be a JSON object at the top level.
+        let wt = serde_json::to_value(ListWorktreesResult {
+            worktrees: vec![WorktreeInfo {
+                path: "/repo".into(),
+                head: "abc123".into(),
+                branch: Some("main".into()),
+                is_bare: false,
+            }],
+        })
+        .unwrap();
+        assert!(wt.is_object());
+        assert_eq!(wt["worktrees"][0]["branch"], "main");
+
+        let br = serde_json::to_value(ListBranchesResult {
+            branches: vec![BranchInfo {
+                name: "main".into(),
+                is_current: true,
+                upstream: Some("origin/main".into()),
+                is_merged: true,
+            }],
+        })
+        .unwrap();
+        assert!(br.is_object());
+        assert_eq!(br["branches"][0]["is_current"], true);
+    }
+}

--- a/src/ops.rs
+++ b/src/ops.rs
@@ -1,0 +1,227 @@
+//! Headless repository operations shared by the CLI subcommands (`wt`, `ls`,
+//! `prune`) and the MCP server (`gct mcp`). Nothing in this module writes to
+//! stdout or stderr: for MCP, stdout is the JSON-RPC channel, so all results
+//! and errors are returned as data and rendered by the caller.
+
+use crate::config;
+use crate::git::command::run_git;
+use crate::git::parser::{parse_branches, parse_worktrees};
+use crate::git::types::{Branch, Worktree};
+
+/// Outcome of `ensure_worktree`.
+pub struct WorktreeOutcome {
+    /// Path of the worktree (existing or newly created).
+    pub path: String,
+    /// `false` means an existing worktree was reused (idempotent hit).
+    pub created: bool,
+    /// The branch did not exist locally and was fetched from origin first.
+    pub fetched_from_origin: bool,
+    /// Non-fatal post-create hook failures (the worktree itself was created).
+    pub hook_errors: Vec<String>,
+}
+
+/// Failure modes of `ensure_worktree`. Display strings match the text
+/// `gct wt` has always printed after its "Error: " prefix, so the CLI
+/// output stays byte-identical.
+pub enum WtError {
+    NotAGitRepo,
+    RepoRoot(String),
+    Fetch { branch: String, msg: String },
+    WorktreeAdd(String),
+}
+
+impl std::fmt::Display for WtError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotAGitRepo => write!(f, "not a git repository."),
+            Self::RepoRoot(e) => write!(f, "failed to resolve repository root: {e}"),
+            Self::Fetch { branch, msg } => {
+                write!(f, "failed to fetch '{branch}' from origin: {msg}")
+            }
+            Self::WorktreeAdd(e) => write!(f, "failed to create worktree: {e}"),
+        }
+    }
+}
+
+/// Find the worktree checked out for `branch` and return its path.
+/// Pure helper over an already-parsed worktree list so it can be unit-tested.
+pub fn worktree_path_for_branch(worktrees: &[Worktree], branch: &str) -> Option<String> {
+    worktrees
+        .iter()
+        .find(|wt| wt.branch.as_deref() == Some(branch))
+        .map(|wt| wt.path.clone())
+}
+
+/// Resolve the active repo's name for the `{repo}` token in `worktree_path_for`.
+/// Prefers the origin remote's repo name, falling back to the toplevel dir name.
+pub async fn active_repo_name(repo_root: &std::path::Path) -> String {
+    if let Ok(url) = run_git(&["remote", "get-url", "origin"]).await
+        && let Some(info) = crate::extract_repo_info(url.trim())
+    {
+        return info.name;
+    }
+    repo_root
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("repo")
+        .to_string()
+}
+
+/// Reuse the worktree for `branch` or create one, applying the configured
+/// path layout and post-create hooks. Idempotent: an existing worktree is
+/// returned with `created: false`. Checks out a local branch directly;
+/// otherwise fetches from origin first and lets `git worktree add` create a
+/// tracking branch.
+pub async fn ensure_worktree(branch: &str) -> Result<WorktreeOutcome, WtError> {
+    if run_git(&["rev-parse", "--git-dir"]).await.is_err() {
+        return Err(WtError::NotAGitRepo);
+    }
+
+    // Idempotent: if a worktree already exists for the branch, just return it.
+    if let Ok(output) = run_git(&["worktree", "list", "--porcelain"]).await
+        && let Some(path) = worktree_path_for_branch(&parse_worktrees(&output), branch)
+    {
+        return Ok(WorktreeOutcome {
+            path,
+            created: false,
+            fetched_from_origin: false,
+            hook_errors: Vec::new(),
+        });
+    }
+
+    let repo_root = match run_git(&["rev-parse", "--show-toplevel"]).await {
+        Ok(s) => std::path::PathBuf::from(s.trim()),
+        Err(e) => return Err(WtError::RepoRoot(e.to_string())),
+    };
+
+    let cfg = config::load_config();
+    let repo_name = active_repo_name(&repo_root).await;
+    let wt_path = cfg.worktree_path_for(&repo_root, &repo_name, branch);
+    if let Some(parent) = std::path::Path::new(&wt_path).parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+
+    // Check out a local branch directly, otherwise fetch from origin first and
+    // let `git worktree add` create a tracking branch.
+    let has_local = run_git(&[
+        "rev-parse",
+        "--verify",
+        "--quiet",
+        &format!("refs/heads/{branch}"),
+    ])
+    .await
+    .is_ok();
+    if !has_local && let Err(e) = run_git(&["fetch", "origin", branch]).await {
+        return Err(WtError::Fetch {
+            branch: branch.to_string(),
+            msg: e.to_string(),
+        });
+    }
+
+    if let Err(e) = run_git(&["worktree", "add", &wt_path, branch]).await {
+        return Err(WtError::WorktreeAdd(e.to_string()));
+    }
+
+    // Post-create hooks are non-fatal.
+    let hook_errors = config::run_post_create(
+        &cfg.worktree.post_create,
+        &repo_root,
+        std::path::Path::new(&wt_path),
+    );
+
+    Ok(WorktreeOutcome {
+        path: wt_path,
+        created: true,
+        fetched_from_origin: !has_local,
+        hook_errors,
+    })
+}
+
+/// List the active repo's worktrees.
+pub async fn list_worktrees() -> anyhow::Result<Vec<Worktree>> {
+    let output = run_git(&["worktree", "list", "--porcelain"]).await?;
+    Ok(parse_worktrees(&output))
+}
+
+/// Load the active repo's branches (no App state). Mirrors the git calls in
+/// the TUI's `load_branches` but returns a plain `Vec<Branch>` or an error.
+pub async fn list_branches() -> anyhow::Result<Vec<Branch>> {
+    let branch_output = run_git(&["branch", "-vv"]).await?;
+    let default_branch = crate::detect_default_branch().await;
+    let merged_output = run_git(&["branch", "--merged", &default_branch])
+        .await
+        .unwrap_or_default();
+    let base_hash = run_git(&["rev-parse", &default_branch])
+        .await
+        .unwrap_or_default();
+    Ok(parse_branches(
+        &branch_output,
+        &merged_output,
+        base_hash.trim(),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn wt(path: &str, branch: Option<&str>, is_bare: bool) -> Worktree {
+        Worktree {
+            path: path.to_string(),
+            head: "abc123".to_string(),
+            branch: branch.map(|s| s.to_string()),
+            is_bare,
+        }
+    }
+
+    #[test]
+    fn worktree_path_for_branch_found() {
+        let wts = vec![
+            wt("/repo", Some("main"), false),
+            wt("/repo-feature", Some("feature/x"), false),
+        ];
+        assert_eq!(
+            worktree_path_for_branch(&wts, "feature/x").as_deref(),
+            Some("/repo-feature")
+        );
+    }
+
+    #[test]
+    fn worktree_path_for_branch_not_found() {
+        let wts = vec![wt("/repo", Some("main"), false)];
+        assert!(worktree_path_for_branch(&wts, "feature/x").is_none());
+    }
+
+    #[test]
+    fn worktree_path_for_branch_ignores_detached_and_bare() {
+        // A detached/bare worktree has no branch and must never match.
+        let wts = vec![
+            wt("/repo-bare", None, true),
+            wt("/repo-detached", None, false),
+        ];
+        assert!(worktree_path_for_branch(&wts, "feature/x").is_none());
+    }
+
+    // Lock the exact error text the CLI prints (after its "Error: " prefix)
+    // so the run_wt refactor stays byte-compatible.
+    #[test]
+    fn wt_error_display_matches_cli_wording() {
+        assert_eq!(WtError::NotAGitRepo.to_string(), "not a git repository.");
+        assert_eq!(
+            WtError::RepoRoot("boom".into()).to_string(),
+            "failed to resolve repository root: boom"
+        );
+        assert_eq!(
+            WtError::Fetch {
+                branch: "feature/x".into(),
+                msg: "boom".into()
+            }
+            .to_string(),
+            "failed to fetch 'feature/x' from origin: boom"
+        );
+        assert_eq!(
+            WtError::WorktreeAdd("boom".into()).to_string(),
+            "failed to create worktree: boom"
+        );
+    }
+}

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -1,0 +1,298 @@
+//! Black-box integration tests for the `gct mcp` subcommand.
+//!
+//! These drive the compiled `gct` binary as a real MCP server subprocess:
+//! newline-delimited JSON-RPC requests go to its stdin and responses are
+//! read back from stdout, against a temp git repo created with the real
+//! `git` CLI. Any stray print to stdout would corrupt the JSON-RPC stream
+//! and fail these tests, so stdout purity is asserted implicitly.
+
+use std::io::{BufRead, BufReader, Write};
+use std::path::Path;
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+use serde_json::{Value, json};
+
+fn gct_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_gct")
+}
+
+fn run_git(dir: &Path, args: &[&str]) {
+    let status = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .status()
+        .expect("git should be installed and on PATH");
+    assert!(status.success(), "git {args:?} failed in {dir:?}");
+}
+
+/// Initializes a temp repo with one commit on `main` and a repo-local
+/// `.gct.toml` setting `worktree.dir = "wt"`, mirroring the setup in
+/// `tests/cli_integration.rs` (see the rationale there).
+fn init_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    run_git(dir.path(), &["init", "-q", "-b", "main"]);
+    run_git(
+        dir.path(),
+        &["config", "user.email", "gct-test@example.com"],
+    );
+    run_git(dir.path(), &["config", "user.name", "gct-test"]);
+    std::fs::write(dir.path().join(".gct.toml"), "[worktree]\ndir = \"wt\"\n")
+        .expect("write .gct.toml");
+    std::fs::write(dir.path().join("README.md"), "hello\n").expect("write README");
+    run_git(dir.path(), &["add", "."]);
+    run_git(dir.path(), &["commit", "-q", "-m", "init"]);
+    dir
+}
+
+/// A `gct mcp` subprocess plus the client side of its JSON-RPC stdio channel.
+struct McpServer {
+    child: Child,
+    stdin: Option<ChildStdin>,
+    reader: BufReader<ChildStdout>,
+    next_id: u64,
+}
+
+impl McpServer {
+    /// Spawns `gct mcp` in `dir` and performs the initialize handshake,
+    /// returning the connection and the `initialize` result.
+    fn start(dir: &Path) -> (Self, Value) {
+        let mut child = Command::new(gct_bin())
+            .arg("mcp")
+            .current_dir(dir)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            // Never inherit an override from the outer test-runner environment.
+            .env_remove("GCT_GIT_BIN")
+            .env_remove("GCT_GH_BIN")
+            .spawn()
+            .expect("failed to spawn gct mcp");
+        let stdin = child.stdin.take().expect("child stdin");
+        let reader = BufReader::new(child.stdout.take().expect("child stdout"));
+        let mut server = Self {
+            child,
+            stdin: Some(stdin),
+            reader,
+            next_id: 0,
+        };
+
+        let init = server.request(
+            "initialize",
+            json!({
+                "protocolVersion": "2025-06-18",
+                "capabilities": {},
+                "clientInfo": {"name": "gct-test", "version": "0"}
+            }),
+        );
+        let init = init.expect("initialize should succeed");
+        server.notify("notifications/initialized");
+        (server, init)
+    }
+
+    /// Sends a request and reads responses until the matching id arrives.
+    /// Returns `Ok(result)` or `Err(error)` from the JSON-RPC response.
+    fn request(&mut self, method: &str, params: Value) -> Result<Value, Value> {
+        self.next_id += 1;
+        let id = self.next_id;
+        let msg = json!({"jsonrpc": "2.0", "id": id, "method": method, "params": params});
+        let stdin = self.stdin.as_mut().expect("stdin still open");
+        writeln!(stdin, "{msg}").expect("write request");
+        stdin.flush().expect("flush request");
+
+        loop {
+            let mut line = String::new();
+            let n = self.reader.read_line(&mut line).expect("read response");
+            assert!(n > 0, "server closed stdout before answering {method}");
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let value: Value = serde_json::from_str(line)
+                .unwrap_or_else(|e| panic!("stdout is not clean JSON-RPC ({e}): {line:?}"));
+            // Skip anything that isn't the response to this request
+            // (e.g. server-initiated notifications).
+            if value.get("id") == Some(&json!(id)) {
+                if let Some(err) = value.get("error") {
+                    return Err(err.clone());
+                }
+                return Ok(value["result"].clone());
+            }
+        }
+    }
+
+    fn notify(&mut self, method: &str) {
+        let msg = json!({"jsonrpc": "2.0", "method": method});
+        let stdin = self.stdin.as_mut().expect("stdin still open");
+        writeln!(stdin, "{msg}").expect("write notification");
+        stdin.flush().expect("flush notification");
+    }
+
+    /// Calls a tool and returns its `structuredContent`, panicking on any
+    /// JSON-RPC error or `isError` tool result.
+    fn call_tool(&mut self, name: &str, arguments: Value) -> Value {
+        let result = self
+            .request("tools/call", json!({"name": name, "arguments": arguments}))
+            .unwrap_or_else(|e| panic!("tools/call {name} failed: {e}"));
+        assert_ne!(
+            result.get("isError"),
+            Some(&json!(true)),
+            "tool {name} returned isError: {result}"
+        );
+        result
+            .get("structuredContent")
+            .unwrap_or_else(|| panic!("tool {name} returned no structuredContent: {result}"))
+            .clone()
+    }
+
+    /// Closes stdin and asserts the server shuts down cleanly.
+    fn shutdown(mut self) {
+        drop(self.stdin.take());
+        let status = self.child.wait().expect("wait for gct mcp");
+        assert!(
+            status.success(),
+            "gct mcp should exit 0 on stdin close, got {status:?}"
+        );
+    }
+}
+
+impl Drop for McpServer {
+    fn drop(&mut self) {
+        // Don't leak the subprocess if a test assertion fails mid-flight.
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[test]
+fn initialize_and_tools_list() {
+    let repo = init_repo();
+    let (mut server, init) = McpServer::start(repo.path());
+
+    assert_eq!(init["serverInfo"]["name"], "gct");
+    let instructions = init["instructions"].as_str().unwrap_or_default();
+    assert!(
+        instructions.contains("create_worktree"),
+        "instructions should steer agents to create_worktree: {instructions:?}"
+    );
+
+    let result = server.request("tools/list", json!({})).unwrap();
+    let tools = result["tools"].as_array().expect("tools array");
+    let mut names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
+    names.sort_unstable();
+    assert_eq!(
+        names,
+        ["create_worktree", "list_branches", "list_worktrees"]
+    );
+    for tool in tools {
+        assert!(
+            tool["inputSchema"].is_object(),
+            "tool {} lacks inputSchema",
+            tool["name"]
+        );
+        assert!(
+            tool["outputSchema"].is_object(),
+            "tool {} lacks outputSchema",
+            tool["name"]
+        );
+    }
+
+    server.shutdown();
+}
+
+#[test]
+fn list_worktrees_returns_structured_json() {
+    let repo = init_repo();
+    let (mut server, _) = McpServer::start(repo.path());
+
+    let content = server.call_tool("list_worktrees", json!({}));
+    let worktrees = content["worktrees"].as_array().expect("worktrees array");
+    assert_eq!(worktrees.len(), 1, "fresh repo has one worktree: {content}");
+    assert_eq!(worktrees[0]["branch"], "main");
+    assert_eq!(worktrees[0]["is_bare"], false);
+    assert!(worktrees[0]["path"].as_str().unwrap().contains("/"));
+
+    server.shutdown();
+}
+
+#[test]
+fn list_branches_marks_current() {
+    let repo = init_repo();
+    run_git(repo.path(), &["branch", "feature/y"]);
+    let (mut server, _) = McpServer::start(repo.path());
+
+    let content = server.call_tool("list_branches", json!({}));
+    let branches = content["branches"].as_array().expect("branches array");
+    let find = |name: &str| {
+        branches
+            .iter()
+            .find(|b| b["name"] == name)
+            .unwrap_or_else(|| panic!("branch {name} missing from {content}"))
+    };
+    assert_eq!(find("main")["is_current"], true);
+    assert_eq!(find("feature/y")["is_current"], false);
+
+    server.shutdown();
+}
+
+#[test]
+fn create_worktree_creates_runs_hooks_and_is_idempotent() {
+    let repo = init_repo();
+    // Add a post-create copy hook for an untracked file, the flagship use
+    // case: .env doesn't travel with `git worktree add`, gct copies it.
+    std::fs::write(repo.path().join(".env"), "SECRET=1\n").expect("write .env");
+    std::fs::write(
+        repo.path().join(".gct.toml"),
+        "[worktree]\ndir = \"wt\"\n\n[[worktree.post_create]]\ntype = \"copy\"\nfrom = \".env\"\nto = \".env\"\n",
+    )
+    .expect("write .gct.toml");
+    run_git(repo.path(), &["branch", "feature/x"]);
+    let (mut server, _) = McpServer::start(repo.path());
+
+    let content = server.call_tool("create_worktree", json!({"branch": "feature/x"}));
+    assert_eq!(content["branch"], "feature/x");
+    assert_eq!(content["created"], true);
+    assert_eq!(content["fetched_from_origin"], false);
+    assert_eq!(content["hook_errors"], json!([]));
+    let path = content["path"].as_str().expect("path string");
+    assert!(
+        path.ends_with("wt/feature/x"),
+        "path should follow the configured `wt/` layout: {path:?}"
+    );
+    assert!(Path::new(path).is_dir(), "worktree dir should exist");
+    assert_eq!(
+        std::fs::read_to_string(Path::new(path).join(".env")).expect(".env copied by hook"),
+        "SECRET=1\n"
+    );
+
+    // Second call is idempotent: same worktree, created=false. Compare
+    // canonicalized paths (git may report a normalized form).
+    let content2 = server.call_tool("create_worktree", json!({"branch": "feature/x"}));
+    assert_eq!(content2["created"], false);
+    assert_eq!(
+        std::fs::canonicalize(path).unwrap(),
+        std::fs::canonicalize(content2["path"].as_str().unwrap()).unwrap()
+    );
+
+    server.shutdown();
+}
+
+#[test]
+fn create_worktree_errors_outside_git_repo() {
+    let dir = tempfile::tempdir().expect("failed to create temp dir");
+    let (mut server, _) = McpServer::start(dir.path());
+
+    let err = server
+        .request(
+            "tools/call",
+            json!({"name": "create_worktree", "arguments": {"branch": "feature/x"}}),
+        )
+        .expect_err("create_worktree should fail outside a git repository");
+    assert!(
+        err["message"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("not a git repository"),
+        "unexpected error: {err}"
+    );
+
+    server.shutdown();
+}


### PR DESCRIPTION
Add a Model Context Protocol server over stdio (official rmcp SDK) so AI
agents create worktrees through gct instead of raw `git worktree add`,
getting the config-driven path layout (worktree.dir, {repo} placeholder)
and post_create hooks (.env copy etc.) automatically.

Tools: create_worktree (idempotent, fetch-from-origin fallback,
post-create hooks), list_worktrees, list_branches. All local-only; gh is
not required. Results are returned as structured JSON with derived
output schemas.

The headless logic behind `gct wt`/`gct ls` moves to a new src/ops.rs
shared by the CLI and the MCP server; ops functions never print, since
stdout is the JSON-RPC channel in MCP mode. CLI output stays
byte-identical (locked by WtError Display tests and the existing
cli_integration suite).

Also: help/completions list the new subcommand; README documents client
setup; tests/mcp_integration.rs drives the compiled binary over real
JSON-RPC stdio against temp repos.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011gRrHZ9NLbytAjHDHkKNAv