### PR TITLE
chore(git): remove dead-code scaffolding for cross-repo gh actions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1670,16 +1670,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
-name = "socket2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
-dependencies = [
- "libc",
- "windows-sys",
-]
-
-[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1893,10 +1883,8 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
  "tokio-macros",
  "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ path = "src/main.rs"
 [dependencies]
 ratatui = "0.30"
 crossterm = "0.29"
-tokio = { version = "1", features = ["full"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time"] }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1619,31 +1619,23 @@ mod pr_detail_cache_tests {
         };
         let detail_a = PrDetail {
             number: 1,
-            title: "A".into(),
-            author: "u".into(),
-            state: "OPEN".into(),
-            body: String::new(),
+            body: "A".into(),
             additions: 0,
             deletions: 0,
-            head_ref: "f".into(),
         };
         let detail_b = PrDetail {
             number: 1,
-            title: "B".into(),
-            author: "u".into(),
-            state: "OPEN".into(),
-            body: String::new(),
+            body: "B".into(),
             additions: 0,
             deletions: 0,
-            head_ref: "f".into(),
         };
         app.pr_detail_cache
             .insert((id_a.clone(), 1), detail_a.clone());
         app.pr_detail_cache
             .insert((id_b.clone(), 1), detail_b.clone());
         assert_eq!(app.pr_detail_cache.len(), 2);
-        assert_eq!(app.pr_detail_cache.get(&(id_a, 1)).unwrap().title, "A");
-        assert_eq!(app.pr_detail_cache.get(&(id_b, 1)).unwrap().title, "B");
+        assert_eq!(app.pr_detail_cache.get(&(id_a, 1)).unwrap().body, "A");
+        assert_eq!(app.pr_detail_cache.get(&(id_b, 1)).unwrap().body, "B");
     }
 }
 

--- a/src/git/command.rs
+++ b/src/git/command.rs
@@ -143,8 +143,6 @@ pub struct CommandRecord {
     /// stdout bytes on success, stderr bytes on failure.
     pub output_bytes: usize,
     pub error: Option<String>,
-    #[allow(dead_code)]
-    pub repo: Option<crate::git::types::RepoId>,
 }
 
 fn history() -> &'static Mutex<VecDeque<CommandRecord>> {
@@ -177,60 +175,27 @@ pub fn command_history_len() -> usize {
 // ---- Command execution ----
 
 pub async fn run_git(args: &[&str]) -> Result<String> {
-    run_cmd_tagged("git", args, None).await
+    run_cmd_tagged("git", args).await
 }
 
 pub async fn run_gh(args: &[&str]) -> Result<String> {
-    run_cmd_tagged("gh", args, None).await
+    run_cmd_tagged("gh", args).await
 }
 
 /// Run `git -C <cwd> <args>` for repo-specific operations.
 pub async fn run_git_in(cwd: &Path, args: &[&str]) -> Result<String> {
-    run_git_in_with_id(cwd, None, args).await
-}
-
-// TODO(future): run_gh_in / run_gh_in_with_id are scaffolding for cross-repo gh actions
-// (e.g. gh CLI invocations against a specific clone). Used selectively today; v1 doesn't
-// need all of them.
-
-/// Run `gh <args>` with `current_dir(cwd)` for repo-specific operations.
-#[allow(dead_code)]
-pub async fn run_gh_in(cwd: &Path, args: &[&str]) -> Result<String> {
-    run_gh_in_with_id(cwd, None, args).await
-}
-
-/// `run_git_in` variant that tags the command-history record with a `RepoId`.
-pub async fn run_git_in_with_id(
-    cwd: &Path,
-    repo: Option<crate::git::types::RepoId>,
-    args: &[&str],
-) -> Result<String> {
     let cwd_str = cwd.to_string_lossy().to_string();
     let mut full = Vec::with_capacity(args.len() + 2);
     full.push("-C");
     full.push(cwd_str.as_str());
     full.extend_from_slice(args);
-    run_cmd_tagged("git", &full, repo).await
-}
-
-/// `run_gh_in` variant that tags the command-history record with a `RepoId`.
-#[allow(dead_code)]
-pub async fn run_gh_in_with_id(
-    cwd: &Path,
-    repo: Option<crate::git::types::RepoId>,
-    args: &[&str],
-) -> Result<String> {
-    run_cmd_in_dir_tagged("gh", cwd, args, repo).await
+    run_cmd_tagged("git", &full).await
 }
 
 /// Shared execution path for `run_git`/`run_gh`:
 /// - logs to the debug file if enabled
 /// - records a `CommandRecord` in the in-memory history buffer
-async fn run_cmd_tagged(
-    executable: &'static str,
-    args: &[&str],
-    repo: Option<crate::git::types::RepoId>,
-) -> Result<String> {
+async fn run_cmd_tagged(executable: &'static str, args: &[&str]) -> Result<String> {
     // Initialize session start lazily; cheap and idempotent.
     let _ = session_start();
     debug_log(&format!("$ {executable} {}", args.join(" ")));
@@ -250,7 +215,6 @@ async fn run_cmd_tagged(
                 duration: started_at.elapsed(),
                 output_bytes: 0,
                 error: Some(e.to_string()),
-                repo,
             });
             return Err(anyhow::Error::new(e))
                 .with_context(|| format!("failed to execute {executable}"));
@@ -270,7 +234,6 @@ async fn run_cmd_tagged(
             duration,
             output_bytes: output.stderr.len(),
             error: Some(stderr.clone()),
-            repo,
         });
         bail!("{executable} {} failed: {stderr}", owned_args.join(" "));
     }
