### PR TITLE
refactor(ui): extract shared layout helpers and a central color theme

### DIFF
--- a/src/ui/branch_create_input.rs
+++ b/src/ui/branch_create_input.rs
@@ -1,12 +1,14 @@
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
 };
 
 use crate::app::BranchCreateInput;
+
+use crate::ui::layout::centered_rect;
+use crate::ui::theme;
 
 pub fn draw(frame: &mut Frame, input: &BranchCreateInput) {
     let area = centered_rect(60, 8, frame.area());
@@ -24,9 +26,9 @@ pub fn draw(frame: &mut Frame, input: &BranchCreateInput) {
     let source_display = truncate_head(&input.source, from_max);
     let window = window_around_cursor(&input.name, input.cursor, name_max);
 
-    let white = Style::default().fg(Color::White);
-    let gray = Style::default().fg(Color::DarkGray);
-    let cyan = Style::default().fg(Color::Cyan);
+    let white = Style::default().fg(theme::TEXT);
+    let gray = Style::default().fg(theme::TEXT_DIM);
+    let cyan = Style::default().fg(theme::ACCENT);
 
     let mut name_spans: Vec<Span> = Vec::with_capacity(6);
     name_spans.push(Span::styled("  Name: ", gray));
@@ -52,16 +54,16 @@ pub fn draw(frame: &mut Frame, input: &BranchCreateInput) {
             Span::styled(
                 " Enter ",
                 Style::default()
-                    .fg(Color::White)
-                    .bg(Color::DarkGray)
+                    .fg(theme::TEXT)
+                    .bg(theme::TEXT_DIM)
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" Create  "),
             Span::styled(
                 " Esc ",
                 Style::default()
-                    .fg(Color::White)
-                    .bg(Color::DarkGray)
+                    .fg(theme::TEXT)
+                    .bg(theme::TEXT_DIM)
                     .add_modifier(Modifier::BOLD),
             ),
             Span::raw(" Cancel"),
@@ -71,7 +73,7 @@ pub fn draw(frame: &mut Frame, input: &BranchCreateInput) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" Create Branch ")
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(theme::ACCENT));
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
@@ -177,16 +179,6 @@ fn window_around_cursor(s: &str, cursor: usize, max: usize) -> CursorWindow {
         left_ellipsis: true,
         right_ellipsis: true,
     }
-}
-
-fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Length(height)])
-        .flex(Flex::Center)
-        .split(area);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
-        .flex(Flex::Center)
-        .split(vertical[0]);
-    horizontal[0]
 }
 
 #[cfg(test)]

--- a/src/ui/confirm_dialog.rs
+++ b/src/ui/confirm_dialog.rs
@@ -1,10 +1,12 @@
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
 };
+
+use crate::ui::layout::centered_rect;
+use crate::ui::theme;
 
 #[derive(Debug, Clone)]
 pub struct ConfirmDialog {
@@ -37,16 +39,16 @@ pub fn draw(frame: &mut Frame, dialog: &ConfirmDialog) {
         Span::styled(
             " y ",
             Style::default()
-                .fg(Color::White)
-                .bg(Color::Red)
+                .fg(theme::TEXT)
+                .bg(theme::ERROR)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" Yes  "),
         Span::styled(
             " n ",
             Style::default()
-                .fg(Color::White)
-                .bg(Color::DarkGray)
+                .fg(theme::TEXT)
+                .bg(theme::TEXT_DIM)
                 .add_modifier(Modifier::BOLD),
         ),
         Span::raw(" No"),
@@ -55,18 +57,8 @@ pub fn draw(frame: &mut Frame, dialog: &ConfirmDialog) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(format!(" {} ", dialog.title))
-        .border_style(Style::default().fg(Color::Yellow));
+        .border_style(Style::default().fg(theme::WARNING));
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
-}
-
-fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Length(height)])
-        .flex(Flex::Center)
-        .split(area);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
-        .flex(Flex::Center)
-        .split(vertical[0]);
-    horizontal[0]
 }

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -7,8 +7,10 @@ use ratatui::{
 };
 
 use crate::app::App;
-use crate::git::types::{BranchEntry, PrDetail, RepoId, ReviewStatus};
+use crate::git::types::{BranchEntry, PrDetail, RepoId};
 use crate::ui::markdown;
+
+use crate::ui::theme;
 
 pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     let entry = app.selected_entry();
@@ -19,7 +21,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
             Some(e) => format!(" {} ", e.name),
             None => " Detail ".to_string(),
         })
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(Style::default().fg(theme::TEXT_DIM));
 
     let mut lines: Vec<Line> = Vec::new();
 
@@ -37,7 +39,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     } else {
         lines.push(Line::from(Span::styled(
             " No branch selected",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         )));
         lines.push(Line::from(""));
     }
@@ -50,7 +52,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     if lines.is_empty() {
         lines.push(Line::from(Span::styled(
             " No additional information",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         )));
     }
 
