### PR TITLE
refactor(app): replace request flags with a Command enum + queue

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -103,6 +103,16 @@ pub enum Command {
     },
     OpenPrInBrowser(crate::git::types::RepoId, u64),
     CopyBranchName(String),
+    /// Quit the TUI and emit this path for the shell-integration `cd`.
+    CdAndQuit(String),
+}
+
+/// A confirm dialog plus the command to run when the user accepts it.
+/// Carrying the consequence with the dialog means `handle_confirm_key`
+/// needs no out-of-band staging state to know what `y` applies to.
+pub struct PendingConfirm {
+    pub dialog: ConfirmDialog,
+    pub on_confirm: Command,
 }
 
 pub struct ActionMenu {
@@ -272,7 +282,7 @@ pub struct App {
     pub verbose_errors: Vec<String>,
 
     // Overlays
-    pub confirm_dialog: Option<ConfirmDialog>,
+    pub confirm_dialog: Option<PendingConfirm>,
     pub action_menu: Option<ActionMenu>,
     pub branch_create_input: Option<BranchCreateInput>,
     pub notification: Option<Notification>,
@@ -285,10 +295,6 @@ pub struct App {
     // handling in `run()`), drained once per loop iteration in `run()`.
     pub commands: VecDeque<Command>,
 
-    // Dialog staging: paths stored while a confirm dialog is open
-    pub wt_delete_pending_path: Option<String>,
-    pub wt_force_delete_pending_path: Option<String>,
-    pub wt_cd_pending_path: Option<String>,
     /// Worktree paths with an in-flight create/delete, gated per-path so unrelated
     /// worktrees stay actionable in the UI while one is still running.
     pub wt_inflight: HashSet<String>,
@@ -360,9 +366,6 @@ impl App {
             show_help: false,
             cd_path: None,
             commands: VecDeque::new(),
-            wt_delete_pending_path: None,
-            wt_force_delete_pending_path: None,
-            wt_cd_pending_path: None,
             wt_inflight: HashSet::new(),
             progress: ProgressTracker::default(),
             quit_pressed_during_progress: false,
@@ -872,7 +875,13 @@ impl App {
                     } else {
                         "Delete Branches + Worktrees"
                     };
-                    self.confirm_dialog = Some(ConfirmDialog::new(title, msg));
+                    // Snapshot the whole selection — the dispatcher re-filters
+                    // (current/protected/inflight) at execution time.
+                    let names: Vec<String> = self.branch_selected.iter().cloned().collect();
+                    self.confirm_dialog = Some(PendingConfirm {
+                        dialog: ConfirmDialog::new(title, msg),
+                        on_confirm: Command::DeleteBranches(names),
+                    });
                 } else if !self.branch_selected.is_empty() {
                     // Non-empty selection but nothing deletable (e.g. PR-only entries
                     // with no local branch and no worktree). Tell the user rather
@@ -886,11 +895,13 @@ impl App {
                     && !self.wt_inflight.contains(wt_path)
                 {
                     let path = wt_path.to_string();
-                    self.confirm_dialog = Some(ConfirmDialog::new(
-                        "Delete Worktree",
-                        format!("Remove worktree at {path}?"),
-                    ));
-                    self.wt_delete_pending_path = Some(path);
+                    self.confirm_dialog = Some(PendingConfirm {
+                        dialog: ConfirmDialog::new(
+                            "Delete Worktree",
+                            format!("Remove worktree at {path}?"),
+                        ),
+                        on_confirm: Command::DeleteWorktree(path),
+                    });
                 }
             }
             KeyCode::Char('w') => {
@@ -1206,13 +1217,16 @@ impl App {
             ActionItem::DeleteWorktree => {
                 if let Some(wt_path) = entry.worktree_path() {
                     let path = wt_path.to_string();
-                    // Clear branch_selected to avoid confirm_key misrouting
+                    // Deleting via the action menu targets one worktree only —
+                    // drop any checkbox selection so the sidebar reflects that.
                     self.branch_selected.clear();
-                    self.confirm_dialog = Some(ConfirmDialog::new(
-                        "Delete Worktree",
-                        format!("Remove worktree at {path}?"),
-                    ));
-                    self.wt_delete_pending_path = Some(path);
+                    self.confirm_dialog = Some(PendingConfirm {
+                        dialog: ConfirmDialog::new(
+                            "Delete Worktree",
+                            format!("Remove worktree at {path}?"),
+                        ),
+                        on_confirm: Command::DeleteWorktree(path),
+                    });
                 }
             }
             ActionItem::CreateBranch => {
@@ -1225,14 +1239,15 @@ impl App {
             ActionItem::DeleteBranch => {
                 let name = entry.name.clone();
                 let is_unmerged = !entry.is_merged() && !entry.pr_is_merged();
-                self.branch_selected.clear();
-                self.branch_selected.insert(name.clone());
                 let msg = if is_unmerged {
                     format!("Delete branch {name}? (unmerged — will force delete)")
                 } else {
                     format!("Delete branch {name}?")
                 };
-                self.confirm_dialog = Some(ConfirmDialog::new("Delete Branch", msg));
+                self.confirm_dialog = Some(PendingConfirm {
+                    dialog: ConfirmDialog::new("Delete Branch", msg),
+                    on_confirm: Command::DeleteBranches(vec![name]),
+                });
             }
             ActionItem::OpenPrInBrowser => {
                 if let Some(pr) = &entry.pull_request {
@@ -1293,30 +1308,18 @@ impl App {
     fn handle_confirm_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('y') => {
-                // Move-to-worktree takes precedence — it can race with a
-                // stale `branch_selected` from before the create finished.
-                if let Some(path) = self.wt_cd_pending_path.take() {
-                    self.cd_path = Some(path);
-                    self.should_quit = true;
-                } else if !self.branch_selected.is_empty() {
-                    let names: Vec<String> = self.branch_selected.drain().collect();
-                    self.push_command(Command::DeleteBranches(names));
-                } else if let Some(path) = self.wt_force_delete_pending_path.take() {
-                    self.push_command(Command::ForceDeleteWorktree(path));
-                } else if let Some(path) = self.wt_delete_pending_path.take() {
-                    self.push_command(Command::DeleteWorktree(path));
+                if let Some(pending) = self.confirm_dialog.take() {
+                    self.push_command(pending.on_confirm);
                 }
-                self.confirm_dialog = None;
             }
             KeyCode::Char('n') | KeyCode::Esc => {
-                self.wt_delete_pending_path = None;
-                self.wt_cd_pending_path = None;
-                // Declining force-delete ends the op — release the path so its
-                // action items reappear.
-                if let Some(path) = self.wt_force_delete_pending_path.take() {
+                if let Some(pending) = self.confirm_dialog.take()
+                    && let Command::ForceDeleteWorktree(path) = pending.on_confirm
+                {
+                    // Declining force-delete ends the op — release the path so
+                    // its action items reappear.
                     self.wt_inflight.remove(&path);
                 }
-                self.confirm_dialog = None;
             }
             _ => {}
         }
@@ -2456,5 +2459,44 @@ mod command_queue_tests {
                 .commands
                 .contains(&Command::FetchPrs(MainFilter::MyPr))
         );
+    }
+
+    fn pending(on_confirm: Command) -> PendingConfirm {
+        PendingConfirm {
+            dialog: ConfirmDialog::new("title", "message"),
+            on_confirm,
+        }
+    }
+
+    #[test]
+    fn confirm_y_pushes_on_confirm_and_closes_dialog() {
+        let mut app = App::new(Config::default());
+        app.confirm_dialog = Some(pending(Command::DeleteWorktree("/wt/p".into())));
+        app.handle_key(key(KeyCode::Char('y')));
+        assert!(app.confirm_dialog.is_none());
+        assert!(
+            app.commands
+                .contains(&Command::DeleteWorktree("/wt/p".into()))
+        );
+    }
+
+    #[test]
+    fn confirm_decline_pushes_nothing() {
+        let mut app = App::new(Config::default());
+        app.confirm_dialog = Some(pending(Command::DeleteWorktree("/wt/p".into())));
+        app.handle_key(key(KeyCode::Esc));
+        assert!(app.confirm_dialog.is_none());
+        assert!(app.commands.is_empty());
+    }
+
+    #[test]
+    fn confirm_decline_force_delete_releases_inflight_path() {
+        let mut app = App::new(Config::default());
+        app.wt_inflight.insert("/wt/p".to_string());
+        app.confirm_dialog = Some(pending(Command::ForceDeleteWorktree("/wt/p".into())));
+        app.handle_key(key(KeyCode::Char('n')));
+        assert!(app.confirm_dialog.is_none());
+        assert!(app.commands.is_empty());
+        assert!(!app.wt_inflight.contains("/wt/p"));
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent};
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::time::Instant;
 
 use crate::git::types::{Branch, BranchEntry, Commit, PrDetail, PullRequest, Worktree};
@@ -73,6 +73,36 @@ impl ActionItem {
             Self::CreateBranch | Self::DeleteBranch => Some("Branch"),
         }
     }
+}
+
+/// A unit of work requested by the UI and executed by the main loop.
+///
+/// `handle_key` (and async-result handling in `run()`) pushes commands onto
+/// `App::commands` via [`App::push_command`]; `run()` drains the queue once
+/// per loop iteration and dispatches each variant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Command {
+    // Read/fetch intents
+    FetchPrs(MainFilter),
+    FetchPrDetail(crate::git::types::RepoId, u64),
+    /// Load `git status` for the worktree at this path.
+    LoadGitStatus(String),
+    LoadWorktreeList(crate::git::types::RepoId),
+    ReloadBranches,
+    ReloadCommits,
+    // Mutating intents
+    DeleteWorktree(String),
+    ForceDeleteWorktree(String),
+    /// `(repo_id, branch_name)` — carries `RepoId` so the main-loop lookup
+    /// matches the correct repo when branch names collide.
+    CreateWorktree(crate::git::types::RepoId, String),
+    DeleteBranches(Vec<String>),
+    CreateBranch {
+        source: String,
+        name: String,
+    },
+    OpenPrInBrowser(crate::git::types::RepoId, u64),
+    CopyBranchName(String),
 }
 
 pub struct ActionMenu {
@@ -232,15 +262,10 @@ pub struct App {
     pub review_prs_loaded: bool,
     pub show_merged: bool,
     pub include_team_reviews: bool,
-    pub pr_fetch_requested: Option<MainFilter>,
 
     // PR Detail (for detail pane, cached by (RepoId, PR number))
     pub pr_detail_cache: HashMap<(crate::git::types::RepoId, u64), PrDetail>,
     pub pr_detail_scroll: usize,
-    pub pr_detail_requested: Option<(crate::git::types::RepoId, u64)>,
-
-    // Git status loading
-    pub git_status_requested: Option<String>, // worktree path
 
     // Verbose mode
     pub verbose: bool,
@@ -256,27 +281,20 @@ pub struct App {
     // Exit with cd path
     pub cd_path: Option<String>,
 
-    // Action requests
-    pub wt_delete_requested: Option<String>,
-    pub wt_delete_pending_path: Option<String>, // path stored when confirm dialog shown
-    pub wt_force_delete_requested: Option<String>,
+    // Command queue: intents staged by key handling (and async-result
+    // handling in `run()`), drained once per loop iteration in `run()`.
+    pub commands: VecDeque<Command>,
+
+    // Dialog staging: paths stored while a confirm dialog is open
+    pub wt_delete_pending_path: Option<String>,
     pub wt_force_delete_pending_path: Option<String>,
     pub wt_cd_pending_path: Option<String>,
-    /// `(repo_id, branch_name)` for the worktree to create. Carries `RepoId` so
-    /// the main-loop lookup matches the correct repo when branch names collide.
-    pub wt_create_requested: Option<(crate::git::types::RepoId, String)>,
     /// Worktree paths with an in-flight create/delete, gated per-path so unrelated
     /// worktrees stay actionable in the UI while one is still running.
     pub wt_inflight: HashSet<String>,
     pub progress: ProgressTracker,
     pub quit_pressed_during_progress: bool,
     pub branch_selected: HashSet<String>,
-    pub branch_delete_requested: bool,
-    pub open_pr_requested: Option<(crate::git::types::RepoId, u64)>,
-    pub copy_branch_requested: Option<String>,
-    pub branch_create_requested: Option<(String, String)>, // (source, name)
-    pub branches_reload_requested: bool,
-    pub commits_reload_requested: bool,
 
     // Spinner animation
     spinner_tick: usize,
@@ -301,7 +319,6 @@ pub struct App {
 
     // Cross-repo worktree list lazy-load state
     pub wt_list_inflight: HashSet<crate::git::types::RepoId>,
-    pub wt_list_requested: Option<crate::git::types::RepoId>,
 }
 
 impl App {
@@ -332,11 +349,8 @@ impl App {
             review_prs_loaded: false,
             show_merged: false,
             include_team_reviews: false,
-            pr_fetch_requested: None,
             pr_detail_cache: HashMap::new(),
             pr_detail_scroll: 0,
-            pr_detail_requested: None,
-            git_status_requested: None,
             verbose: false,
             verbose_errors: Vec::new(),
             confirm_dialog: None,
@@ -345,22 +359,14 @@ impl App {
             notification: None,
             show_help: false,
             cd_path: None,
-            wt_delete_requested: None,
+            commands: VecDeque::new(),
             wt_delete_pending_path: None,
-            wt_force_delete_requested: None,
             wt_force_delete_pending_path: None,
             wt_cd_pending_path: None,
-            wt_create_requested: None,
             wt_inflight: HashSet::new(),
             progress: ProgressTracker::default(),
             quit_pressed_during_progress: false,
             branch_selected: HashSet::new(),
-            branch_delete_requested: false,
-            open_pr_requested: None,
-            copy_branch_requested: None,
-            branch_create_requested: None,
-            branches_reload_requested: false,
-            commits_reload_requested: false,
             spinner_tick: 0,
             config,
             global_layers: toml::Table::new(),
@@ -369,8 +375,23 @@ impl App {
             repos: HashMap::new(),
             wt_lists_per_repo: HashMap::new(),
             wt_list_inflight: HashSet::new(),
-            wt_list_requested: None,
         }
+    }
+
+    /// Queue a command for the main loop, coalescing exact duplicates —
+    /// pushing an intent that is already pending is a no-op, matching the
+    /// one-slot semantics of the request flags this queue replaced.
+    pub fn push_command(&mut self, cmd: Command) {
+        if !self.commands.contains(&cmd) {
+            self.commands.push_back(cmd);
+        }
+    }
+
+    /// Take a snapshot of the queued commands, leaving the queue empty.
+    /// `run()` dispatches the snapshot; commands pushed during dispatch land
+    /// on the fresh queue and are serviced next iteration (no busy re-loop).
+    pub fn take_commands(&mut self) -> VecDeque<Command> {
+        std::mem::take(&mut self.commands)
     }
 
     pub fn current_prs(&self) -> &[PullRequest] {
@@ -578,14 +599,14 @@ impl App {
                     .pr_detail_cache
                     .contains_key(&(entry.repo_id.clone(), pr_num))
             {
-                self.pr_detail_requested = Some((entry.repo_id.clone(), pr_num));
+                self.push_command(Command::FetchPrDetail(entry.repo_id.clone(), pr_num));
             }
 
             // Request git status if entry has a worktree and status not yet loaded
             if let Some(wt_path) = entry.worktree_path()
                 && entry.git_status.is_none()
             {
-                self.git_status_requested = Some(wt_path.to_string());
+                self.push_command(Command::LoadGitStatus(wt_path.to_string()));
             }
         }
 
@@ -602,7 +623,7 @@ impl App {
                 .and_then(|m| m.local_path.as_ref())
                 .is_some()
             {
-                self.wt_list_requested = Some(entry.repo_id.clone());
+                self.push_command(Command::LoadWorktreeList(entry.repo_id.clone()));
             }
         }
     }
@@ -684,7 +705,7 @@ impl App {
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.local_prs_loaded {
-                    self.pr_fetch_requested = Some(MainFilter::Local);
+                    self.push_command(Command::FetchPrs(MainFilter::Local));
                 }
                 self.request_details_for_selection();
             }
@@ -697,7 +718,7 @@ impl App {
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.my_prs_loaded {
-                    self.pr_fetch_requested = Some(MainFilter::MyPr);
+                    self.push_command(Command::FetchPrs(MainFilter::MyPr));
                 }
                 self.request_details_for_selection();
             }
@@ -710,7 +731,7 @@ impl App {
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.review_prs_loaded {
-                    self.pr_fetch_requested = Some(MainFilter::ReviewRequested);
+                    self.push_command(Command::FetchPrs(MainFilter::ReviewRequested));
                 }
                 self.request_details_for_selection();
             }
@@ -739,12 +760,12 @@ impl App {
                     self.wt_lists_per_repo.clear();
                     self.wt_list_inflight.clear();
                     // Signal branches/worktrees reload + PR fetch
-                    self.branches_reload_requested = true;
-                    self.pr_fetch_requested = Some(self.main_filter);
+                    self.push_command(Command::ReloadBranches);
+                    self.push_command(Command::FetchPrs(self.main_filter));
                     self.notification = Some(Notification::success("Refreshing…"));
                 }
                 ActiveView::Log => {
-                    self.commits_reload_requested = true;
+                    self.push_command(Command::ReloadCommits);
                     self.notification = Some(Notification::success("Refreshing…"));
                 }
                 ActiveView::History => {
@@ -915,7 +936,10 @@ impl App {
                 if self.wt_inflight.contains(&wt_path) {
                     return;
                 }
-                self.wt_create_requested = Some((entry.repo_id.clone(), entry.name.clone()));
+                self.push_command(Command::CreateWorktree(
+                    entry.repo_id.clone(),
+                    entry.name.clone(),
+                ));
                 self.notification = Some(Notification::success("Creating worktree...".to_string()));
             }
             KeyCode::Enter => {
@@ -933,7 +957,7 @@ impl App {
                     self.review_prs.clear();
                     self.review_prs_loaded = false;
                     self.rebuild_entries();
-                    self.pr_fetch_requested = Some(self.main_filter);
+                    self.push_command(Command::FetchPrs(self.main_filter));
                     self.sidebar_scroll = 0;
                     self.sidebar_offset = 0;
                     self.snap_scroll_to_entry();
@@ -944,7 +968,7 @@ impl App {
                 self.review_prs.clear();
                 self.review_prs_loaded = false;
                 self.rebuild_entries();
-                self.pr_fetch_requested = Some(MainFilter::ReviewRequested);
+                self.push_command(Command::FetchPrs(MainFilter::ReviewRequested));
                 self.sidebar_scroll = 0;
                 self.sidebar_offset = 0;
                 self.snap_scroll_to_entry();
@@ -1167,7 +1191,10 @@ impl App {
         };
         match action {
             ActionItem::CreateWorktree => {
-                self.wt_create_requested = Some((entry.repo_id.clone(), entry.name.clone()));
+                self.push_command(Command::CreateWorktree(
+                    entry.repo_id.clone(),
+                    entry.name.clone(),
+                ));
                 self.notification = Some(Notification::success("Creating worktree...".to_string()));
             }
             ActionItem::CdIntoWorktree => {
@@ -1209,11 +1236,11 @@ impl App {
             }
             ActionItem::OpenPrInBrowser => {
                 if let Some(pr) = &entry.pull_request {
-                    self.open_pr_requested = Some((entry.repo_id.clone(), pr.number));
+                    self.push_command(Command::OpenPrInBrowser(entry.repo_id.clone(), pr.number));
                 }
             }
             ActionItem::CopyBranchName => {
-                self.copy_branch_requested = Some(entry.name.clone());
+                self.push_command(Command::CopyBranchName(entry.name.clone()));
                 self.notification = Some(Notification::success(format!("Copied: {}", entry.name)));
             }
         }
@@ -1234,7 +1261,7 @@ impl App {
                 let source = input.source.clone();
                 let name = input.name.clone();
                 self.branch_create_input = None;
-                self.branch_create_requested = Some((source, name));
+                self.push_command(Command::CreateBranch { source, name });
             }
             KeyCode::Left => {
                 input.cursor = input.cursor.saturating_sub(1);
@@ -1272,11 +1299,12 @@ impl App {
                     self.cd_path = Some(path);
                     self.should_quit = true;
                 } else if !self.branch_selected.is_empty() {
-                    self.branch_delete_requested = true;
+                    let names: Vec<String> = self.branch_selected.drain().collect();
+                    self.push_command(Command::DeleteBranches(names));
                 } else if let Some(path) = self.wt_force_delete_pending_path.take() {
-                    self.wt_force_delete_requested = Some(path);
+                    self.push_command(Command::ForceDeleteWorktree(path));
                 } else if let Some(path) = self.wt_delete_pending_path.take() {
-                    self.wt_delete_requested = Some(path);
+                    self.push_command(Command::DeleteWorktree(path));
                 }
                 self.confirm_dialog = None;
             }
@@ -2334,7 +2362,10 @@ mod wt_list_lazy_load_tests {
         }];
         app.snap_scroll_to_entry();
         app.request_details_for_selection();
-        assert_eq!(app.wt_list_requested.as_ref(), Some(&other));
+        assert!(
+            app.commands
+                .contains(&Command::LoadWorktreeList(other.clone()))
+        );
     }
 
     #[test]
@@ -2364,6 +2395,66 @@ mod wt_list_lazy_load_tests {
         }];
         app.snap_scroll_to_entry();
         app.request_details_for_selection();
-        assert!(app.wt_list_requested.is_none());
+        assert!(
+            !app.commands
+                .iter()
+                .any(|c| matches!(c, Command::LoadWorktreeList(_)))
+        );
+    }
+}
+
+#[cfg(test)]
+mod command_queue_tests {
+    use super::*;
+    use crate::config::Config;
+    use crossterm::event::KeyModifiers;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn push_command_coalesces_duplicates_and_keeps_fifo_order() {
+        let mut app = App::new(Config::default());
+        app.push_command(Command::ReloadBranches);
+        app.push_command(Command::ReloadCommits);
+        app.push_command(Command::ReloadBranches); // duplicate — coalesced
+        assert_eq!(app.commands.len(), 2);
+        let drained: Vec<Command> = app.take_commands().into_iter().collect();
+        assert_eq!(
+            drained,
+            vec![Command::ReloadBranches, Command::ReloadCommits]
+        );
+        assert!(app.commands.is_empty());
+    }
+
+    #[test]
+    fn refresh_key_queues_branch_reload_and_pr_fetch() {
+        let mut app = App::new(Config::default());
+        app.handle_key(key(KeyCode::Char('r')));
+        let drained: Vec<Command> = app.take_commands().into_iter().collect();
+        assert_eq!(
+            drained,
+            vec![
+                Command::ReloadBranches,
+                Command::FetchPrs(MainFilter::Local)
+            ]
+        );
+    }
+
+    #[test]
+    fn filter_switch_queues_pr_fetch_only_when_not_loaded() {
+        let mut app = App::new(Config::default());
+        app.handle_key(key(KeyCode::Char('2')));
+        assert!(app.commands.contains(&Command::FetchPrs(MainFilter::MyPr)));
+
+        let mut loaded = App::new(Config::default());
+        loaded.my_prs_loaded = true;
+        loaded.handle_key(key(KeyCode::Char('2')));
+        assert!(
+            !loaded
+                .commands
+                .contains(&Command::FetchPrs(MainFilter::MyPr))
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use tokio::task::JoinSet;
 
 use crate::app::App;
 use crate::app::MainFilter;
-use crate::app::{OpProgress, OpStep};
+use crate::app::{Command, OpProgress, OpStep};
 use crate::data::merge_entries;
 use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git, run_git_in};
@@ -857,181 +857,6 @@ async fn run(
             None => break,
         }
 
-        // Spawn PR detail load in background (non-blocking, deduplicated)
-        if let Some((repo_id, number)) = app.pr_detail_requested.take()
-            && !pr_inflight.contains(&(repo_id.clone(), number))
-        {
-            pr_inflight.insert((repo_id.clone(), number));
-            let tx = tx.clone();
-            // `gh pr view` doesn't accept --hostname; the host (if any) is
-            // embedded into --repo as `[HOST/]OWNER/REPO`.
-            let repo_arg = repo_id.repo_arg();
-            tokio::spawn(async move {
-                let num_str = number.to_string();
-                let args = vec![
-                    "pr",
-                    "view",
-                    &num_str,
-                    "--repo",
-                    repo_arg.as_str(),
-                    "--json",
-                    "number,body,additions,deletions",
-                ];
-                let result = run_gh(&args).await;
-                match result {
-                    Ok(output) => match serde_json::from_str::<PrDetail>(&output) {
-                        Ok(detail) => {
-                            let _ = tx.send(AsyncResult::PrDetail { repo_id, detail });
-                        }
-                        Err(e) => {
-                            let _ = tx.send(AsyncResult::PrDetailError {
-                                repo_id,
-                                number,
-                                error: format!("PR #{number} parse error: {e}"),
-                            });
-                        }
-                    },
-                    Err(e) => {
-                        let _ = tx.send(AsyncResult::PrDetailError {
-                            repo_id,
-                            number,
-                            error: format!("PR #{number} fetch failed: {e}"),
-                        });
-                    }
-                }
-            });
-        }
-
-        // Spawn cross-repo worktree list load in background (non-blocking, deduplicated)
-        if let Some(repo_id) = app.wt_list_requested.take()
-            && !app.wt_list_inflight.contains(&repo_id)
-            && let Some(path) = app.repos.get(&repo_id).and_then(|m| m.local_path.clone())
-        {
-            app.wt_list_inflight.insert(repo_id.clone());
-            let tx_c = tx.clone();
-            let repo_id_c = repo_id.clone();
-            tokio::spawn(async move {
-                match run_git_in(&path, &["worktree", "list", "--porcelain"]).await {
-                    Ok(out) => {
-                        let list = crate::git::parser::parse_worktrees(&out);
-                        let _ = tx_c.send(AsyncResult::WtListLoaded {
-                            repo_id: repo_id_c,
-                            list,
-                        });
-                    }
-                    Err(_) => {
-                        let _ = tx_c.send(AsyncResult::WtListLoaded {
-                            repo_id: repo_id_c,
-                            list: Vec::new(),
-                        });
-                    }
-                }
-            });
-        }
-
-        // Reload branches/worktrees in background (non-blocking, deduplicated).
-        // Triggered by `r` in Main view, and also re-armed after worktree/branch
-        // mutations elsewhere in this loop that invalidate the cached entries.
-        if app.branches_reload_requested && !branches_reload_inflight {
-            app.branches_reload_requested = false;
-            branches_reload_inflight = true;
-            let tx = tx.clone();
-            tokio::spawn(async move {
-                let data = fetch_branches_and_worktrees().await;
-                let _ = tx.send(AsyncResult::BranchesReloaded(data));
-            });
-        }
-
-        // Reload commits on `r` refresh from Log view (non-blocking, deduplicated)
-        if app.commits_reload_requested && !commits_reload_inflight {
-            app.commits_reload_requested = false;
-            commits_reload_inflight = true;
-            let tx = tx.clone();
-            tokio::spawn(async move {
-                // Always send, even on failure, so `commits_reload_inflight`
-                // is reliably cleared instead of getting stuck forever.
-                let commits = run_git(LOG_ARGS)
-                    .await
-                    .ok()
-                    .map(|output| parse_log(&output));
-                let _ = tx.send(AsyncResult::CommitsReloaded(commits));
-            });
-        }
-
-        // Spawn git status load in background (non-blocking, deduplicated)
-        if let Some(wt_path) = app.git_status_requested.take()
-            && !status_inflight.contains(&wt_path)
-        {
-            status_inflight.insert(wt_path.clone());
-            let tx = tx.clone();
-            tokio::spawn(async move {
-                if let Some(status) = data::load_git_status(&wt_path).await {
-                    let _ = tx.send(AsyncResult::GitStatus { wt_path, status });
-                } else {
-                    let _ = tx.send(AsyncResult::GitStatusError(wt_path));
-                }
-            });
-        }
-
-        // Spawn PR fetch for view switch (non-blocking)
-        if let Some(filter) = app.pr_fetch_requested.take() {
-            let tx = tx.clone();
-            match filter {
-                MainFilter::Local => {
-                    if let Some(ref info) = repo_info {
-                        let branch_names: Vec<String> =
-                            app.branches.iter().map(|b| b.name.clone()).collect();
-                        let owner = info.owner.clone();
-                        let repo = info.name.clone();
-                        let hostname = info.host.clone();
-                        tokio::spawn(async move {
-                            let (prs, errors) = data::fetch_local_prs(
-                                &branch_names,
-                                &owner,
-                                &repo,
-                                hostname.as_deref(),
-                            )
-                            .await;
-                            let _ = tx.send(AsyncResult::LocalPrList(prs, errors));
-                        });
-                    }
-                }
-                MainFilter::MyPr => {
-                    let show_merged = app.show_merged;
-                    let hosts = app.known_hosts();
-                    tokio::spawn(async move {
-                        let (prs, errors) = data::fetch_my_prs(show_merged, &hosts).await;
-                        let _ = tx.send(AsyncResult::MyPrList(prs, errors));
-                    });
-                }
-                MainFilter::ReviewRequested => {
-                    // Defer until gh_user is known — GitHub's `review-requested:@me`
-                    // search expands to team memberships, and the post-fetch filter
-                    // in fetch_review_prs only runs when gh_user is non-empty. Without
-                    // this guard, switching to Review right after startup can show
-                    // team PRs even in me-only mode. If the user-login fetch failed,
-                    // proceed anyway — no point in spinning forever.
-                    if app.gh_user.is_empty()
-                        && !app.include_team_reviews
-                        && !app.gh_user_load_failed
-                    {
-                        app.pr_fetch_requested = Some(MainFilter::ReviewRequested);
-                    } else {
-                        let show_merged = app.show_merged;
-                        let include_team = app.include_team_reviews;
-                        let gh_user = app.gh_user.clone();
-                        let hosts = app.known_hosts();
-                        tokio::spawn(async move {
-                            let (prs, errors) =
-                                data::fetch_review_prs(show_merged, include_team, &gh_user, &hosts)
-                                    .await;
-                            let _ = tx.send(AsyncResult::ReviewPrList(prs, errors));
-                        });
-                    }
-                }
-            }
-        }
-
         // Receive completed background results (non-blocking)
         while let Ok(result) = rx.try_recv() {
             match result {
@@ -1168,7 +993,7 @@ async fn run(
                             app.record_error(e);
                         }
                     }
-                    app.branches_reload_requested = true;
+                    app.push_command(Command::ReloadBranches);
                     // Cross-repo: invalidate worktree-list cache for target so next selection re-fetches.
                     if let Some(repo_id) = target_repo {
                         app.wt_lists_per_repo.remove(&repo_id);
@@ -1244,7 +1069,7 @@ async fn run(
                     }
                     app.progress.clear();
                     app.quit_pressed_during_progress = false;
-                    app.branches_reload_requested = true;
+                    app.push_command(Command::ReloadBranches);
                 }
                 AsyncResult::WtForceDecisionRequested { path, reason } => {
                     // Plain remove failed; ask the user whether to force.
@@ -1293,7 +1118,7 @@ async fn run(
                     app.notification = Some(Notification::success(format!(
                         "Created branch '{name}' from '{source}'"
                     )));
-                    app.branches_reload_requested = true;
+                    app.push_command(Command::ReloadBranches);
                 }
                 AsyncResult::BranchCreateError(err_str) => {
                     let short = err_str.lines().next().unwrap_or(&err_str).to_string();
@@ -1303,306 +1128,510 @@ async fn run(
             }
         }
 
-        // Delete worktree if requested (single-item, no auto-force fallback).
-        if let Some(path) = app.wt_delete_requested.take() {
-            app.wt_inflight.insert(path.clone());
-            let op_id = app.progress.allocate_ids(1).start;
-            let label = wt_label_for(&path);
-            let claimed = vec![path.clone()];
-            let tx_c = tx.clone();
-            tokio::spawn(async move {
-                let result = run_delete_op(
-                    op_id,
-                    label.clone(),
-                    Some(path.clone()),
-                    None,
-                    false,
-                    DeleteMode::PlainOnly,
-                    tx_c.clone(),
-                )
-                .await;
+        // Dispatch commands staged by key handling above and by the
+        // async-result handling just before this point. Snapshot drain:
+        // commands pushed while dispatching (e.g. reload re-arms) land on
+        // the fresh queue and run next iteration — no busy re-loop.
+        let mut queued = app.take_commands();
+        while let Some(cmd) = queued.pop_front() {
+            match cmd {
+                // Delete worktree (single-item, no auto-force fallback).
+                Command::DeleteWorktree(path) => {
+                    app.wt_inflight.insert(path.clone());
+                    let op_id = app.progress.allocate_ids(1).start;
+                    let label = wt_label_for(&path);
+                    let claimed = vec![path.clone()];
+                    let tx_c = tx.clone();
+                    tokio::spawn(async move {
+                        let result = run_delete_op(
+                            op_id,
+                            label.clone(),
+                            Some(path.clone()),
+                            None,
+                            false,
+                            DeleteMode::PlainOnly,
+                            tx_c.clone(),
+                        )
+                        .await;
 
-                if let Some(failure) = result.failure {
-                    // Plain failed — drain the progress panel without raising a
-                    // failure notification (it would flash before the force-confirm
-                    // dialog appears). The actual outcome is communicated by the
-                    // subsequent force attempt or by the user dismissing the dialog.
-                    let _ = tx_c.send(AsyncResult::OpAllDone {
-                        branches_deleted: vec![],
-                        worktrees_removed: vec![],
-                        failures: vec![],
-                        wt_paths_claimed: claimed,
+                        if let Some(failure) = result.failure {
+                            // Plain failed — drain the progress panel without raising a
+                            // failure notification (it would flash before the force-confirm
+                            // dialog appears). The actual outcome is communicated by the
+                            // subsequent force attempt or by the user dismissing the dialog.
+                            let _ = tx_c.send(AsyncResult::OpAllDone {
+                                branches_deleted: vec![],
+                                worktrees_removed: vec![],
+                                failures: vec![],
+                                wt_paths_claimed: claimed,
+                            });
+                            let reason = failure
+                                .lines()
+                                .next()
+                                .unwrap_or("unknown error")
+                                .to_string();
+                            let _ =
+                                tx_c.send(AsyncResult::WtForceDecisionRequested { path, reason });
+                        } else {
+                            let mut wts = vec![];
+                            if result.worktree_removed
+                                && let Some(p) = result.wt_path
+                            {
+                                wts.push(p);
+                            }
+                            let _ = tx_c.send(AsyncResult::OpAllDone {
+                                branches_deleted: vec![],
+                                worktrees_removed: wts,
+                                failures: vec![],
+                                wt_paths_claimed: claimed,
+                            });
+                        }
                     });
-                    let reason = failure
-                        .lines()
-                        .next()
-                        .unwrap_or("unknown error")
-                        .to_string();
-                    let _ = tx_c.send(AsyncResult::WtForceDecisionRequested { path, reason });
-                } else {
-                    let mut wts = vec![];
-                    if result.worktree_removed
-                        && let Some(p) = result.wt_path
+                }
+
+                // Force delete worktree after confirmation (single-item, force only).
+                Command::ForceDeleteWorktree(path) => {
+                    app.wt_inflight.insert(path.clone());
+                    let op_id = app.progress.allocate_ids(1).start;
+                    let label = wt_label_for(&path);
+                    let claimed = vec![path.clone()];
+                    let tx_c = tx.clone();
+                    tokio::spawn(async move {
+                        let result = run_delete_op(
+                            op_id,
+                            label,
+                            Some(path),
+                            None,
+                            false,
+                            DeleteMode::ForceOnly,
+                            tx_c.clone(),
+                        )
+                        .await;
+                        let mut wts = vec![];
+                        let mut failures = vec![];
+                        if let Some(f) = result.failure {
+                            failures.push(f);
+                        } else if let Some(p) = result.wt_path
+                            && result.worktree_removed
+                        {
+                            wts.push(p);
+                        }
+                        let _ = tx_c.send(AsyncResult::OpAllDone {
+                            branches_deleted: vec![],
+                            worktrees_removed: wts,
+                            failures,
+                            wt_paths_claimed: claimed,
+                        });
+                    });
+                }
+
+                // Create worktree (async, non-blocking)
+                Command::CreateWorktree(req_repo_id, branch_name) => {
+                    // Resolve target repo (active or cross-repo) and its root path.
+                    let entry = app
+                        .entries
+                        .iter()
+                        .find(|e| e.repo_id == req_repo_id && e.name == branch_name)
+                        .cloned();
+                    let Some(entry) = entry else {
+                        continue;
+                    };
+                    let target_repo = entry.repo_id.clone();
+                    let active_repo = app.active_repo.clone();
+                    let is_active = active_repo.as_ref() == Some(&target_repo);
+
+                    // The active repo's root is already cached in `app.repos` (seeded
+                    // at startup), so this never needs a blocking `rev-parse` call —
+                    // cross-repo targets rely on the same cached `local_path` too.
+                    let target_root: std::path::PathBuf = match app
+                        .repos
+                        .get(&target_repo)
+                        .and_then(|m| m.local_path.clone())
                     {
-                        wts.push(p);
+                        Some(p) => p,
+                        None if is_active => std::env::current_dir().unwrap_or_default(),
+                        None => {
+                            app.notification =
+                                Some(Notification::error(format!("{target_repo} not cloned")));
+                            continue;
+                        }
+                    };
+
+                    // Active repo uses the launch config; cross-repo resolves the
+                    // target repo's own config (global layers + <target_root>/.gct.toml).
+                    let cfg = if is_active {
+                        app.config.clone()
+                    } else {
+                        config::resolve_config(&app.global_layers, Some(&target_root))
+                    };
+
+                    let wt_path =
+                        cfg.worktree_path_for(&target_root, &entry.repo_id.name, &branch_name);
+                    app.wt_inflight.insert(wt_path.clone());
+                    if let Some(parent) = std::path::Path::new(&wt_path).parent() {
+                        let _ = std::fs::create_dir_all(parent);
                     }
-                    let _ = tx_c.send(AsyncResult::OpAllDone {
-                        branches_deleted: vec![],
-                        worktrees_removed: wts,
-                        failures: vec![],
-                        wt_paths_claimed: claimed,
-                    });
-                }
-            });
-        }
 
-        // Force delete worktree if confirmed (single-item, force only).
-        if let Some(path) = app.wt_force_delete_requested.take() {
-            app.wt_inflight.insert(path.clone());
-            let op_id = app.progress.allocate_ids(1).start;
-            let label = wt_label_for(&path);
-            let claimed = vec![path.clone()];
-            let tx_c = tx.clone();
-            tokio::spawn(async move {
-                let result = run_delete_op(
-                    op_id,
-                    label,
-                    Some(path),
-                    None,
-                    false,
-                    DeleteMode::ForceOnly,
-                    tx_c.clone(),
-                )
-                .await;
-                let mut wts = vec![];
-                let mut failures = vec![];
-                if let Some(f) = result.failure {
-                    failures.push(f);
-                } else if let Some(p) = result.wt_path
-                    && result.worktree_removed
-                {
-                    wts.push(p);
-                }
-                let _ = tx_c.send(AsyncResult::OpAllDone {
-                    branches_deleted: vec![],
-                    worktrees_removed: wts,
-                    failures,
-                    wt_paths_claimed: claimed,
-                });
-            });
-        }
+                    let is_active_with_local =
+                        is_active && app.branches.iter().any(|b| b.name == branch_name);
+                    let post_create = cfg.worktree.post_create.clone();
+                    let target_repo_for_send = if is_active {
+                        None
+                    } else {
+                        Some(target_repo.clone())
+                    };
+                    let tx = tx.clone();
+                    let wt_path_arg = wt_path.clone();
+                    let branch_arg = branch_name.clone();
+                    let target_root_arg = target_root.clone();
 
-        // Create worktree if requested (async, non-blocking)
-        if let Some((req_repo_id, branch_name)) = app.wt_create_requested.take() {
-            // Resolve target repo (active or cross-repo) and its root path.
-            let entry = app
-                .entries
-                .iter()
-                .find(|e| e.repo_id == req_repo_id && e.name == branch_name)
-                .cloned();
-            let Some(entry) = entry else {
-                continue;
-            };
-            let target_repo = entry.repo_id.clone();
-            let active_repo = app.active_repo.clone();
-            let is_active = active_repo.as_ref() == Some(&target_repo);
-
-            // The active repo's root is already cached in `app.repos` (seeded
-            // at startup), so this never needs a blocking `rev-parse` call —
-            // cross-repo targets rely on the same cached `local_path` too.
-            let target_root: std::path::PathBuf = match app
-                .repos
-                .get(&target_repo)
-                .and_then(|m| m.local_path.clone())
-            {
-                Some(p) => p,
-                None if is_active => std::env::current_dir().unwrap_or_default(),
-                None => {
-                    app.notification =
-                        Some(Notification::error(format!("{target_repo} not cloned")));
-                    continue;
-                }
-            };
-
-            // Active repo uses the launch config; cross-repo resolves the
-            // target repo's own config (global layers + <target_root>/.gct.toml).
-            let cfg = if is_active {
-                app.config.clone()
-            } else {
-                config::resolve_config(&app.global_layers, Some(&target_root))
-            };
-
-            let wt_path = cfg.worktree_path_for(&target_root, &entry.repo_id.name, &branch_name);
-            app.wt_inflight.insert(wt_path.clone());
-            if let Some(parent) = std::path::Path::new(&wt_path).parent() {
-                let _ = std::fs::create_dir_all(parent);
-            }
-
-            let is_active_with_local =
-                is_active && app.branches.iter().any(|b| b.name == branch_name);
-            let post_create = cfg.worktree.post_create.clone();
-            let target_repo_for_send = if is_active {
-                None
-            } else {
-                Some(target_repo.clone())
-            };
-            let tx = tx.clone();
-            let wt_path_arg = wt_path.clone();
-            let branch_arg = branch_name.clone();
-            let target_root_arg = target_root.clone();
-
-            tokio::spawn(async move {
-                let result = if is_active_with_local {
-                    run_git_in(
-                        &target_root_arg,
-                        &["worktree", "add", &wt_path_arg, &branch_arg],
-                    )
-                    .await
-                } else {
-                    match run_git_in(&target_root_arg, &["fetch", "origin", &branch_arg]).await {
-                        Ok(_) => {
+                    tokio::spawn(async move {
+                        let result = if is_active_with_local {
                             run_git_in(
                                 &target_root_arg,
                                 &["worktree", "add", &wt_path_arg, &branch_arg],
                             )
                             .await
+                        } else {
+                            match run_git_in(&target_root_arg, &["fetch", "origin", &branch_arg])
+                                .await
+                            {
+                                Ok(_) => {
+                                    run_git_in(
+                                        &target_root_arg,
+                                        &["worktree", "add", &wt_path_arg, &branch_arg],
+                                    )
+                                    .await
+                                }
+                                Err(e) => Err(e),
+                            }
+                        };
+                        match result {
+                            Ok(_) => {
+                                let copy_errors = config::run_post_create(
+                                    &post_create,
+                                    &target_root_arg,
+                                    std::path::Path::new(&wt_path_arg),
+                                );
+                                let _ = tx.send(AsyncResult::WtCreated {
+                                    wt_path: wt_path_arg,
+                                    copy_errors,
+                                    target_repo: target_repo_for_send,
+                                });
+                            }
+                            Err(e) => {
+                                let _ = tx.send(AsyncResult::WtCreateError {
+                                    wt_path: wt_path_arg,
+                                    message: format!("Failed to create worktree: {e}"),
+                                });
+                            }
                         }
-                        Err(e) => Err(e),
-                    }
-                };
-                match result {
-                    Ok(_) => {
-                        let copy_errors = config::run_post_create(
-                            &post_create,
-                            &target_root_arg,
-                            std::path::Path::new(&wt_path_arg),
-                        );
-                        let _ = tx.send(AsyncResult::WtCreated {
-                            wt_path: wt_path_arg,
-                            copy_errors,
-                            target_repo: target_repo_for_send,
-                        });
-                    }
-                    Err(e) => {
-                        let _ = tx.send(AsyncResult::WtCreateError {
-                            wt_path: wt_path_arg,
-                            message: format!("Failed to create worktree: {e}"),
-                        });
-                    }
-                }
-            });
-        }
-
-        // Delete selected entries (branches + optional worktrees) in parallel.
-        if app.branch_delete_requested {
-            app.branch_delete_requested = false;
-            let selected: Vec<String> = app.branch_selected.drain().collect();
-
-            struct Work {
-                name: String,
-                wt_path: Option<String>,
-                has_local_branch: bool,
-            }
-            let mut work: Vec<Work> = Vec::with_capacity(selected.len());
-            let mut wt_paths_claimed: Vec<String> = Vec::new();
-            let active_repo = app.active_repo.clone();
-            for name in selected {
-                let Some(entry) = app
-                    .entries
-                    .iter()
-                    .find(|e| e.name == name && active_repo.as_ref() == Some(&e.repo_id))
-                else {
-                    continue;
-                };
-                if entry.is_current() || app.is_protected_branch(&entry.name) {
-                    continue;
-                }
-                let wt_path = entry.worktree_path().map(str::to_string);
-                if let Some(ref p) = wt_path
-                    && app.wt_inflight.contains(p)
-                {
-                    continue;
-                }
-                if let Some(ref p) = wt_path {
-                    app.wt_inflight.insert(p.clone());
-                    wt_paths_claimed.push(p.clone());
-                }
-                work.push(Work {
-                    name: entry.name.clone(),
-                    wt_path,
-                    has_local_branch: entry.local_branch.is_some(),
-                });
-            }
-
-            if work.is_empty() {
-                app.notification = Some(Notification::error("Nothing to delete".to_string()));
-            } else {
-                let ids: Vec<u64> = app.progress.allocate_ids(work.len()).collect();
-                let mut set: JoinSet<DeleteOpResult> = JoinSet::new();
-                for (op_id, w) in ids.into_iter().zip(work) {
-                    let tx_c = tx.clone();
-                    set.spawn(run_delete_op(
-                        op_id,
-                        w.name.clone(),
-                        w.wt_path,
-                        Some(w.name),
-                        w.has_local_branch,
-                        DeleteMode::TryThenForce,
-                        tx_c,
-                    ));
-                }
-
-                let tx_done = tx.clone();
-                let claimed = wt_paths_claimed;
-                tokio::spawn(async move {
-                    let mut branches: Vec<String> = Vec::new();
-                    let mut wts: Vec<String> = Vec::new();
-                    let mut failures: Vec<String> = Vec::new();
-                    while let Some(res) = set.join_next().await {
-                        match res {
-                            Ok(r) => r.collect_into(&mut branches, &mut wts, &mut failures),
-                            Err(e) => failures.push(format!("task panic: {e}")),
-                        }
-                    }
-                    let _ = tx_done.send(AsyncResult::OpAllDone {
-                        branches_deleted: branches,
-                        worktrees_removed: wts,
-                        failures,
-                        wt_paths_claimed: claimed,
                     });
-                });
-            }
-        }
+                }
 
-        // Create a new branch from the selected branch if requested (non-blocking)
-        if let Some((source, name)) = app.branch_create_requested.take() {
-            let tx = tx.clone();
-            tokio::spawn(async move {
-                match run_git(&["branch", "--", &name, &source]).await {
-                    Ok(_) => {
-                        let _ = tx.send(AsyncResult::BranchCreated { name, source });
+                // Delete selected entries (branches + optional worktrees) in parallel.
+                Command::DeleteBranches(selected) => {
+                    struct Work {
+                        name: String,
+                        wt_path: Option<String>,
+                        has_local_branch: bool,
                     }
-                    Err(e) => {
-                        let _ = tx.send(AsyncResult::BranchCreateError(e.to_string()));
+                    let mut work: Vec<Work> = Vec::with_capacity(selected.len());
+                    let mut wt_paths_claimed: Vec<String> = Vec::new();
+                    let active_repo = app.active_repo.clone();
+                    for name in selected {
+                        let Some(entry) = app
+                            .entries
+                            .iter()
+                            .find(|e| e.name == name && active_repo.as_ref() == Some(&e.repo_id))
+                        else {
+                            continue;
+                        };
+                        if entry.is_current() || app.is_protected_branch(&entry.name) {
+                            continue;
+                        }
+                        let wt_path = entry.worktree_path().map(str::to_string);
+                        if let Some(ref p) = wt_path
+                            && app.wt_inflight.contains(p)
+                        {
+                            continue;
+                        }
+                        if let Some(ref p) = wt_path {
+                            app.wt_inflight.insert(p.clone());
+                            wt_paths_claimed.push(p.clone());
+                        }
+                        work.push(Work {
+                            name: entry.name.clone(),
+                            wt_path,
+                            has_local_branch: entry.local_branch.is_some(),
+                        });
+                    }
+
+                    if work.is_empty() {
+                        app.notification =
+                            Some(Notification::error("Nothing to delete".to_string()));
+                    } else {
+                        let ids: Vec<u64> = app.progress.allocate_ids(work.len()).collect();
+                        let mut set: JoinSet<DeleteOpResult> = JoinSet::new();
+                        for (op_id, w) in ids.into_iter().zip(work) {
+                            let tx_c = tx.clone();
+                            set.spawn(run_delete_op(
+                                op_id,
+                                w.name.clone(),
+                                w.wt_path,
+                                Some(w.name),
+                                w.has_local_branch,
+                                DeleteMode::TryThenForce,
+                                tx_c,
+                            ));
+                        }
+
+                        let tx_done = tx.clone();
+                        let claimed = wt_paths_claimed;
+                        tokio::spawn(async move {
+                            let mut branches: Vec<String> = Vec::new();
+                            let mut wts: Vec<String> = Vec::new();
+                            let mut failures: Vec<String> = Vec::new();
+                            while let Some(res) = set.join_next().await {
+                                match res {
+                                    Ok(r) => r.collect_into(&mut branches, &mut wts, &mut failures),
+                                    Err(e) => failures.push(format!("task panic: {e}")),
+                                }
+                            }
+                            let _ = tx_done.send(AsyncResult::OpAllDone {
+                                branches_deleted: branches,
+                                worktrees_removed: wts,
+                                failures,
+                                wt_paths_claimed: claimed,
+                            });
+                        });
                     }
                 }
-            });
-        }
 
-        // Open PR in browser if requested (non-blocking; result is ignored either way)
-        if let Some((repo_id, pr_number)) = app.open_pr_requested.take() {
-            tokio::spawn(async move {
-                // `gh pr view --web` doesn't accept --hostname; embed host into --repo.
-                let repo_arg = repo_id.repo_arg();
-                let num = pr_number.to_string();
-                let args = vec!["pr", "view", &num, "--web", "--repo", repo_arg.as_str()];
-                let _ = run_gh(&args).await;
-            });
-        }
+                // Create a new branch from the selected branch (non-blocking)
+                Command::CreateBranch { source, name } => {
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        match run_git(&["branch", "--", &name, &source]).await {
+                            Ok(_) => {
+                                let _ = tx.send(AsyncResult::BranchCreated { name, source });
+                            }
+                            Err(e) => {
+                                let _ = tx.send(AsyncResult::BranchCreateError(e.to_string()));
+                            }
+                        }
+                    });
+                }
 
-        // Copy branch name to clipboard if requested
-        if let Some(name) = app.copy_branch_requested.take() {
-            copy_to_clipboard(&name);
+                // Open PR in browser (non-blocking; result is ignored either way)
+                Command::OpenPrInBrowser(repo_id, pr_number) => {
+                    tokio::spawn(async move {
+                        // `gh pr view --web` doesn't accept --hostname; embed host into --repo.
+                        let repo_arg = repo_id.repo_arg();
+                        let num = pr_number.to_string();
+                        let args = vec!["pr", "view", &num, "--web", "--repo", repo_arg.as_str()];
+                        let _ = run_gh(&args).await;
+                    });
+                }
+
+                // Copy branch name to clipboard (synchronous)
+                Command::CopyBranchName(name) => {
+                    copy_to_clipboard(&name);
+                }
+
+                // Spawn PR detail load in background (deduplicated)
+                Command::FetchPrDetail(repo_id, number) => {
+                    if pr_inflight.contains(&(repo_id.clone(), number)) {
+                        continue;
+                    }
+                    pr_inflight.insert((repo_id.clone(), number));
+                    let tx = tx.clone();
+                    // `gh pr view` doesn't accept --hostname; the host (if any) is
+                    // embedded into --repo as `[HOST/]OWNER/REPO`.
+                    let repo_arg = repo_id.repo_arg();
+                    tokio::spawn(async move {
+                        let num_str = number.to_string();
+                        let args = vec![
+                            "pr",
+                            "view",
+                            &num_str,
+                            "--repo",
+                            repo_arg.as_str(),
+                            "--json",
+                            "number,body,additions,deletions",
+                        ];
+                        let result = run_gh(&args).await;
+                        match result {
+                            Ok(output) => match serde_json::from_str::<PrDetail>(&output) {
+                                Ok(detail) => {
+                                    let _ = tx.send(AsyncResult::PrDetail { repo_id, detail });
+                                }
+                                Err(e) => {
+                                    let _ = tx.send(AsyncResult::PrDetailError {
+                                        repo_id,
+                                        number,
+                                        error: format!("PR #{number} parse error: {e}"),
+                                    });
+                                }
+                            },
+                            Err(e) => {
+                                let _ = tx.send(AsyncResult::PrDetailError {
+                                    repo_id,
+                                    number,
+                                    error: format!("PR #{number} fetch failed: {e}"),
+                                });
+                            }
+                        }
+                    });
+                }
+
+                // Spawn cross-repo worktree list load in background (deduplicated)
+                Command::LoadWorktreeList(repo_id) => {
+                    if app.wt_list_inflight.contains(&repo_id) {
+                        continue;
+                    }
+                    let Some(path) = app.repos.get(&repo_id).and_then(|m| m.local_path.clone())
+                    else {
+                        continue;
+                    };
+                    app.wt_list_inflight.insert(repo_id.clone());
+                    let tx_c = tx.clone();
+                    let repo_id_c = repo_id.clone();
+                    tokio::spawn(async move {
+                        match run_git_in(&path, &["worktree", "list", "--porcelain"]).await {
+                            Ok(out) => {
+                                let list = crate::git::parser::parse_worktrees(&out);
+                                let _ = tx_c.send(AsyncResult::WtListLoaded {
+                                    repo_id: repo_id_c,
+                                    list,
+                                });
+                            }
+                            Err(_) => {
+                                let _ = tx_c.send(AsyncResult::WtListLoaded {
+                                    repo_id: repo_id_c,
+                                    list: Vec::new(),
+                                });
+                            }
+                        }
+                    });
+                }
+
+                // Reload branches/worktrees in background (deduplicated).
+                // Triggered by `r` in Main view, and also re-armed after
+                // worktree/branch mutations that invalidate the cached entries.
+                Command::ReloadBranches => {
+                    if branches_reload_inflight {
+                        // A reload is already running — retry next iteration so a
+                        // request issued mid-reload still yields a fresh fetch.
+                        app.push_command(Command::ReloadBranches);
+                        continue;
+                    }
+                    branches_reload_inflight = true;
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        let data = fetch_branches_and_worktrees().await;
+                        let _ = tx.send(AsyncResult::BranchesReloaded(data));
+                    });
+                }
+
+                // Reload commits on `r` refresh from Log view (deduplicated)
+                Command::ReloadCommits => {
+                    if commits_reload_inflight {
+                        app.push_command(Command::ReloadCommits);
+                        continue;
+                    }
+                    commits_reload_inflight = true;
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        // Always send, even on failure, so `commits_reload_inflight`
+                        // is reliably cleared instead of getting stuck forever.
+                        let commits = run_git(LOG_ARGS)
+                            .await
+                            .ok()
+                            .map(|output| parse_log(&output));
+                        let _ = tx.send(AsyncResult::CommitsReloaded(commits));
+                    });
+                }
+
+                // Spawn git status load in background (deduplicated)
+                Command::LoadGitStatus(wt_path) => {
+                    if status_inflight.contains(&wt_path) {
+                        continue;
+                    }
+                    status_inflight.insert(wt_path.clone());
+                    let tx = tx.clone();
+                    tokio::spawn(async move {
+                        if let Some(status) = data::load_git_status(&wt_path).await {
+                            let _ = tx.send(AsyncResult::GitStatus { wt_path, status });
+                        } else {
+                            let _ = tx.send(AsyncResult::GitStatusError(wt_path));
+                        }
+                    });
+                }
+
+                // Spawn PR fetch for view switch (non-blocking)
+                Command::FetchPrs(filter) => {
+                    let tx = tx.clone();
+                    match filter {
+                        MainFilter::Local => {
+                            if let Some(ref info) = repo_info {
+                                let branch_names: Vec<String> =
+                                    app.branches.iter().map(|b| b.name.clone()).collect();
+                                let owner = info.owner.clone();
+                                let repo = info.name.clone();
+                                let hostname = info.host.clone();
+                                tokio::spawn(async move {
+                                    let (prs, errors) = data::fetch_local_prs(
+                                        &branch_names,
+                                        &owner,
+                                        &repo,
+                                        hostname.as_deref(),
+                                    )
+                                    .await;
+                                    let _ = tx.send(AsyncResult::LocalPrList(prs, errors));
+                                });
+                            }
+                        }
+                        MainFilter::MyPr => {
+                            let show_merged = app.show_merged;
+                            let hosts = app.known_hosts();
+                            tokio::spawn(async move {
+                                let (prs, errors) = data::fetch_my_prs(show_merged, &hosts).await;
+                                let _ = tx.send(AsyncResult::MyPrList(prs, errors));
+                            });
+                        }
+                        MainFilter::ReviewRequested => {
+                            // Defer until gh_user is known — GitHub's `review-requested:@me`
+                            // search expands to team memberships, and the post-fetch filter
+                            // in fetch_review_prs only runs when gh_user is non-empty. Without
+                            // this guard, switching to Review right after startup can show
+                            // team PRs even in me-only mode. If the user-login fetch failed,
+                            // proceed anyway — no point in spinning forever.
+                            if app.gh_user.is_empty()
+                                && !app.include_team_reviews
+                                && !app.gh_user_load_failed
+                            {
+                                app.push_command(Command::FetchPrs(MainFilter::ReviewRequested));
+                            } else {
+                                let show_merged = app.show_merged;
+                                let include_team = app.include_team_reviews;
+                                let gh_user = app.gh_user.clone();
+                                let hosts = app.known_hosts();
+                                tokio::spawn(async move {
+                                    let (prs, errors) = data::fetch_review_prs(
+                                        show_merged,
+                                        include_team,
+                                        &gh_user,
+                                        &hosts,
+                                    )
+                                    .await;
+                                    let _ = tx.send(AsyncResult::ReviewPrList(prs, errors));
+                                });
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         if app.should_quit {

--- a/src/main.rs
+++ b/src/main.rs
@@ -999,13 +999,15 @@ async fn run(
                         app.wt_lists_per_repo.remove(&repo_id);
                     }
                     if app.confirm_dialog.is_none() {
-                        app.confirm_dialog = Some(crate::ui::confirm_dialog::ConfirmDialog::new(
-                            "Move to Worktree",
-                            format!(
-                                "Move into the new worktree?\n(Requires shell integration — see README.)\n{wt_path}"
+                        app.confirm_dialog = Some(crate::app::PendingConfirm {
+                            dialog: crate::ui::confirm_dialog::ConfirmDialog::new(
+                                "Move to Worktree",
+                                format!(
+                                    "Move into the new worktree?\n(Requires shell integration — see README.)\n{wt_path}"
+                                ),
                             ),
-                        ));
-                        app.wt_cd_pending_path = Some(wt_path);
+                            on_confirm: Command::CdAndQuit(wt_path),
+                        });
                     }
                 }
                 AsyncResult::WtCreateError { wt_path, message } => {
@@ -1073,11 +1075,13 @@ async fn run(
                 }
                 AsyncResult::WtForceDecisionRequested { path, reason } => {
                     // Plain remove failed; ask the user whether to force.
-                    app.confirm_dialog = Some(crate::ui::confirm_dialog::ConfirmDialog::new(
-                        "Force Delete Worktree",
-                        format!("{reason}\nForce remove {path}?"),
-                    ));
-                    app.wt_force_delete_pending_path = Some(path);
+                    app.confirm_dialog = Some(crate::app::PendingConfirm {
+                        dialog: crate::ui::confirm_dialog::ConfirmDialog::new(
+                            "Force Delete Worktree",
+                            format!("{reason}\nForce remove {path}?"),
+                        ),
+                        on_confirm: Command::ForceDeleteWorktree(path),
+                    });
                 }
                 AsyncResult::WtListLoaded { repo_id, list } => {
                     app.wt_list_inflight.remove(&repo_id);
@@ -1331,6 +1335,9 @@ async fn run(
 
                 // Delete selected entries (branches + optional worktrees) in parallel.
                 Command::DeleteBranches(selected) => {
+                    // The op is starting — clear the sidebar checkboxes now
+                    // (a declined dialog keeps the selection intact).
+                    app.branch_selected.clear();
                     struct Work {
                         name: String,
                         wt_path: Option<String>,
@@ -1437,6 +1444,12 @@ async fn run(
                 // Copy branch name to clipboard (synchronous)
                 Command::CopyBranchName(name) => {
                     copy_to_clipboard(&name);
+                }
+
+                // Quit and hand the path to the shell-integration `cd`
+                Command::CdAndQuit(path) => {
+                    app.cd_path = Some(path);
+                    app.should_quit = true;
                 }
 
                 // Spawn PR detail load in background (deduplicated)

--- a/src/ui/main_view.rs
+++ b/src/ui/main_view.rs
@@ -17,8 +17,8 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
     detail_pane::draw(frame, chunks[1], app);
 
     // Confirm dialog overlay
-    if let Some(dialog) = &app.confirm_dialog {
-        confirm_dialog::draw(frame, dialog);
+    if let Some(pending) = &app.confirm_dialog {
+        confirm_dialog::draw(frame, &pending.dialog);
     }
 
     // Action menu overlay


### PR DESCRIPTION
## Summary

Replaces the hand-rolled command bus on `App` — 13 ad-hoc request fields (3 bools + 10 `Option<payload>` slots) plus 3 `*_pending_path` dialog-staging mirrors — with a single `Command` enum, a coalescing `VecDeque<Command>` queue, and one dispatch point in `run()`.

Closes #221

### Commit 1 — `Command` enum + queue

- `handle_key` (and async-result handling in `run()`) now express intent as `Command` values pushed via `App::push_command`; `run()` drains a snapshot of the queue at a single dispatch point per loop iteration, replacing the 13 scattered flag-polling blocks.
- `push_command` coalesces exact duplicates, preserving the old one-slot-per-intent overwrite semantics (e.g. multiple `ReloadBranches` re-arms from one result drain still trigger a single reload).
- The snapshot drain (`take_commands` via `mem::take`) means commands pushed *during* dispatch — reload re-arms, the gh-user gate re-push for review fetches — run on the next iteration, keeping the old retry-per-tick cadence without a busy loop.
- Per-intent semantics preserved: fetch commands drop when already inflight; reload commands re-queue until the running reload finishes (freshness guarantee).
- The dispatch point sits after the `AsyncResult` drain, where the mutating blocks already lived, so key-originated commands still execute in the same iteration as the keypress. Commands staged by result handling now run up to one 80 ms tick earlier — benign for these deduplicated fetches.

### Commit 2 — `PendingConfirm` carries the dialog's consequence

- The three staging mirrors (`wt_delete_pending_path`, `wt_force_delete_pending_path`, `wt_cd_pending_path`) are replaced by `PendingConfirm { dialog, on_confirm: Command }`: each confirm dialog now carries the exact command that `y` should run.
- `handle_confirm_key` shrinks from a fixed-priority field cascade (with a special case for a stale-`branch_selected` race) to: `y` → push `on_confirm`; `n`/Esc → discard, releasing the `wt_inflight` path when the declined command is `ForceDeleteWorktree` (the only cancel side effect).
- The move-to-worktree prompt maps to a new `Command::CdAndQuit`; branch deletes snapshot their targets into `Command::DeleteBranches` at dialog-open, and the sidebar checkboxes clear when the op starts, so a declined dialog keeps the selection.
- One deliberate behavior delta: declining the action-menu single-branch delete no longer leaves that branch checkbox-selected (it was seeded into `branch_selected` purely for confirm routing).

This creates the single dispatch seam that #222 (break up `run()`) will extract and removes state #220 (decompose `App`) would otherwise have to move. Inflight-tracking consolidation is intentionally untouched (#236).

## Test plan

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build` — clean
- `cargo test` — 209 unit + 17 integration tests pass, including the PTY-driven e2e suite (`tests/tui_e2e.rs`), which exercises the full key → command → task → result cycle against the real binary
- New unit tests: queue coalescing/FIFO ordering, refresh/filter-switch key smoke tests, confirm-dialog accept/decline flows (including `wt_inflight` release on declined force-delete)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr

---
_Generated by [Claude Code](https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr)_