@@ -285,77 +248,6 @@ async fn run_cmd_tagged(
         duration,
         output_bytes: stdout.len(),
         error: None,
-        repo,
-    });
-    Ok(stdout)
-}
-
-/// Like `run_cmd_tagged` but sets `current_dir` on the spawned process.
-#[allow(dead_code)]
-async fn run_cmd_in_dir_tagged(
-    executable: &'static str,
-    cwd: &Path,
-    args: &[&str],
-    repo: Option<crate::git::types::RepoId>,
-) -> Result<String> {
-    let _ = session_start();
-    debug_log(&format!(
-        "$ {executable} {} [cwd={}]",
-        args.join(" "),
-        cwd.display()
-    ));
-    let started_at = Instant::now();
-    let owned_args: Vec<String> = args.iter().map(|s| s.to_string()).collect();
-
-    let mut cmd = Command::new(resolve_executable(executable));
-    cmd.args(args).current_dir(cwd);
-    let output = match run_with_timeout(&mut cmd).await {
-        Ok(o) => o,
-        Err(e) => {
-            push_record(CommandRecord {
-                started_at,
-                executable,
-                args: owned_args,
-                success: false,
-                duration: started_at.elapsed(),
-                output_bytes: 0,
-                error: Some(e.to_string()),
-                repo,
-            });
-            return Err(anyhow::Error::new(e))
-                .with_context(|| format!("failed to execute {executable}"));
-        }
-    };
-
-    let duration = started_at.elapsed();
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-        debug_log(&format!("  → FAIL: {stderr}"));
-        push_record(CommandRecord {
-            started_at,
-            executable,
-            args: owned_args.clone(),
-            success: false,
-            duration,
-            output_bytes: output.stderr.len(),
-            error: Some(stderr.clone()),
-            repo,
-        });
-        bail!("{executable} {} failed: {stderr}", owned_args.join(" "));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
-    debug_log(&format!("  → OK ({} bytes)", stdout.len()));
-    push_record(CommandRecord {
-        started_at,
-        executable,
-        args: owned_args,
-        success: true,
-        duration,
-        output_bytes: stdout.len(),
-        error: None,
-        repo,
     });
     Ok(stdout)
 }