@@ -62,7 +64,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn section_header(title: &str) -> Line<'static> {
-    section_header_with_color(title, Color::Cyan)
+    section_header_with_color(title, theme::ACCENT)
 }
 
 fn section_header_with_color(title: &str, color: Color) -> Line<'static> {
@@ -78,7 +80,7 @@ fn draw_git_status_section(lines: &mut Vec<Line<'static>>, entry: &BranchEntry, 
     if entry.worktree.is_none() {
         lines.push(Line::from(Span::styled(
             "  —",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         )));
         lines.push(Line::from(""));
         return;
@@ -89,7 +91,7 @@ fn draw_git_status_section(lines: &mut Vec<Line<'static>>, entry: &BranchEntry, 
         None => {
             lines.push(Line::from(Span::styled(
                 format!("  {spinner} Loading"),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme::TEXT_DIM),
             )));
             lines.push(Line::from(""));
             return;
@@ -100,7 +102,7 @@ fn draw_git_status_section(lines: &mut Vec<Line<'static>>, entry: &BranchEntry, 
     for file in &status.staged {
         lines.push(Line::from(Span::styled(
             format!("  {file}"),
-            Style::default().fg(Color::Green),
+            Style::default().fg(theme::SUCCESS),
         )));
     }
 
@@ -108,7 +110,7 @@ fn draw_git_status_section(lines: &mut Vec<Line<'static>>, entry: &BranchEntry, 
     for file in &status.unstaged {
         lines.push(Line::from(Span::styled(
             format!("  {file}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(theme::ERROR),
         )));
     }
 
@@ -116,7 +118,7 @@ fn draw_git_status_section(lines: &mut Vec<Line<'static>>, entry: &BranchEntry, 
     for file in &status.untracked {
         lines.push(Line::from(Span::styled(
             format!("  ?? {file}"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         )));
     }
 
@@ -126,14 +128,14 @@ fn draw_git_status_section(lines: &mut Vec<Line<'static>>, entry: &BranchEntry, 
         if status.ahead > 0 {
             ab_spans.push(Span::styled(
                 format!("↑{}", status.ahead),
-                Style::default().fg(Color::Green),
+                Style::default().fg(theme::SUCCESS),
             ));
             ab_spans.push(Span::raw(" "));
         }
         if status.behind > 0 {
             ab_spans.push(Span::styled(
                 format!("↓{}", status.behind),
-                Style::default().fg(Color::Red),
+                Style::default().fg(theme::ERROR),
             ));
         }
         lines.push(Line::from(ab_spans));
@@ -148,7 +150,7 @@ fn draw_git_status_section(lines: &mut Vec<Line<'static>>, entry: &BranchEntry, 
     {
         lines.push(Line::from(Span::styled(
             "  (clean)",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         )));
     }
 
@@ -162,13 +164,13 @@ fn draw_worktree_section(lines: &mut Vec<Line<'static>>, entry: &BranchEntry) {
         Some(wt) => {
             lines.push(Line::from(Span::styled(
                 format!("  {}", wt.path),
-                Style::default().fg(Color::White),
+                Style::default().fg(theme::TEXT),
             )));
         }
         None => {
             lines.push(Line::from(Span::styled(
                 "  —",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme::TEXT_DIM),
             )));
         }
     }
@@ -188,7 +190,7 @@ fn draw_pr_section(
             lines.push(section_header("PR"));
             lines.push(Line::from(Span::styled(
                 "  —",
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme::TEXT_DIM),
             )));
             lines.push(Line::from(""));
             return;
@@ -205,11 +207,11 @@ fn draw_pr_section(
         && active != &entry.repo_id
     {
         lines.push(Line::from(vec![
-            Span::styled("  repo: ", Style::default().fg(Color::DarkGray)),
+            Span::styled("  repo: ", Style::default().fg(theme::TEXT_DIM)),
             Span::styled(
                 entry.repo_id.to_string(),
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
         ]));
@@ -223,33 +225,22 @@ fn draw_pr_section(
 
     // Author + State
     let (state_str, state_color) = if pr.is_draft {
-        ("DRAFT".to_string(), Color::DarkGray)
+        ("DRAFT".to_string(), theme::TEXT_DIM)
     } else {
-        let color = match pr.state.as_str() {
-            "OPEN" => Color::Green,
-            "CLOSED" => Color::Red,
-            "MERGED" => Color::Magenta,
-            _ => Color::White,
-        };
-        (pr.state.clone(), color)
+        (pr.state.clone(), theme::pr_state_color(&pr.state))
     };
     lines.push(Line::from(vec![
-        Span::styled("  Author: ", Style::default().fg(Color::DarkGray)),
-        Span::styled(pr.author.clone(), Style::default().fg(Color::White)),
-        Span::styled("  State: ", Style::default().fg(Color::DarkGray)),
+        Span::styled("  Author: ", Style::default().fg(theme::TEXT_DIM)),
+        Span::styled(pr.author.clone(), Style::default().fg(theme::TEXT)),
+        Span::styled("  State: ", Style::default().fg(theme::TEXT_DIM)),
         Span::styled(state_str, Style::default().fg(state_color)),
     ]));
 
     // Review status
     if let Some(status) = &pr.review_status {
-        let (label, color) = match status {
-            ReviewStatus::NeedsReview => ("Needs review", Color::Red),
-            ReviewStatus::Approved => ("Approved", Color::Green),
-            ReviewStatus::ChangesRequested => ("Changes requested", Color::Yellow),
-            ReviewStatus::Commented => ("Commented", Color::Cyan),
-        };
+        let (label, color) = theme::review_status(status);
         lines.push(Line::from(vec![
-            Span::styled("  Review: ", Style::default().fg(Color::DarkGray)),
+            Span::styled("  Review: ", Style::default().fg(theme::TEXT_DIM)),
             Span::styled(label, Style::default().fg(color)),
         ]));
     }
@@ -261,12 +252,12 @@ fn draw_pr_section(
             lines.push(Line::from(vec![
                 Span::styled(
                     format!("  +{}", detail.additions),
-                    Style::default().fg(Color::Green),
+                    Style::default().fg(theme::SUCCESS),
                 ),
-                Span::styled(" / ", Style::default().fg(Color::DarkGray)),
+                Span::styled(" / ", Style::default().fg(theme::TEXT_DIM)),
                 Span::styled(
                     format!("-{}", detail.deletions),
-                    Style::default().fg(Color::Red),
+                    Style::default().fg(theme::ERROR),
                 ),
             ]));
 
@@ -276,7 +267,7 @@ fn draw_pr_section(
             if detail.body.trim().is_empty() {
                 lines.push(Line::from(Span::styled(
                     "  (no description)",
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme::TEXT_DIM),
                 )));
             } else {
                 let md_lines = markdown::render_markdown(&detail.body);
@@ -288,7 +279,7 @@ fn draw_pr_section(
     } else {
         lines.push(Line::from(Span::styled(
             format!("  {spinner} Loading"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         )));
     }
 
@@ -296,11 +287,11 @@ fn draw_pr_section(
 }
 
 fn draw_errors_section(lines: &mut Vec<Line<'static>>, errors: &[String]) {
-    lines.push(section_header_with_color("Errors", Color::Red));
+    lines.push(section_header_with_color("Errors", theme::ERROR));
     for err in errors {
         lines.push(Line::from(Span::styled(
             format!("  {err}"),
-            Style::default().fg(Color::Red),
+            Style::default().fg(theme::ERROR),
         )));
     }
     lines.push(Line::from(""));

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -1,20 +1,19 @@
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
 };
 
-pub fn draw(frame: &mut Frame) {
-    let area = centered_rect(60, 31, frame.area());
-    frame.render_widget(Clear, area);
+use crate::ui::layout::centered_rect;
+use crate::ui::theme;
 
+pub fn draw(frame: &mut Frame) {
     let lines = vec![
         Line::from(Span::styled(
             "Git Control Tower — Keyboard Shortcuts",
             Style::default()
-                .fg(Color::Cyan)
+                .fg(theme::ACCENT)
                 .add_modifier(Modifier::BOLD),
         )),
         Line::from(""),
@@ -50,14 +49,20 @@ pub fn draw(frame: &mut Frame) {
         Line::from(""),
         Line::from(Span::styled(
             "Press ? or Esc to close",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         )),
     ];
+
+    // Content height + 2 border rows — computed so the overlay never drifts
+    // out of sync when shortcuts are added or removed above.
+    let height = lines.len() as u16 + 2;
+    let area = centered_rect(60, height, frame.area());
+    frame.render_widget(Clear, area);
 
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" Help ")
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(theme::ACCENT));
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
@@ -67,24 +72,17 @@ fn section(name: &str) -> Line<'static> {
     Line::from(Span::styled(
         format!("  {name}"),
         Style::default()
-            .fg(Color::Yellow)
+            .fg(theme::WARNING)
             .add_modifier(Modifier::BOLD),
     ))
 }
 
 fn key_line(key: &str, desc: &str) -> Line<'static> {
     Line::from(vec![
-        Span::styled(format!("    {key:<14}"), Style::default().fg(Color::Green)),
+        Span::styled(
+            format!("    {key:<14}"),
+            Style::default().fg(theme::SUCCESS),
+        ),
         Span::raw(desc.to_string()),
     ])
-}
-
-fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Length(height)])
-        .flex(Flex::Center)
-        .split(area);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
-        .flex(Flex::Center)
-        .split(vertical[0]);
-    horizontal[0]
 }

--- a/src/ui/history_view.rs
+++ b/src/ui/history_view.rs
@@ -3,13 +3,15 @@ use std::time::Duration;
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
 };
 
 use crate::app::App;
 use crate::git::command::{CommandRecord, command_history_snapshot, session_elapsed_at};
+
+use crate::ui::theme;
 
 pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     let block = Block::default().borders(Borders::ALL).title(" History ");
@@ -19,7 +21,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     if records.is_empty() {
         let placeholder = List::new(vec![ListItem::new(Span::styled(
             "No commands recorded yet.",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         ))])
         .block(block);
         frame.render_widget(placeholder, area);
@@ -44,14 +46,14 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn format_record(record: &CommandRecord) -> ListItem<'static> {
-    let offset_style = Style::default().fg(Color::DarkGray);
-    let exec_style = Style::default().fg(Color::Cyan);
+    let offset_style = Style::default().fg(theme::TEXT_DIM);
+    let exec_style = Style::default().fg(theme::ACCENT);
     let status_style = if record.success {
-        Style::default().fg(Color::Green)
+        Style::default().fg(theme::SUCCESS)
     } else {
-        Style::default().fg(Color::Red)
+        Style::default().fg(theme::ERROR)
     };
-    let meta_style = Style::default().fg(Color::DarkGray);
+    let meta_style = Style::default().fg(theme::TEXT_DIM);
 
     let status = if record.success { "OK " } else { "ERR" };
     let duration = format_duration(record.duration);
@@ -75,7 +77,7 @@ fn format_record(record: &CommandRecord) -> ListItem<'static> {
         spans.push(Span::raw("  "));
         spans.push(Span::styled(
             err.lines().next().unwrap_or("").to_string(),
-            Style::default().fg(Color::Red),
+            Style::default().fg(theme::ERROR),
         ));
     }
 

--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -1,0 +1,47 @@
+//! Shared geometry helpers for overlay placement.
+
+use ratatui::layout::{Constraint, Flex, Layout, Rect};
+
+/// A rect centered both ways: `percent_x` of the width, fixed `height`.
+pub fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .split(area);
+    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
+        .flex(Flex::Center)
+        .split(vertical[0]);
+    horizontal[0]
+}
+
+/// A rect pinned to the bottom edge: `percent_x` of the width (centered
+/// horizontally), fixed `height`.
+pub fn bottom_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Min(0), Constraint::Length(height)]).split(area);
+    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
+        .flex(Flex::Center)
+        .split(vertical[1]);
+    horizontal[0]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn centered_rect_is_centered_with_requested_size() {
+        let area = Rect::new(0, 0, 100, 40);
+        let r = centered_rect(50, 10, area);
+        assert_eq!((r.width, r.height), (50, 10));
+        assert_eq!(r.x, 25);
+        assert_eq!(r.y, 15);
+    }
+
+    #[test]
+    fn bottom_rect_is_pinned_to_bottom_edge() {
+        let area = Rect::new(0, 0, 100, 40);
+        let r = bottom_rect(80, 3, area);
+        assert_eq!((r.width, r.height), (80, 3));
+        assert_eq!(r.x, 10);
+        assert_eq!(r.y + r.height, area.height);
+    }
+}

--- a/src/ui/log_view.rs
+++ b/src/ui/log_view.rs
@@ -1,12 +1,14 @@
 use ratatui::{
     Frame,
     layout::Rect,
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
 };
 
 use crate::app::App;
+
+use crate::ui::theme;
 
 pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     let block = Block::default().borders(Borders::ALL).title(" Log ");
@@ -24,12 +26,12 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
             let line = Line::from(vec![
                 Span::styled(
                     format!("{} ", commit.hash),
-                    Style::default().fg(Color::Yellow),
+                    Style::default().fg(theme::WARNING),
                 ),
                 Span::raw(&commit.message),
                 Span::styled(
                     format!("  ({}, {})", commit.author, commit.date),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme::TEXT_DIM),
                 ),
             ]);
             ListItem::new(line)

--- a/src/ui/main_view.rs
+++ b/src/ui/main_view.rs
@@ -1,13 +1,16 @@
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Rect},
-    style::{Color, Modifier, Style},
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, List, ListItem, ListState, Paragraph, Wrap},
 };
 
 use crate::app::App;
 use crate::ui::{confirm_dialog, detail_pane, sidebar};
+
+use crate::ui::layout::centered_rect;
+use crate::ui::theme;
 
 pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
     let chunks =
@@ -92,14 +95,14 @@ fn draw_action_menu(frame: &mut Frame, menu: &crate::app::ActionMenu) {
         .map(|row| match row {
             MenuRow::Item(item) => ListItem::new(Line::from(Span::styled(
                 format!("  {}", item.label()),
-                Style::default().fg(Color::White),
+                Style::default().fg(theme::TEXT),
             ))),
             MenuRow::Separator(label) => {
                 let head = format!("── {label} ");
                 let fill = "─".repeat(inner_width.saturating_sub(head.chars().count()));
                 ListItem::new(Line::from(Span::styled(
                     format!("{head}{fill}"),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme::TEXT_DIM),
                 )))
             }
         })
@@ -108,13 +111,13 @@ fn draw_action_menu(frame: &mut Frame, menu: &crate::app::ActionMenu) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" Actions (j/k:navigate  Enter:select  Esc:cancel) ")
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(theme::ACCENT));
 
     let list = List::new(items)
         .block(block)
         .highlight_style(
             Style::default()
-                .fg(Color::Cyan)
+                .fg(theme::ACCENT)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol("▸ ");
@@ -126,21 +129,11 @@ fn draw_action_menu(frame: &mut Frame, menu: &crate::app::ActionMenu) {
     if let Some(ref footer) = menu.footer {
         let footer_line = Line::from(Span::styled(
             format!("─ {footer}"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         ));
         let paragraph = Paragraph::new(footer_line).wrap(Wrap { trim: true });
         frame.render_widget(paragraph, footer_area);
     }
-}
-
-fn centered_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Length(height)])
-        .flex(Flex::Center)
-        .split(area);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
-        .flex(Flex::Center)
-        .split(vertical[0]);
-    horizontal[0]
 }
 
 #[cfg(test)]

