### PR TITLE
perf(ui): consolidate inflight tracking and debounce navigation fetches

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -315,6 +315,10 @@ pub struct App {
     // handling in `run()`), drained once per loop iteration in `run()`.
     pub commands: VecDeque<Command>,
 
+    // Selection changed; detail fetches are flushed on the next tick
+    // (debounce — see request_details_for_selection).
+    selection_details_pending: bool,
+
     // Async-work dedup bookkeeping (fetches, reloads, worktree ops).
     pub inflight: Inflight,
     pub progress: ProgressTracker,
@@ -382,6 +386,7 @@ impl App {
             show_help: false,
             cd_path: None,
             commands: VecDeque::new(),
+            selection_details_pending: false,
             inflight: Inflight::default(),
             progress: ProgressTracker::default(),
             quit_pressed_during_progress: false,
@@ -425,6 +430,9 @@ impl App {
 
     pub fn tick(&mut self) {
         self.spinner_tick = self.spinner_tick.wrapping_add(1);
+        if std::mem::take(&mut self.selection_details_pending) {
+            self.flush_selection_details();
+        }
         // Don't auto-dismiss while a worktree operation is in progress
         if self.inflight.worktrees.is_empty()
             && let Some(ref mut n) = self.notification
@@ -615,9 +623,21 @@ impl App {
         self.pr_detail_cache.get(&(entry.repo_id.clone(), pr_num))
     }
 
-    /// Signal that the selection changed; request PR detail and git status as needed.
+    /// Signal that the selection changed. The actual detail fetches are
+    /// deferred to the next `tick()`: ticks are starved while key events are
+    /// pending (see `EventHandler`), so holding `j`/`k` coalesces to a single
+    /// fetch for the final selection ~80ms after scrolling settles, instead
+    /// of spawning a `gh`/`git` subprocess per row passed through.
     pub fn request_details_for_selection(&mut self) {
         self.pr_detail_scroll = 0;
+        self.selection_details_pending = true;
+    }
+
+    /// Queue the fetches the current selection needs (PR detail, git status,
+    /// cross-repo worktree list). Called from `tick()` once input settles;
+    /// recomputing from the *current* selection here is what discards the
+    /// intermediate targets of a rapid scroll.
+    fn flush_selection_details(&mut self) {
         let selected = self.selected_entry().cloned();
 
         if let Some(entry) = &selected {
@@ -2390,6 +2410,7 @@ mod wt_list_lazy_load_tests {
         }];
         app.snap_scroll_to_entry();
         app.request_details_for_selection();
+        app.tick(); // fetches are debounced to the next tick
         assert!(
             app.commands
                 .contains(&Command::LoadWorktreeList(other.clone()))
@@ -2423,6 +2444,7 @@ mod wt_list_lazy_load_tests {
         }];
         app.snap_scroll_to_entry();
         app.request_details_for_selection();
+        app.tick();
         assert!(
             !app.commands
                 .iter()
@@ -2484,6 +2506,103 @@ mod command_queue_tests {
                 .commands
                 .contains(&Command::FetchPrs(MainFilter::MyPr))
         );
+    }
+
+    fn pr_entry(name: &str, number: u64) -> BranchEntry {
+        use crate::git::types::{PrState, RepoId};
+        let repo = RepoId {
+            host: None,
+            owner: "o".into(),
+            name: "r".into(),
+        };
+        BranchEntry {
+            name: name.into(),
+            repo_id: repo.clone(),
+            local_branch: Some(crate::git::types::Branch {
+                name: name.into(),
+                is_current: false,
+                upstream: None,
+                is_merged: false,
+            }),
+            worktree: None,
+            pull_request: Some(PullRequest {
+                number,
+                title: "t".into(),
+                author: "u".into(),
+                state: PrState::Open,
+                head_ref: name.into(),
+                updated_at: "2024".into(),
+                is_draft: false,
+                review_requests: vec![],
+                latest_reviews: vec![],
+                review_status: None,
+                repo_id: repo,
+            }),
+            git_status: None,
+        }
+    }
+
+    fn app_with_pr_entries() -> App {
+        use crate::git::types::RepoId;
+        let mut app = App::new(Config::default());
+        app.active_repo = Some(RepoId {
+            host: None,
+            owner: "o".into(),
+            name: "r".into(),
+        });
+        app.entries = vec![pr_entry("a", 1), pr_entry("b", 2)];
+        app
+    }
+
+    #[test]
+    fn selection_detail_fetch_is_debounced_to_next_tick() {
+        let mut app = app_with_pr_entries();
+        app.request_details_for_selection();
+        assert!(app.commands.is_empty(), "no fetch before the debounce tick");
+        app.tick();
+        assert!(
+            app.commands
+                .iter()
+                .any(|c| matches!(c, Command::FetchPrDetail(_, 1)))
+        );
+    }
+
+    #[test]
+    fn rapid_selection_moves_coalesce_to_latest_target() {
+        let mut app = app_with_pr_entries();
+        // Two selection changes before any tick — like holding `j`.
+        app.request_details_for_selection();
+        app.sidebar_scroll = 1;
+        app.request_details_for_selection();
+        app.tick();
+        let fetches: Vec<u64> = app
+            .commands
+            .iter()
+            .filter_map(|c| match c {
+                Command::FetchPrDetail(_, n) => Some(*n),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(fetches, vec![2], "only the final selection is fetched");
+    }
+
+    #[test]
+    fn cached_detail_queues_no_fetch_after_tick() {
+        use crate::git::types::PrDetail;
+        let mut app = app_with_pr_entries();
+        let repo = app.entries[0].repo_id.clone();
+        app.pr_detail_cache.insert(
+            (repo, 1),
+            PrDetail {
+                number: 1,
+                body: String::new(),
+                additions: 0,
+                deletions: 0,
+            },
+        );
+        app.request_details_for_selection();
+        app.tick();
+        assert!(app.commands.is_empty());
     }
 
     fn pending(on_confirm: Command) -> PendingConfirm {

--- a/src/app.rs
+++ b/src/app.rs
@@ -236,6 +236,26 @@ impl ProgressTracker {
     }
 }
 
+/// All async-work dedup state, in one place (issue #236).
+///
+/// At dispatch time the `HashSet`-tracked fetches are *dropped* when already
+/// inflight (a duplicate fetch is pointless), while the two reload bools use
+/// *requeue-if-busy* (a reload requested mid-reload must still produce a
+/// fresh fetch afterwards).
+#[derive(Default)]
+pub struct Inflight {
+    pub pr_detail: HashSet<(crate::git::types::RepoId, u64)>,
+    /// Worktree paths with a running `git status` load.
+    pub git_status: HashSet<String>,
+    pub branches_reload: bool,
+    pub commits_reload: bool,
+    /// Worktree paths with an in-flight create/delete, gated per-path so
+    /// unrelated worktrees stay actionable in the UI while one is running.
+    pub worktrees: HashSet<String>,
+    /// Repos with a running cross-repo worktree-list load.
+    pub wt_lists: HashSet<crate::git::types::RepoId>,
+}
+
 pub struct App {
     pub active_view: ActiveView,
     pub should_quit: bool,
@@ -295,9 +315,8 @@ pub struct App {
     // handling in `run()`), drained once per loop iteration in `run()`.
     pub commands: VecDeque<Command>,
 
-    /// Worktree paths with an in-flight create/delete, gated per-path so unrelated
-    /// worktrees stay actionable in the UI while one is still running.
-    pub wt_inflight: HashSet<String>,
+    // Async-work dedup bookkeeping (fetches, reloads, worktree ops).
+    pub inflight: Inflight,
     pub progress: ProgressTracker,
     pub quit_pressed_during_progress: bool,
     pub branch_selected: HashSet<String>,
@@ -322,9 +341,6 @@ pub struct App {
     // Worktree lists per repo (populated lazily as cross-repo PRs are selected)
     pub wt_lists_per_repo:
         std::collections::HashMap<crate::git::types::RepoId, Vec<crate::git::types::Worktree>>,
-
-    // Cross-repo worktree list lazy-load state
-    pub wt_list_inflight: HashSet<crate::git::types::RepoId>,
 }
 
 impl App {
@@ -366,7 +382,7 @@ impl App {
             show_help: false,
             cd_path: None,
             commands: VecDeque::new(),
-            wt_inflight: HashSet::new(),
+            inflight: Inflight::default(),
             progress: ProgressTracker::default(),
             quit_pressed_during_progress: false,
             branch_selected: HashSet::new(),
@@ -377,7 +393,6 @@ impl App {
             clone_root: None,
             repos: HashMap::new(),
             wt_lists_per_repo: HashMap::new(),
-            wt_list_inflight: HashSet::new(),
         }
     }
 
@@ -411,7 +426,7 @@ impl App {
     pub fn tick(&mut self) {
         self.spinner_tick = self.spinner_tick.wrapping_add(1);
         // Don't auto-dismiss while a worktree operation is in progress
-        if self.wt_inflight.is_empty()
+        if self.inflight.worktrees.is_empty()
             && let Some(ref mut n) = self.notification
         {
             if n.ticks_remaining > 0 {
@@ -627,7 +642,7 @@ impl App {
         if let Some(entry) = &selected
             && self.active_repo.as_ref() != Some(&entry.repo_id)
             && !self.wt_lists_per_repo.contains_key(&entry.repo_id)
-            && !self.wt_list_inflight.contains(&entry.repo_id)
+            && !self.inflight.wt_lists.contains(&entry.repo_id)
         {
             self.resolve_local_path(&entry.repo_id);
             if self
@@ -771,7 +786,7 @@ impl App {
                     self.pr_detail_cache.clear();
                     // Invalidate cross-repo worktree list caches so they re-fetch.
                     self.wt_lists_per_repo.clear();
-                    self.wt_list_inflight.clear();
+                    self.inflight.wt_lists.clear();
                     // Signal branches/worktrees reload + PR fetch
                     self.push_command(Command::ReloadBranches);
                     self.push_command(Command::FetchPrs(self.main_filter));
@@ -902,7 +917,7 @@ impl App {
                 } else if let Some(entry) = self.selected_entry().cloned()
                     && let Some(wt_path) = entry.worktree_path()
                     && !entry.is_current()
-                    && !self.wt_inflight.contains(wt_path)
+                    && !self.inflight.worktrees.contains(wt_path)
                 {
                     let path = wt_path.to_string();
                     self.confirm_dialog = Some(PendingConfirm {
@@ -954,7 +969,7 @@ impl App {
                         &entry.name,
                     )
                 };
-                if self.wt_inflight.contains(&wt_path) {
+                if self.inflight.worktrees.contains(&wt_path) {
                     return;
                 }
                 self.push_command(Command::CreateWorktree(
@@ -1123,7 +1138,7 @@ impl App {
             && !cross_repo_no_clone
             && wt_path_for_inflight
                 .as_deref()
-                .map(|p| !self.wt_inflight.contains(p))
+                .map(|p| !self.inflight.worktrees.contains(p))
                 .unwrap_or(false);
         if can_create_wt {
             items.push(ActionItem::CreateWorktree);
@@ -1133,7 +1148,7 @@ impl App {
         if is_active_repo
             && let Some(wt_path) = entry.worktree_path()
             && !entry.is_current()
-            && !self.wt_inflight.contains(wt_path)
+            && !self.inflight.worktrees.contains(wt_path)
         {
             items.push(ActionItem::DeleteWorktree);
         }
@@ -1328,7 +1343,7 @@ impl App {
                 {
                     // Declining force-delete ends the op — release the path so
                     // its action items reappear.
-                    self.wt_inflight.remove(&path);
+                    self.inflight.worktrees.remove(&path);
                 }
             }
             _ => {}
@@ -2502,11 +2517,11 @@ mod command_queue_tests {
     #[test]
     fn confirm_decline_force_delete_releases_inflight_path() {
         let mut app = App::new(Config::default());
-        app.wt_inflight.insert("/wt/p".to_string());
+        app.inflight.worktrees.insert("/wt/p".to_string());
         app.confirm_dialog = Some(pending(Command::ForceDeleteWorktree("/wt/p".into())));
         app.handle_key(key(KeyCode::Char('n')));
         assert!(app.confirm_dialog.is_none());
         assert!(app.commands.is_empty());
-        assert!(!app.wt_inflight.contains("/wt/p"));
+        assert!(!app.inflight.worktrees.contains("/wt/p"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,6 @@ mod ops;
 mod ui;
 
 use anyhow::Context;
-use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::process;
 use std::time::Duration;
@@ -725,14 +724,7 @@ async fn run(
     let mut events = EventHandler::new(Duration::from_millis(80));
     let (tx, mut rx) = mpsc::unbounded_channel::<AsyncResult>();
     let repo_info = startup(&mut app, config_warnings, &tx).await;
-    let mut tasks = RunState {
-        tx,
-        repo_info,
-        pr_inflight: HashSet::new(),
-        status_inflight: HashSet::new(),
-        branches_reload_inflight: false,
-        commits_reload_inflight: false,
-    };
+    let mut tasks = RunState { tx, repo_info };
 
     loop {
         if let Err(e) = terminal.draw(|frame| ui::draw(frame, &mut app)) {
@@ -753,7 +745,7 @@ async fn run(
 
         // Receive completed background results (non-blocking)
         while let Ok(result) = rx.try_recv() {
-            handle_result(&mut app, result, &mut tasks);
+            handle_result(&mut app, result);
         }
 
         // Dispatch commands staged by key handling above and by the
@@ -774,16 +766,12 @@ async fn run(
     (Ok(()), cd_path)
 }
 
-/// Loop-local state of `run()`: the task-result channel sender, the active
-/// repo's identity, and inflight-dedup bookkeeping shared between result
-/// handling and command dispatch.
+/// Loop-local state of `run()`: the task-result channel sender and the
+/// active repo's identity. (Inflight-dedup bookkeeping lives on
+/// `App::inflight` so key handling and dispatch share one tracker.)
 struct RunState {
     tx: mpsc::UnboundedSender<AsyncResult>,
     repo_info: Option<crate::git::types::RepoId>,
-    pr_inflight: HashSet<(crate::git::types::RepoId, u64)>,
-    status_inflight: HashSet<String>,
-    branches_reload_inflight: bool,
-    commits_reload_inflight: bool,
 }
 
 /// One-time startup: surface config warnings, detect the active repo, run
@@ -937,11 +925,11 @@ fn apply_pr_list(
 }
 
 /// Handle one completed background-task result.
-fn handle_result(app: &mut App, result: AsyncResult, tasks: &mut RunState) {
+fn handle_result(app: &mut App, result: AsyncResult) {
     match result {
         AsyncResult::PrDetail { repo_id, detail } => {
             let key = (repo_id.clone(), detail.number);
-            tasks.pr_inflight.remove(&key);
+            app.inflight.pr_detail.remove(&key);
             app.pr_detail_cache.insert(key, detail);
         }
         AsyncResult::PrDetailError {
@@ -949,12 +937,12 @@ fn handle_result(app: &mut App, result: AsyncResult, tasks: &mut RunState) {
             number,
             error,
         } => {
-            tasks.pr_inflight.remove(&(repo_id, number));
+            app.inflight.pr_detail.remove(&(repo_id, number));
             app.notification = Some(Notification::error(format!("Failed to load PR #{number}")));
             app.record_error(error);
         }
         AsyncResult::GitStatus { wt_path, status } => {
-            tasks.status_inflight.remove(&wt_path);
+            app.inflight.git_status.remove(&wt_path);
             if let Some(entry) = app
                 .entries
                 .iter_mut()
@@ -964,7 +952,7 @@ fn handle_result(app: &mut App, result: AsyncResult, tasks: &mut RunState) {
             }
         }
         AsyncResult::GitStatusError(wt_path) => {
-            tasks.status_inflight.remove(&wt_path);
+            app.inflight.git_status.remove(&wt_path);
             let msg = format!("git status failed for {wt_path}");
             app.notification = Some(Notification::error(msg.clone()));
             app.record_error(msg);
@@ -1000,7 +988,7 @@ fn handle_result(app: &mut App, result: AsyncResult, tasks: &mut RunState) {
             copy_errors,
             target_repo,
         } => {
-            app.wt_inflight.remove(&wt_path);
+            app.inflight.worktrees.remove(&wt_path);
             if copy_errors.is_empty() {
                 app.notification = Some(Notification::success(format!(
                     "Worktree created: {wt_path}"
@@ -1032,7 +1020,7 @@ fn handle_result(app: &mut App, result: AsyncResult, tasks: &mut RunState) {
             }
         }
         AsyncResult::WtCreateError { wt_path, message } => {
-            app.wt_inflight.remove(&wt_path);
+            app.inflight.worktrees.remove(&wt_path);
             app.notification = Some(Notification::error(message));
         }
         AsyncResult::OpStarted { op_id, label } => {
@@ -1059,7 +1047,7 @@ fn handle_result(app: &mut App, result: AsyncResult, tasks: &mut RunState) {
             wt_paths_claimed,
         } => {
             for path in &wt_paths_claimed {
-                app.wt_inflight.remove(path);
+                app.inflight.worktrees.remove(path);
             }
             app.progress.sweep_unfinished();
             let success_parts = bulk_success_parts(branches_deleted.len(), worktrees_removed.len());
@@ -1104,13 +1092,13 @@ fn handle_result(app: &mut App, result: AsyncResult, tasks: &mut RunState) {
             });
         }
         AsyncResult::WtListLoaded { repo_id, list } => {
-            app.wt_list_inflight.remove(&repo_id);
+            app.inflight.wt_lists.remove(&repo_id);
             app.wt_lists_per_repo.insert(repo_id, list);
             app.rebuild_entries();
             app.snap_scroll_to_entry();
         }
         AsyncResult::BranchesReloaded(data) => {
-            tasks.branches_reload_inflight = false;
+            app.inflight.branches_reload = false;
             if let Some(branches) = data.branches {
                 app.branches = branches;
             }
@@ -1122,7 +1110,7 @@ fn handle_result(app: &mut App, result: AsyncResult, tasks: &mut RunState) {
             app.snap_scroll_to_entry();
         }
         AsyncResult::CommitsReloaded(commits) => {
-            tasks.commits_reload_inflight = false;
+            app.inflight.commits_reload = false;
             if let Some(commits) = commits {
                 app.commits = commits;
             }
@@ -1147,7 +1135,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
     match cmd {
         // Delete worktree (single-item, no auto-force fallback).
         Command::DeleteWorktree(path) => {
-            app.wt_inflight.insert(path.clone());
+            app.inflight.worktrees.insert(path.clone());
             let op_id = app.progress.allocate_ids(1).start;
             let label = wt_label_for(&path);
             let claimed = vec![path.clone()];
@@ -1200,7 +1188,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
 
         // Force delete worktree after confirmation (single-item, force only).
         Command::ForceDeleteWorktree(path) => {
-            app.wt_inflight.insert(path.clone());
+            app.inflight.worktrees.insert(path.clone());
             let op_id = app.progress.allocate_ids(1).start;
             let label = wt_label_for(&path);
             let claimed = vec![path.clone()];
@@ -1275,7 +1263,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
             };
 
             let wt_path = cfg.worktree_path_for(&target_root, &entry.repo_id.name, &branch_name);
-            app.wt_inflight.insert(wt_path.clone());
+            app.inflight.worktrees.insert(wt_path.clone());
             if let Some(parent) = std::path::Path::new(&wt_path).parent() {
                 let _ = std::fs::create_dir_all(parent);
             }
@@ -1361,12 +1349,12 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
                 }
                 let wt_path = entry.worktree_path().map(str::to_string);
                 if let Some(ref p) = wt_path
-                    && app.wt_inflight.contains(p)
+                    && app.inflight.worktrees.contains(p)
                 {
                     continue;
                 }
                 if let Some(ref p) = wt_path {
-                    app.wt_inflight.insert(p.clone());
+                    app.inflight.worktrees.insert(p.clone());
                     wt_paths_claimed.push(p.clone());
                 }
                 work.push(Work {
@@ -1455,10 +1443,10 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
 
         // Spawn PR detail load in background (deduplicated)
         Command::FetchPrDetail(repo_id, number) => {
-            if tasks.pr_inflight.contains(&(repo_id.clone(), number)) {
+            if app.inflight.pr_detail.contains(&(repo_id.clone(), number)) {
                 return;
             }
-            tasks.pr_inflight.insert((repo_id.clone(), number));
+            app.inflight.pr_detail.insert((repo_id.clone(), number));
             let tx = tasks.tx.clone();
             // `gh pr view` doesn't accept --hostname; the host (if any) is
             // embedded into --repo as `[HOST/]OWNER/REPO`.
@@ -1501,13 +1489,13 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
 
         // Spawn cross-repo worktree list load in background (deduplicated)
         Command::LoadWorktreeList(repo_id) => {
-            if app.wt_list_inflight.contains(&repo_id) {
+            if app.inflight.wt_lists.contains(&repo_id) {
                 return;
             }
             let Some(path) = app.repos.get(&repo_id).and_then(|m| m.local_path.clone()) else {
                 return;
             };
-            app.wt_list_inflight.insert(repo_id.clone());
+            app.inflight.wt_lists.insert(repo_id.clone());
             let tx_c = tasks.tx.clone();
             let repo_id_c = repo_id.clone();
             tokio::spawn(async move {
@@ -1533,13 +1521,13 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
         // Triggered by `r` in Main view, and also re-armed after
         // worktree/branch mutations that invalidate the cached entries.
         Command::ReloadBranches => {
-            if tasks.branches_reload_inflight {
+            if app.inflight.branches_reload {
                 // A reload is already running — retry next iteration so a
                 // request issued mid-reload still yields a fresh fetch.
                 app.push_command(Command::ReloadBranches);
                 return;
             }
-            tasks.branches_reload_inflight = true;
+            app.inflight.branches_reload = true;
             let tx = tasks.tx.clone();
             tokio::spawn(async move {
                 let data = fetch_branches_and_worktrees().await;
@@ -1549,14 +1537,14 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
 
         // Reload commits on `r` refresh from Log view (deduplicated)
         Command::ReloadCommits => {
-            if tasks.commits_reload_inflight {
+            if app.inflight.commits_reload {
                 app.push_command(Command::ReloadCommits);
                 return;
             }
-            tasks.commits_reload_inflight = true;
+            app.inflight.commits_reload = true;
             let tx = tasks.tx.clone();
             tokio::spawn(async move {
-                // Always send, even on failure, so `commits_reload_inflight`
+                // Always send, even on failure, so `Inflight.commits_reload`
                 // is reliably cleared instead of getting stuck forever.
                 let commits = run_git(LOG_ARGS)
                     .await
@@ -1568,10 +1556,10 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
 
         // Spawn git status load in background (deduplicated)
         Command::LoadGitStatus(wt_path) => {
-            if tasks.status_inflight.contains(&wt_path) {
+            if app.inflight.git_status.contains(&wt_path) {
                 return;
             }
-            tasks.status_inflight.insert(wt_path.clone());
+            app.inflight.git_status.insert(wt_path.clone());
             let tx = tasks.tx.clone();
             tokio::spawn(async move {
                 if let Some(status) = data::load_git_status(&wt_path).await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -722,6 +722,10 @@ async fn run(
     let mut app = App::new(config);
     app.verbose = verbose;
     let mut events = EventHandler::new(Duration::from_millis(80));
+    // Unbounded by design: the receiver drains fully every loop iteration,
+    // and senders are spawned tasks that must never block on the UI. The
+    // producer count — not the channel — is the real resource bound, and it
+    // is capped by `App::inflight` dedup plus the selection-fetch debounce.
     let (tx, mut rx) = mpsc::unbounded_channel::<AsyncResult>();
     let repo_info = startup(&mut app, config_warnings, &tx).await;
     let mut tasks = RunState { tx, repo_info };


### PR DESCRIPTION
## Summary

Second PR of the Low batch (#232 ✅ → **#236** → #235). Two commits:

Closes #236

### Commit 1 — one `Inflight` tracker

The dedup state was split between `App` (`wt_inflight`, `wt_list_inflight` — read by key handlers) and `run()`-local `RunState` fields (`pr_inflight`, `status_inflight`, `branches_reload_inflight`, `commits_reload_inflight` — touched only by dispatch/result handling). All six now live on `App::inflight` (new `Inflight` struct), the one place both key handling and the main loop can reach. `RunState` shrinks to the channel sender + repo identity, and `handle_result` no longer needs it at all. Per-kind semantics are unchanged: `HashSet`-tracked fetches drop duplicates at dispatch; the reload bools requeue-if-busy.

### Commit 2 — debounced selection fetches

Previously, holding `j`/`k` spawned a `gh pr view` + `git status` subprocess for every row passed through. Now `request_details_for_selection` just marks the selection dirty, and `App::tick()` flushes the fetches for the *then-current* selection.

The trick that makes this a real debounce with zero timer machinery: `EventHandler` only emits `Tick` when `event::poll(80ms)` times out with no input pending, so **ticks are starved during key-repeat**. Holding a nav key spawns nothing; one fetch for the final selection fires ~80 ms after scrolling settles. Recomputing targets at flush time (instead of storing payloads) is what discards the intermediate rows. Deliberate single actions (filter switch, search exit, startup) defer at most one tick, visually covered by the existing loading spinner.

### Bounded channel — considered, deliberately not adopted

The issue asked to "consider a bounded channel". Analysis: the receiver drains the channel fully every loop iteration, so depth is bounded by drain rate; the real resource risk was *producer* fan-out (subprocess storms), which the `Inflight` dedup + debounce now cap. A bounded channel would risk blocking spawned sender tasks against the UI loop. The channel stays unbounded with this rationale documented at the creation site.

## Test plan

- `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo build` — clean
- `cargo test` — 214 unit + 17 integration tests pass (PTY e2e confirmed not sensitive to detail-fetch timing; its assertions poll-until-visible)
- New unit tests: no fetch before the debounce tick; two rapid selection moves coalesce to only the final target; cached detail queues nothing after tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr

---
_Generated by [Claude Code](https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr)_