### PR TITLE
refactor(types): replace stringly-typed PR/review state with enums

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1817,7 +1817,7 @@ mod cursor_skip_tests {
     fn cursor_moves_skips_headers_in_grouped_view() {
         use crate::app::SidebarRow;
         use crate::config::Config;
-        use crate::git::types::{BranchEntry, PullRequest, RepoId};
+        use crate::git::types::{BranchEntry, PrState, PullRequest, RepoId};
         use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
         let mut app = App::new(Config::default());
         let active = RepoId {
@@ -1836,7 +1836,7 @@ mod cursor_skip_tests {
             number: num,
             title: "t".into(),
             author: "u".into(),
-            state: "OPEN".into(),
+            state: PrState::Open,
             head_ref: head.into(),
             updated_at: "2024".into(),
             is_draft: false,
@@ -1890,7 +1890,7 @@ mod sidebar_rows_tests {
     fn render_rows_groups_when_multi_repo() {
         use crate::app::SidebarRow;
         use crate::config::Config;
-        use crate::git::types::{BranchEntry, PullRequest, RepoId};
+        use crate::git::types::{BranchEntry, PrState, PullRequest, RepoId};
         let mut app = App::new(Config::default());
         let active = RepoId {
             host: None,
@@ -1908,7 +1908,7 @@ mod sidebar_rows_tests {
             number: num,
             title: "x".into(),
             author: "u".into(),
-            state: "OPEN".into(),
+            state: PrState::Open,
             head_ref: head.into(),
             updated_at: "2024".into(),
             is_draft: false,
@@ -1952,7 +1952,7 @@ mod sidebar_rows_tests {
     fn render_rows_no_headers_when_single_repo() {
         use crate::app::SidebarRow;
         use crate::config::Config;
-        use crate::git::types::{BranchEntry, PullRequest, RepoId};
+        use crate::git::types::{BranchEntry, PrState, PullRequest, RepoId};
         let mut app = App::new(Config::default());
         let active = RepoId {
             host: None,
@@ -1965,7 +1965,7 @@ mod sidebar_rows_tests {
             number: num,
             title: "x".into(),
             author: "u".into(),
-            state: "OPEN".into(),
+            state: PrState::Open,
             head_ref: head.into(),
             updated_at: "2024".into(),
             is_draft: false,
@@ -2109,7 +2109,7 @@ mod action_menu_cross_repo_tests {
     fn action_menu_cross_repo_no_clone_excludes_worktree_actions() {
         use crate::app::ActionItem;
         use crate::config::Config;
-        use crate::git::types::{BranchEntry, PullRequest, RepoId, RepoMeta};
+        use crate::git::types::{BranchEntry, PrState, PullRequest, RepoId, RepoMeta};
         let mut app = App::new(Config::default());
         let active = RepoId {
             host: None,
@@ -2139,7 +2139,7 @@ mod action_menu_cross_repo_tests {
                 number: 1,
                 title: "x".into(),
                 author: "u".into(),
-                state: "OPEN".into(),
+                state: PrState::Open,
                 head_ref: "feat".into(),
                 updated_at: "2024".into(),
                 is_draft: false,
@@ -2165,7 +2165,7 @@ mod action_menu_cross_repo_tests {
     fn action_menu_cross_repo_with_clone_enables_worktree_create() {
         use crate::app::ActionItem;
         use crate::config::Config;
-        use crate::git::types::{BranchEntry, PullRequest, RepoId, RepoMeta};
+        use crate::git::types::{BranchEntry, PrState, PullRequest, RepoId, RepoMeta};
         let mut app = App::new(Config::default());
         let active = RepoId {
             host: None,
@@ -2198,7 +2198,7 @@ mod action_menu_cross_repo_tests {
                 number: 1,
                 title: "x".into(),
                 author: "u".into(),
-                state: "OPEN".into(),
+                state: PrState::Open,
                 head_ref: "feat".into(),
                 updated_at: "2024".into(),
                 is_draft: false,
@@ -2256,7 +2256,7 @@ mod action_menu_cross_repo_tests {
     fn execute_action_targets_correct_repo_when_branch_names_collide() {
         use crate::app::ActionItem;
         use crate::config::Config;
-        use crate::git::types::{Branch, BranchEntry, PullRequest, RepoId, Worktree};
+        use crate::git::types::{Branch, BranchEntry, PrState, PullRequest, RepoId, Worktree};
         let mut app = App::new(Config::default());
         let active = RepoId {
             host: None,
@@ -2299,7 +2299,7 @@ mod action_menu_cross_repo_tests {
                 number: 7,
                 title: "x".into(),
                 author: "u".into(),
-                state: "OPEN".into(),
+                state: PrState::Open,
                 head_ref: "feature/auth".into(),
                 updated_at: "2024".into(),
                 is_draft: false,
@@ -2327,7 +2327,7 @@ mod wt_list_lazy_load_tests {
     #[test]
     fn selecting_cross_repo_entry_signals_wt_list_load() {
         use crate::config::Config;
-        use crate::git::types::{BranchEntry, PullRequest, RepoId, RepoMeta};
+        use crate::git::types::{BranchEntry, PrState, PullRequest, RepoId, RepoMeta};
         let tmp = tempfile::tempdir().unwrap();
         let clone_path = tmp.path().join("github.com").join("b").join("y");
         std::fs::create_dir_all(&clone_path).unwrap();
@@ -2362,7 +2362,7 @@ mod wt_list_lazy_load_tests {
                 number: 1,
                 title: "x".into(),
                 author: "u".into(),
-                state: "OPEN".into(),
+                state: PrState::Open,
                 head_ref: "feat".into(),
                 updated_at: "2024".into(),
                 is_draft: false,

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::git::command::{debug_log, run_gh, run_git};
-use crate::git::types::{Branch, BranchEntry, GitStatus, PullRequest, ReviewRequest, Worktree};
+use crate::git::types::{
+    Branch, BranchEntry, GitStatus, PrState, PullRequest, ReviewRequest, Worktree,
+};
 
 /// Merge local branches, worktrees, and PRs into unified BranchEntry list.
 pub fn merge_entries(
@@ -60,8 +62,8 @@ pub fn merge_entries(
             pull_request: None,
             git_status: None,
         });
-        match (&entry.pull_request, pr.state.as_str()) {
-            (Some(existing), "MERGED") if existing.state == "OPEN" => {
+        match (&entry.pull_request, pr.state) {
+            (Some(existing), PrState::Merged) if existing.state == PrState::Open => {
                 // Don't overwrite an OPEN PR with a MERGED one
             }
             _ => {
@@ -263,7 +265,7 @@ pub async fn fetch_local_prs(
 fn parse_graphql_pr(node: &serde_json::Value) -> Option<PullRequest> {
     let number = node["number"].as_u64()?;
     let title = node["title"].as_str()?.to_string();
-    let state = node["state"].as_str()?.to_string();
+    let state = PrState::from_graphql(node["state"].as_str()?)?;
     let head_ref = node["headRefName"].as_str()?.to_string();
     let updated_at = node["updatedAt"].as_str().unwrap_or_default().to_string();
     let author = node["author"]["login"]
@@ -319,7 +321,7 @@ fn parse_graphql_search_pr(node: &serde_json::Value) -> Option<PullRequest> {
             .filter_map(|r| {
                 Some(crate::git::types::LatestReview {
                     author: r["author"]["login"].as_str()?.to_string(),
-                    state: r["state"].as_str()?.to_string(),
+                    state: crate::git::types::ReviewState::from_graphql(r["state"].as_str()?),
                 })
             })
             .collect();
@@ -655,7 +657,7 @@ mod tests {
             number: 42,
             title: "Add feature A".to_string(),
             author: "alice".to_string(),
-            state: "OPEN".to_string(),
+            state: PrState::Open,
             head_ref: "feature-a".to_string(),
             updated_at: "2024-01-15".to_string(),
             review_requests: vec![],
@@ -682,7 +684,7 @@ mod tests {
             number: 99,
             title: "Remote only PR".to_string(),
             author: "bob".to_string(),
-            state: "OPEN".to_string(),
+            state: PrState::Open,
             head_ref: "remote-branch".to_string(),
             updated_at: "2024-01-15".to_string(),
             review_requests: vec![],
@@ -712,7 +714,7 @@ mod tests {
             number: 10,
             title: "Feature A".to_string(),
             author: "alice".to_string(),
-            state: "MERGED".to_string(),
+            state: PrState::Merged,
             head_ref: "feature-a".to_string(),
             updated_at: "2024-01-15".to_string(),
             review_requests: vec![],
@@ -744,7 +746,7 @@ mod tests {
                 number: 5,
                 title: "Old merged PR".to_string(),
                 author: "alice".to_string(),
-                state: "MERGED".to_string(),
+                state: PrState::Merged,
                 head_ref: "feature-a".to_string(),
                 updated_at: "2024-01-01".to_string(),
                 review_requests: vec![],
@@ -757,7 +759,7 @@ mod tests {
                 number: 10,
                 title: "New open PR".to_string(),
                 author: "alice".to_string(),
-                state: "OPEN".to_string(),
+                state: PrState::Open,
                 head_ref: "feature-a".to_string(),
                 updated_at: "2024-01-15".to_string(),
                 review_requests: vec![],
@@ -809,7 +811,7 @@ mod tests {
         let pr = parse_graphql_pr(&node).unwrap();
         assert_eq!(pr.number, 42);
         assert_eq!(pr.title, "Add feature");
-        assert_eq!(pr.state, "OPEN");
+        assert_eq!(pr.state, PrState::Open);
         assert_eq!(pr.head_ref, "feature-branch");
         assert_eq!(pr.author, "alice");
         assert_eq!(pr.review_requests.len(), 1);
@@ -941,7 +943,7 @@ mod tests {
                 number: 1,
                 title: "active PR".into(),
                 author: "a".into(),
-                state: "OPEN".into(),
+                state: PrState::Open,
                 head_ref: "feature/auth".into(),
                 updated_at: "2024".into(),
                 is_draft: false,
@@ -954,7 +956,7 @@ mod tests {
                 number: 99,
                 title: "other PR".into(),
                 author: "b".into(),
-                state: "OPEN".into(),
+                state: PrState::Open,
                 head_ref: "feature/auth".into(),
                 updated_at: "2024".into(),
                 is_draft: false,
@@ -992,7 +994,7 @@ mod tests {
             number: 7,
             title: "x".into(),
             author: "u".into(),
-            state: "OPEN".into(),
+            state: PrState::Open,
             head_ref: "feat/x".into(),
             updated_at: "2024".into(),
             is_draft: false,
@@ -1117,7 +1119,7 @@ mod tests {
             number,
             title: format!("PR {number}"),
             author: "alice".into(),
-            state: "OPEN".into(),
+            state: PrState::Open,
             head_ref: format!("feature-{number}"),
             updated_at: "2024-01-15T00:00:00Z".into(),
             is_draft: false,

--- a/src/git/types.rs
+++ b/src/git/types.rs
@@ -47,6 +47,53 @@ pub enum ReviewStatus {
     Commented,
 }
 
+/// Raw GitHub GraphQL `PullRequestState` — a closed three-value enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum PrState {
+    Open,
+    Closed,
+    Merged,
+}
+
+impl PrState {
+    /// Parse a raw GraphQL value. `None` for anything outside the closed
+    /// variant set — impossible today; it would signal a GitHub API change.
+    pub fn from_graphql(s: &str) -> Option<Self> {
+        match s {
+            "OPEN" => Some(Self::Open),
+            "CLOSED" => Some(Self::Closed),
+            "MERGED" => Some(Self::Merged),
+            _ => None,
+        }
+    }
+}
+
+/// Raw GitHub GraphQL `PullRequestReviewState`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ReviewState {
+    Approved,
+    ChangesRequested,
+    Commented,
+    Dismissed,
+    Pending,
+}
+
+impl ReviewState {
+    /// Parse a raw GraphQL value. Unknown values fall back to `Commented`,
+    /// preserving the long-standing catch-all in review-status derivation.
+    pub fn from_graphql(s: &str) -> Self {
+        match s {
+            "APPROVED" => Self::Approved,
+            "CHANGES_REQUESTED" => Self::ChangesRequested,
+            "DISMISSED" => Self::Dismissed,
+            "PENDING" => Self::Pending,
+            _ => Self::Commented,
+        }
+    }
+}
+
 // label() methods are on the UI side (sidebar.rs, detail_pane.rs) to keep
 // display logic separate from data types.
 
@@ -74,7 +121,7 @@ pub struct PullRequest {
     pub title: String,
     #[serde(deserialize_with = "deserialize_author")]
     pub author: String,
-    pub state: String,
+    pub state: PrState,
     #[serde(rename = "headRefName")]
     pub head_ref: String,
     #[serde(rename = "updatedAt")]
@@ -101,7 +148,7 @@ pub struct ReviewRequest {
 pub struct LatestReview {
     #[serde(deserialize_with = "deserialize_author")]
     pub author: String,
-    pub state: String,
+    pub state: ReviewState,
 }
 
 fn deserialize_author<'de, D>(deserializer: D) -> Result<String, D::Error>
@@ -162,7 +209,7 @@ impl BranchEntry {
     pub fn pr_is_merged(&self) -> bool {
         self.pull_request
             .as_ref()
-            .is_some_and(|pr| pr.state == "MERGED")
+            .is_some_and(|pr| pr.state == PrState::Merged)
     }
 
     pub fn worktree_path(&self) -> Option<&str> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ use crate::app::{Command, OpProgress, OpStep};
 use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git, run_git_in};
 use crate::git::parser::{parse_branches, parse_log, parse_worktrees};
-use crate::git::types::{GitStatus, PrDetail, PullRequest, RepoId, ReviewStatus};
+use crate::git::types::{GitStatus, PrDetail, PullRequest, RepoId, ReviewState, ReviewStatus};
 use crate::ui::notification::Notification;
 
 /// Args used for fetching commits in the Log view (startup + `r` refresh).
@@ -1963,11 +1963,12 @@ fn compute_review_status(pr: &PullRequest, gh_user: &str) -> ReviewStatus {
     }
     for review in &pr.latest_reviews {
         if review.author == gh_user {
-            return match review.state.as_str() {
-                "APPROVED" => ReviewStatus::Approved,
-                "CHANGES_REQUESTED" => ReviewStatus::ChangesRequested,
-                "COMMENTED" => ReviewStatus::Commented,
-                _ => ReviewStatus::Commented,
+            return match review.state {
+                ReviewState::Approved => ReviewStatus::Approved,
+                ReviewState::ChangesRequested => ReviewStatus::ChangesRequested,
+                ReviewState::Commented | ReviewState::Dismissed | ReviewState::Pending => {
+                    ReviewStatus::Commented
+                }
             };
         }
     }
@@ -2273,12 +2274,12 @@ mod tests {
 
     #[test]
     fn test_compute_review_status_no_user() {
-        use crate::git::types::RepoId;
+        use crate::git::types::{PrState, RepoId};
         let pr = PullRequest {
             number: 1,
             title: String::new(),
             author: String::new(),
-            state: "OPEN".to_string(),
+            state: PrState::Open,
             head_ref: String::new(),
             updated_at: String::new(),
             review_requests: vec![],
@@ -2292,19 +2293,19 @@ mod tests {
 
     #[test]
     fn test_compute_review_status_no_matching_review() {
-        use crate::git::types::{LatestReview, RepoId};
+        use crate::git::types::{LatestReview, PrState, RepoId};
         let pr = PullRequest {
             number: 1,
             title: String::new(),
             author: String::new(),
-            state: "OPEN".to_string(),
+            state: PrState::Open,
             head_ref: String::new(),
             updated_at: String::new(),
             review_requests: vec![],
             is_draft: false,
             latest_reviews: vec![LatestReview {
                 author: "other-user".to_string(),
-                state: "APPROVED".to_string(),
+                state: ReviewState::Approved,
             }],
             review_status: None,
             repo_id: RepoId::default(),
@@ -2317,19 +2318,19 @@ mod tests {
 
     #[test]
     fn test_compute_review_status_approved() {
-        use crate::git::types::{LatestReview, RepoId};
+        use crate::git::types::{LatestReview, PrState, RepoId};
         let pr = PullRequest {
             number: 1,
             title: String::new(),
             author: String::new(),
-            state: "OPEN".to_string(),
+            state: PrState::Open,
             head_ref: String::new(),
             updated_at: String::new(),
             review_requests: vec![],
             is_draft: false,
             latest_reviews: vec![LatestReview {
                 author: "katzkb".to_string(),
-                state: "APPROVED".to_string(),
+                state: ReviewState::Approved,
             }],
             review_status: None,
             repo_id: RepoId::default(),
@@ -2339,19 +2340,19 @@ mod tests {
 
     #[test]
     fn test_compute_review_status_changes_requested() {
-        use crate::git::types::{LatestReview, RepoId};
+        use crate::git::types::{LatestReview, PrState, RepoId};
         let pr = PullRequest {
             number: 1,
             title: String::new(),
             author: String::new(),
-            state: "OPEN".to_string(),
+            state: PrState::Open,
             head_ref: String::new(),
             updated_at: String::new(),
             review_requests: vec![],
             is_draft: false,
             latest_reviews: vec![LatestReview {
                 author: "katzkb".to_string(),
-                state: "CHANGES_REQUESTED".to_string(),
+                state: ReviewState::ChangesRequested,
             }],
             review_status: None,
             repo_id: RepoId::default(),

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -225,9 +225,9 @@ fn draw_pr_section(
 
     // Author + State
     let (state_str, state_color) = if pr.is_draft {
-        ("DRAFT".to_string(), theme::TEXT_DIM)
+        ("DRAFT", theme::TEXT_DIM)
     } else {
-        (pr.state.clone(), theme::pr_state_color(&pr.state))
+        theme::pr_state(pr.state)
     };
     lines.push(Line::from(vec![
         Span::styled("  Author: ", Style::default().fg(theme::TEXT_DIM)),

--- a/src/ui/theme.rs
+++ b/src/ui/theme.rs
@@ -5,7 +5,7 @@
 
 use ratatui::style::Color;
 
-use crate::git::types::ReviewStatus;
+use crate::git::types::{PrState, ReviewStatus};
 
 /// Highlight color: titles, selection, key hints, worktree markers.
 pub const ACCENT: Color = Color::Cyan;
@@ -36,12 +36,11 @@ pub fn review_status(status: &ReviewStatus) -> (&'static str, Color) {
     }
 }
 
-/// Color for a PR state string as reported by `gh` (`OPEN`/`CLOSED`/`MERGED`).
-pub fn pr_state_color(state: &str) -> Color {
+/// Display label and color for a PR state.
+pub fn pr_state(state: PrState) -> (&'static str, Color) {
     match state {
-        "OPEN" => SUCCESS,
-        "CLOSED" => ERROR,
-        "MERGED" => PR_MERGED,
-        _ => TEXT,
+        PrState::Open => ("OPEN", SUCCESS),
+        PrState::Closed => ("CLOSED", ERROR),
+        PrState::Merged => ("MERGED", PR_MERGED),
     }
 }


### PR DESCRIPTION
## Summary

First PR of the Low-severity batch (#232 → #236 → #235). Replaces `PullRequest.state: String` and `LatestReview.state: String` with enums modeling the raw GitHub GraphQL values, so state typos become compile errors instead of silent mismatches.

Closes #232

### Changes

- **`PrState { Open, Closed, Merged }`** — GraphQL `PullRequestState` is a closed three-value enum. `from_graphql` returns `Option`: an unrecognized value (only possible if GitHub changes the API) skips that PR row instead of carrying an arbitrary string through the app.
- **`ReviewState { Approved, ChangesRequested, Commented, Dismissed, Pending }`** — `from_graphql` folds unknown values into `Commented`, preserving the long-standing catch-all in `compute_review_status`, which is now an exhaustive match (`Dismissed`/`Pending` explicitly map to `Commented`, same behavior as before via `_`).
- **Literal comparisons removed** at every site: `pr_is_merged` (`== "MERGED"`), the `merge_entries` dedup (`"MERGED"`/`"OPEN"` guard), and `theme::pr_state_color`'s string match — now `theme::pr_state(PrState) -> (&'static str, Color)`, mirroring the existing `theme::review_status` shape and keeping display labels on the UI side per the `types.rs` convention. The unreachable `_ => TEXT` fallback disappears.
- **Serde kept working** via `#[serde(rename_all = "SCREAMING_SNAKE_CASE")]`, so the derive-based deserialization path parses the same JSON as before.
- The derived `ReviewStatus` enum (semantic status) is unchanged — the new enums model raw wire values, which is a different axis.

### Out of scope (per the issue's "optional" note)

Typed timestamps for `updated_at` / `Commit.date`: the lexical sorts at the two fetch sites operate on ISO-8601 strings and remain correct; converting them is orthogonal to the state-enum work.

## Test plan

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build` — clean
- `cargo test` — 211 unit + 17 integration tests pass. The GraphQL-parser unit tests exercise `from_graphql` against raw JSON fixtures, the serde round-trip test covers the rename attributes, and the PTY e2e suite confirms rendered output (state labels/colors) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr

---
_Generated by [Claude Code](https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr)_