--- a/src/ui/markdown.rs
+++ b/src/ui/markdown.rs
@@ -1,7 +1,9 @@
 use ratatui::{
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
 };
+
+use crate::ui::theme;
 
 /// Convert markdown text to styled ratatui Lines.
 /// Supports: headings (#), bold (**), inline code (`), unordered lists (- ), code blocks (```).
@@ -18,7 +20,7 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
         if in_code_block {
             lines.push(Line::from(Span::styled(
                 format!("  {raw_line}"),
-                Style::default().fg(Color::Green),
+                Style::default().fg(theme::SUCCESS),
             )));
             continue;
         }
@@ -27,31 +29,31 @@ pub fn render_markdown(text: &str) -> Vec<Line<'static>> {
             lines.push(Line::from(Span::styled(
                 format!("   {heading}"),
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             )));
         } else if let Some(heading) = raw_line.strip_prefix("## ") {
             lines.push(Line::from(Span::styled(
                 format!("  {heading}"),
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             )));
         } else if let Some(heading) = raw_line.strip_prefix("# ") {
             lines.push(Line::from(Span::styled(
                 heading.to_string(),
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             )));
         } else if let Some(item) = raw_line.strip_prefix("- ") {
             lines.push(Line::from(vec![
-                Span::styled("  • ", Style::default().fg(Color::Yellow)),
+                Span::styled("  • ", Style::default().fg(theme::WARNING)),
                 Span::raw(render_inline(item)),
             ]));
         } else if let Some(item) = raw_line.strip_prefix("* ") {
             lines.push(Line::from(vec![
-                Span::styled("  • ", Style::default().fg(Color::Yellow)),
+                Span::styled("  • ", Style::default().fg(theme::WARNING)),
                 Span::raw(render_inline(item)),
             ]));
         } else if raw_line.is_empty() {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -3,17 +3,19 @@ pub mod confirm_dialog;
 mod detail_pane;
 mod help_overlay;
 mod history_view;
+pub mod layout;
 mod log_view;
 mod main_view;
 pub mod markdown;
 pub mod notification;
 pub mod progress_panel;
 pub mod sidebar;
+pub mod theme;
 
 use ratatui::{
     Frame,
     layout::{Constraint, Layout},
-    style::{Color, Style},
+    style::Style,
     widgets::Paragraph,
 };
 
@@ -55,7 +57,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
         ActiveView::History => " [History]  j/k:Scroll  Esc:Back  ?:Help  q:Quit".to_string(),
     };
     let status =
-        Paragraph::new(status_text).style(Style::default().fg(Color::White).bg(Color::DarkGray));
+        Paragraph::new(status_text).style(Style::default().fg(theme::TEXT).bg(theme::TEXT_DIM));
     frame.render_widget(status, chunks[1]);
 
     // Branch-create input modal

--- a/src/ui/notification.rs
+++ b/src/ui/notification.rs
@@ -1,9 +1,11 @@
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Rect},
-    style::{Color, Style},
+    style::Style,
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
 };
+
+use crate::ui::layout::bottom_rect;
+use crate::ui::theme;
 
 const SUCCESS_TICKS: u32 = 38; // ~3 seconds at 80ms tick
 const ERROR_TICKS: u32 = 63; // ~5 seconds at 80ms tick
@@ -39,9 +41,9 @@ pub fn draw(frame: &mut Frame, notification: &Notification) {
     frame.render_widget(Clear, area);
 
     let color = if notification.is_error {
-        Color::Red
+        theme::ERROR
     } else {
-        Color::Green
+        theme::SUCCESS
     };
 
     let block = Block::default()
@@ -54,12 +56,4 @@ pub fn draw(frame: &mut Frame, notification: &Notification) {
         .wrap(Wrap { trim: false });
 
     frame.render_widget(paragraph, area);
-}
-
-fn bottom_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Min(0), Constraint::Length(height)]).split(area);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
-        .flex(Flex::Center)
-        .split(vertical[1]);
-    horizontal[0]
 }

--- a/src/ui/progress_panel.rs
+++ b/src/ui/progress_panel.rs
@@ -2,13 +2,15 @@ use std::time::Instant;
 
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
 };
 
 use crate::app::{OpProgress, OpStep, ProgressTracker};
+
+use crate::ui::layout::bottom_rect;
+use crate::ui::theme;
 
 const MAX_VISIBLE_OPS: usize = 7;
 
@@ -20,7 +22,7 @@ pub fn draw(frame: &mut Frame, tracker: &ProgressTracker, quit_warning: bool) {
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::Cyan));
+        .border_style(Style::default().fg(theme::ACCENT));
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
@@ -33,7 +35,7 @@ fn build_lines(tracker: &ProgressTracker, quit_warning: bool, now: Instant) -> V
         lines.push(Line::from(Span::styled(
             "Delete in progress. Press q/Esc again to quit anyway.".to_string(),
             Style::default()
-                .fg(Color::Yellow)
+                .fg(theme::WARNING)
                 .add_modifier(Modifier::BOLD),
         )));
     }
@@ -47,7 +49,7 @@ fn build_lines(tracker: &ProgressTracker, quit_warning: bool, now: Instant) -> V
     lines.push(Line::from(Span::styled(
         format!("Deleting ({done}/{total} done · {elapsed:.1}s)"),
         Style::default()
-            .fg(Color::White)
+            .fg(theme::TEXT)
             .add_modifier(Modifier::BOLD),
     )));
 
@@ -61,7 +63,7 @@ fn build_lines(tracker: &ProgressTracker, quit_warning: bool, now: Instant) -> V
     if remaining > 0 {
         lines.push(Line::from(Span::styled(
             format!("  +{remaining} more"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         )));
     }
 
@@ -75,9 +77,9 @@ fn format_op_line(op: &OpProgress, now: Instant) -> Line<'static> {
         _ => "⏳",
     };
     let icon_style = match op.current_step {
-        OpStep::Done { success: true } => Style::default().fg(Color::Green),
-        OpStep::Done { success: false } => Style::default().fg(Color::Red),
-        _ => Style::default().fg(Color::Yellow),
+        OpStep::Done { success: true } => Style::default().fg(theme::SUCCESS),
+        OpStep::Done { success: false } => Style::default().fg(theme::ERROR),
+        _ => Style::default().fg(theme::WARNING),
     };
     let label = format!(" {:<14}", trunc(&op.label, 14));
     let cmd = op
@@ -91,11 +93,11 @@ fn format_op_line(op: &OpProgress, now: Instant) -> Line<'static> {
         .saturating_duration_since(op.op_started_at)
         .as_secs_f32();
     let row_style = if matches!(op.current_step, OpStep::Done { success: true }) {
-        Style::default().fg(Color::DarkGray)
+        Style::default().fg(theme::TEXT_DIM)
     } else if matches!(op.current_step, OpStep::Done { success: false }) {
-        Style::default().fg(Color::Red)
+        Style::default().fg(theme::ERROR)
     } else {
-        Style::default().fg(Color::White)
+        Style::default().fg(theme::TEXT)
     };
 
     Line::from(vec![
@@ -104,7 +106,7 @@ fn format_op_line(op: &OpProgress, now: Instant) -> Line<'static> {
         Span::styled(format!(" {cmd}"), row_style),
         Span::styled(
             format!("  {elapsed:.1}s"),
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         ),
     ])
 }
@@ -121,14 +123,6 @@ fn trunc(s: &str, n: usize) -> String {
         out.push('…');
         out
     }
-}
-
-fn bottom_rect(percent_x: u16, height: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Min(0), Constraint::Length(height)]).split(area);
-    let horizontal = Layout::horizontal([Constraint::Percentage(percent_x)])
-        .flex(Flex::Center)
-        .split(vertical[1]);
-    horizontal[0]
 }
 
 #[cfg(test)]

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -1,13 +1,15 @@
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
-    style::{Color, Modifier, Style},
+    style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, List, ListItem, ListState},
 };
 
 use crate::app::{App, MainFilter};
-use crate::git::types::{BranchEntry, ReviewStatus};
+use crate::git::types::BranchEntry;
+
+use crate::ui::theme;
 
 pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
     let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(area);
@@ -22,20 +24,20 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
             Span::styled(
                 " /",
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(app.search_query.clone(), Style::default().fg(Color::White)),
-            Span::styled("_", Style::default().fg(Color::Cyan)),
+            Span::styled(app.search_query.clone(), Style::default().fg(theme::TEXT)),
+            Span::styled("_", Style::default().fg(theme::ACCENT)),
         ])
     } else {
         let label = app.main_filter.label();
         let mut spans = vec![
-            Span::styled(" Filter: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(" Filter: ", Style::default().fg(theme::TEXT_DIM)),
             Span::styled(
                 label,
                 Style::default()
-                    .fg(Color::Cyan)
+                    .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
         ];
@@ -47,14 +49,14 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
         {
             spans.push(Span::styled(
                 " [+merged]",
-                Style::default().fg(Color::Yellow),
+                Style::default().fg(theme::WARNING),
             ));
         }
         // Show active search filter
         if !app.search_query.is_empty() {
             spans.push(Span::styled(
                 format!(" /{}", app.search_query),
-                Style::default().fg(Color::Cyan),
+                Style::default().fg(theme::ACCENT),
             ));
         }
         // Show team toggle indicator for Review view
@@ -64,7 +66,7 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
             } else {
                 " [me]"
             };
-            spans.push(Span::styled(team_label, Style::default().fg(Color::Cyan)));
+            spans.push(Span::styled(team_label, Style::default().fg(theme::ACCENT)));
         }
         // Show repo/PR counter when multiple repos are present
         if matches!(
@@ -81,14 +83,14 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
                 let pr_count = filtered.iter().filter(|e| e.pull_request.is_some()).count();
                 spans.push(Span::styled(
                     format!("  {repo_count} repos · {pr_count} PRs"),
-                    Style::default().fg(Color::DarkGray),
+                    Style::default().fg(theme::TEXT_DIM),
                 ));
             }
         }
         Line::from(spans)
     };
     frame.render_widget(
-        ratatui::widgets::Paragraph::new(bar).style(Style::default().bg(Color::Black)),
+        ratatui::widgets::Paragraph::new(bar).style(Style::default().bg(theme::BAR_BG)),
         area,
     );
 }
@@ -105,7 +107,7 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
             let spinner = app.spinner_frame();
             vec![ListItem::new(Line::from(Span::styled(
                 format!("  {spinner} Loading"),
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme::TEXT_DIM),
             )))]
         } else if rows.is_empty() {
             let msg = if !app.search_query.is_empty() {
@@ -119,7 +121,7 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
             };
             vec![ListItem::new(Line::from(Span::styled(
                 msg,
-                Style::default().fg(Color::DarkGray),
+                Style::default().fg(theme::TEXT_DIM),
             )))]
         } else {
             let search_query = &app.search_query;
@@ -129,7 +131,7 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                         ListItem::new(Line::from(vec![Span::styled(
                             format!(" ▾ {repo_id} "),
                             Style::default()
-                                .fg(Color::Cyan)
+                                .fg(theme::ACCENT)
                                 .add_modifier(Modifier::DIM | Modifier::BOLD),
                         )]))
                     }
@@ -157,7 +159,7 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
     let block = Block::default()
         .borders(Borders::ALL)
         .title(" Branches ")
-        .border_style(Style::default().fg(Color::DarkGray));
+        .border_style(Style::default().fg(theme::TEXT_DIM));
 
     let list = List::new(items)
         .block(block)
@@ -183,21 +185,21 @@ fn format_entry_line(
     // Checkbox (only shown when multi-select is active)
     if show_checkboxes {
         if is_selected {
-            spans.push(Span::styled("[x] ", Style::default().fg(Color::Cyan)));
+            spans.push(Span::styled("[x] ", Style::default().fg(theme::ACCENT)));
         } else {
-            spans.push(Span::styled("[ ] ", Style::default().fg(Color::DarkGray)));
+            spans.push(Span::styled("[ ] ", Style::default().fg(theme::TEXT_DIM)));
         }
     }
 
     // Branch name (with search highlight)
     let name_style = if entry.is_current() {
         Style::default()
-            .fg(Color::Green)
+            .fg(theme::SUCCESS)
             .add_modifier(Modifier::BOLD)
     } else if (entry.is_merged() || entry.pr_is_merged()) && !is_protected {
-        Style::default().fg(Color::Yellow)
+        Style::default().fg(theme::WARNING)
     } else {
-        Style::default().fg(Color::White)
+        Style::default().fg(theme::TEXT)
     };
     spans.extend(format_branch_name(&entry.name, search_query, name_style));
 
@@ -206,7 +208,7 @@ fn format_entry_line(
         spans.push(Span::styled(
             " *",
             Style::default()
-                .fg(Color::Green)
+                .fg(theme::SUCCESS)
                 .add_modifier(Modifier::BOLD),
         ));
     }
@@ -215,7 +217,7 @@ fn format_entry_line(
     if let Some(pr) = &entry.pull_request {
         spans.push(Span::styled(
             format!(" #{}", pr.number),
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(theme::WARNING),
         ));
     }
 
@@ -225,7 +227,7 @@ fn format_entry_line(
     {
         spans.push(Span::styled(
             " [draft]",
-            Style::default().fg(Color::DarkGray),
+            Style::default().fg(theme::TEXT_DIM),
         ));
     }
 
@@ -233,28 +235,23 @@ fn format_entry_line(
     if let Some(pr) = &entry.pull_request
         && let Some(status) = &pr.review_status
     {
-        let (label, color) = match status {
-            ReviewStatus::NeedsReview => ("needs review", Color::Red),
-            ReviewStatus::Approved => ("approved", Color::Green),
-            ReviewStatus::ChangesRequested => ("changes requested", Color::Yellow),
-            ReviewStatus::Commented => ("commented", Color::Cyan),
-        };
+        let (label, color) = theme::review_status(status);
         spans.push(Span::styled(
-            format!(" [{label}]"),
+            format!(" [{}]", label.to_ascii_lowercase()),
             Style::default().fg(color),
         ));
     }
 
     // Worktree indicator
     if entry.worktree.is_some() && !entry.is_current() {
-        spans.push(Span::styled(" wt", Style::default().fg(Color::Cyan)));
+        spans.push(Span::styled(" wt", Style::default().fg(theme::ACCENT)));
     }
 
     // Merged tag
     if (entry.is_merged() || entry.pr_is_merged()) && !entry.is_current() && !is_protected {
         spans.push(Span::styled(
             " [merged]",
-            Style::default().fg(Color::Yellow),
+            Style::default().fg(theme::WARNING),
         ));
     }
 
@@ -280,7 +277,7 @@ fn format_branch_name(name: &str, search_query: &str, base_style: Style) -> Vec<
         let end = start + lower_query_chars.len();
         let highlight_style = base_style
             .add_modifier(Modifier::UNDERLINED)
-            .fg(Color::Cyan);
+            .fg(theme::ACCENT);
         vec![
             Span::styled(
                 format!(" {}", name_chars[..start].iter().collect::<String>()),

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -1,0 +1,47 @@
+//! Central color palette and shared status→color mappings.
+//!
+//! UI code refers to these semantic names instead of raw `ratatui`
+//! colors, so restyling the app means editing this file only.
+
+use ratatui::style::Color;
+
+use crate::git::types::ReviewStatus;
+
+/// Highlight color: titles, selection, key hints, worktree markers.
+pub const ACCENT: Color = Color::Cyan;
+/// Primary foreground text.
+pub const TEXT: Color = Color::White;
+/// De-emphasized text: labels, separators, hints, disabled items.
+pub const TEXT_DIM: Color = Color::DarkGray;
+/// Positive outcomes: success toasts, merged branches, additions.
+pub const SUCCESS: Color = Color::Green;
+/// Caution: unmerged deletes, selections pending action, section headers.
+pub const WARNING: Color = Color::Yellow;
+/// Failures and destructive states: error toasts, deletions, needs-review.
+pub const ERROR: Color = Color::Red;
+/// Merged pull requests.
+pub const PR_MERGED: Color = Color::Magenta;
+/// Background for the sidebar scroll indicator bar.
+pub const BAR_BG: Color = Color::Black;
+
+/// Display label (capitalized) and color for a PR review status.
+/// Callers that want a lowercase tag (e.g. the sidebar's `[approved]`)
+/// can `to_ascii_lowercase()` the label.
+pub fn review_status(status: &ReviewStatus) -> (&'static str, Color) {
+    match status {
+        ReviewStatus::NeedsReview => ("Needs review", ERROR),
+        ReviewStatus::Approved => ("Approved", SUCCESS),
+        ReviewStatus::ChangesRequested => ("Changes requested", WARNING),
+        ReviewStatus::Commented => ("Commented", ACCENT),
+    }
+}
+
+/// Color for a PR state string as reported by `gh` (`OPEN`/`CLOSED`/`MERGED`).
+pub fn pr_state_color(state: &str) -> Color {
+    match state {
+        "OPEN" => SUCCESS,
+        "CLOSED" => ERROR,
+        "MERGED" => PR_MERGED,
+        _ => TEXT,
+    }
+}


### PR DESCRIPTION
## Summary

Centralizes the UI's duplicated geometry helpers and scattered hardcoded colors.

Closes #230

### Changes

- **`ui/layout.rs`** — new module hosting `centered_rect` / `bottom_rect`, which were copy-pasted verbatim across six files (`centered_rect` ×4 in main_view, branch_create_input, help_overlay, confirm_dialog; `bottom_rect` ×2 in notification, progress_panel). The local copies are deleted; the shared versions get unit tests for the rect math.
- **`ui/theme.rs`** — new semantic palette (`ACCENT`, `TEXT`, `TEXT_DIM`, `SUCCESS`, `WARNING`, `ERROR`, `PR_MERGED`, `BAR_BG`) replacing ~155 hardcoded `Color::*` references across all 12 UI files. The constants map 1:1 to the previous colors, so rendering is pixel-identical — but changing the accent color is now a one-line edit.
- **Shared status mappings** — the review-status → label/color match duplicated between `detail_pane.rs` and `sidebar.rs` becomes `theme::review_status` (the sidebar lowercases the shared label for its `[approved]` tag form), and the `OPEN`/`CLOSED`/`MERGED` color match becomes `theme::pr_state_color`.
- **`help_overlay.rs`** — the overlay height is now computed from the content lines (`lines.len() + 2` borders) instead of the hand-counted `31` that silently drifted whenever a shortcut row was added or removed.

## Test plan

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build` — clean
- `cargo test` — 211 unit + 17 integration tests pass, including the PTY e2e suite, whose screen-content assertions confirm the rendered output is unchanged
- New unit tests for `centered_rect` / `bottom_rect` placement math

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr

---
_Generated by [Claude Code](https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr)_