@@ -372,32 +264,6 @@ mod plumbing_tests {
         let expected = std::fs::canonicalize(&cwd).unwrap();
         let actual = std::fs::canonicalize(toplevel.trim()).unwrap();
         assert_eq!(actual, expected);
-    }
-
-    #[tokio::test]
-    async fn run_git_in_records_repo_when_provided() {
-        let cwd = std::env::current_dir().unwrap();
-        let _ = run_git_in_with_id(
-            &cwd,
-            Some(crate::git::types::RepoId {
-                host: None,
-                owner: "katzkb".into(),
-                name: "git-control-tower".into(),
-            }),
-            &["--version"],
-        )
-        .await;
-        // `COMMAND_HISTORY` is a global buffer shared by every test in this
-        // binary running concurrently, so this test's record isn't
-        // guaranteed to be the most recent one by the time we read it back
-        // — find it by its distinguishing feature (repo set) instead of
-        // assuming order.
-        let history = command_history_snapshot();
-        let recorded = history.iter().find(|r| r.repo.is_some());
-        assert!(
-            recorded.is_some(),
-            "expected a recorded command with repo set"
-        );
     }
 
     #[cfg(unix)]

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -64,7 +64,6 @@ pub struct Commit {
 pub struct Branch {
     pub name: String,
     pub is_current: bool,
-    #[allow(dead_code)]
     pub upstream: Option<String>,
     pub is_merged: bool,
 }
@@ -77,13 +76,10 @@ pub struct PullRequest {
     pub author: String,
     pub state: String,
     #[serde(rename = "headRefName")]
-    #[allow(dead_code)]
     pub head_ref: String,
     #[serde(rename = "updatedAt")]
-    #[allow(dead_code)]
     pub updated_at: String,
     #[serde(rename = "reviewRequests", default)]
-    #[allow(dead_code)]
     pub review_requests: Vec<ReviewRequest>,
     #[serde(rename = "isDraft", default)]
     pub is_draft: bool,
@@ -97,7 +93,6 @@ pub struct PullRequest {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct ReviewRequest {
-    #[allow(dead_code)]
     #[serde(default)]
     pub login: Option<String>,
 }
@@ -124,31 +119,19 @@ where
 #[derive(Debug, Clone, Deserialize)]
 pub struct PrDetail {
     pub number: u64,
-    #[allow(dead_code)]
-    pub title: String,
-    #[serde(deserialize_with = "deserialize_author")]
-    #[allow(dead_code)]
-    pub author: String,
-    #[allow(dead_code)]
-    pub state: String,
     #[serde(default)]
     pub body: String,
     #[serde(default)]
     pub additions: u64,
     #[serde(default)]
     pub deletions: u64,
-    #[serde(rename = "headRefName")]
-    #[allow(dead_code)]
-    pub head_ref: String,
 }
 
 #[derive(Debug, Clone)]
 pub struct Worktree {
     pub path: String,
-    #[allow(dead_code)]
     pub head: String,
     pub branch: Option<String>,
-    #[allow(dead_code)]
     pub is_bare: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -875,7 +875,7 @@ async fn run(
                     "--repo",
                     repo_arg.as_str(),
                     "--json",
-                    "number,title,author,state,body,additions,deletions,headRefName",
+                    "number,body,additions,deletions",
                 ];
                 let result = run_gh(&args).await;
                 match result {


### PR DESCRIPTION
Remove unused functions run_gh_in, run_gh_in_with_id, and
run_cmd_in_dir_tagged (a near-verbatim copy of run_cmd_tagged), along
with the repo-tagging plumbing that only existed for them:
CommandRecord.repo was never Some in production, so run_git_in_with_id
is folded back into run_git_in and the repo parameter dropped from
run_cmd_tagged.

Also clean up #[allow(dead_code)] in types.rs:
- Delete production-dead PrDetail fields (title, author, state,
  head_ref) and trim the matching gh pr view --json field list.
- Drop stale attributes on fields that are actually used in production
  (PullRequest.head_ref/updated_at/review_requests, ReviewRequest.login,
  Branch.upstream, Worktree.head/is_bare).
- Keep Commit.graph: it is populated by the log parser and needed by the
  planned commit-graph rendering (#12).

Closes #226

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr