### PR TITLE
refactor(app): break up the God-object App struct into sub-structs

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -171,6 +171,10 @@ pub struct ProgressTracker {
     pub ops: BTreeMap<u64, OpProgress>,
     next_id: u64,
     pub started_at: Option<Instant>,
+    /// `q`/`Esc` was pressed while ops were active; the next press quits.
+    /// Reset explicitly by the main loop when the op batch finishes —
+    /// deliberately not folded into `clear()`/`sweep_unfinished()` (issue #220).
+    pub quit_pressed: bool,
 }
 
 impl ProgressTracker {
@@ -604,7 +608,6 @@ pub struct App {
     // Async-work dedup bookkeeping (fetches, reloads, worktree ops).
     pub inflight: Inflight,
     pub progress: ProgressTracker,
-    pub quit_pressed_during_progress: bool,
 
     // Spinner animation
     spinner_tick: usize,
@@ -632,7 +635,6 @@ impl App {
             selection_details_pending: false,
             inflight: Inflight::default(),
             progress: ProgressTracker::default(),
-            quit_pressed_during_progress: false,
             spinner_tick: 0,
             config,
             cross_repo: CrossRepoState::default(),
@@ -836,10 +838,10 @@ impl App {
         match key.code {
             KeyCode::Char('?') => self.overlays.show_help = true,
             KeyCode::Char('q') => {
-                if !self.progress.is_active() || self.quit_pressed_during_progress {
+                if !self.progress.is_active() || self.progress.quit_pressed {
                     self.should_quit = true;
                 } else {
-                    self.quit_pressed_during_progress = true;
+                    self.progress.quit_pressed = true;
                 }
             }
             KeyCode::Esc => {
@@ -852,10 +854,10 @@ impl App {
                     self.request_details_for_selection();
                 } else if matches!(self.active_view, ActiveView::Log | ActiveView::History) {
                     self.active_view = ActiveView::Main;
-                } else if !self.progress.is_active() || self.quit_pressed_during_progress {
+                } else if !self.progress.is_active() || self.progress.quit_pressed {
                     self.should_quit = true;
                 } else {
-                    self.quit_pressed_during_progress = true;
+                    self.progress.quit_pressed = true;
                 }
             }
             KeyCode::Char('l') => self.active_view = ActiveView::Log,
@@ -1710,7 +1712,7 @@ mod text_edit_tests {
             crossterm::event::KeyModifiers::NONE,
         ));
         assert!(!app.should_quit);
-        assert!(app.quit_pressed_during_progress);
+        assert!(app.progress.quit_pressed);
 
         // Second 'q': force quits.
         app.handle_key(crossterm::event::KeyEvent::new(
@@ -1744,7 +1746,7 @@ mod text_edit_tests {
             crossterm::event::KeyModifiers::NONE,
         ));
         assert!(!app.should_quit);
-        assert!(app.quit_pressed_during_progress);
+        assert!(app.progress.quit_pressed);
 
         // Second Esc: force quits.
         app.handle_key(crossterm::event::KeyEvent::new(

--- a/src/app.rs
+++ b/src/app.rs
@@ -256,6 +256,17 @@ pub struct Inflight {
     pub wt_lists: HashSet<crate::git::types::RepoId>,
 }
 
+/// Raw data fetched from `git`/`gh`: inputs to `rebuild_entries` and the Log
+/// view, plus the gh identity used for review-status computation (issue #220).
+#[derive(Default)]
+pub struct RawData {
+    pub branches: Vec<Branch>,
+    pub worktrees: Vec<Worktree>,
+    pub commits: Vec<Commit>,
+    pub gh_user: String,
+    pub gh_user_load_failed: bool,
+}
+
 /// Cross-repo context: active repo, clone root, lazily-populated per-repo
 /// metadata and worktree lists, and the merged global config layers used to
 /// resolve per-repo effective configs (issue #220).
@@ -327,7 +338,6 @@ pub struct App {
     pub should_quit: bool,
 
     // Log View
-    pub commits: Vec<Commit>,
     pub log_scroll: usize,
 
     // History View
@@ -342,11 +352,8 @@ pub struct App {
     pub search_query: String,
     search_pre_scroll: usize, // saved scroll position before search
 
-    // Raw data sources (for merge_entries and async reload)
-    pub branches: Vec<Branch>,
-    pub worktrees: Vec<Worktree>,
-    pub gh_user: String,
-    pub gh_user_load_failed: bool,
+    // Raw data fetched from git/gh (issue #220).
+    pub raw: RawData,
 
     // Per-view PR caches
     pub local_prs: Vec<PullRequest>,
@@ -405,7 +412,6 @@ impl App {
         Self {
             active_view: ActiveView::default(),
             should_quit: false,
-            commits: Vec::new(),
             log_scroll: 0,
             history_scroll: 0,
             entries: Vec::new(),
@@ -415,10 +421,7 @@ impl App {
             search_active: false,
             search_query: String::new(),
             search_pre_scroll: 0,
-            branches: Vec::new(),
-            worktrees: Vec::new(),
-            gh_user: String::new(),
-            gh_user_load_failed: false,
+            raw: RawData::default(),
             local_prs: Vec::new(),
             my_prs: Vec::new(),
             review_prs: Vec::new(),
@@ -535,8 +538,8 @@ impl App {
         let active = self.cross_repo.active_repo.clone().unwrap_or_default();
         self.entries = crate::data::merge_entries(
             &active,
-            &self.branches,
-            &self.worktrees,
+            &self.raw.branches,
+            &self.raw.worktrees,
             self.current_prs(),
             &self.cross_repo.wt_lists_per_repo,
         );
@@ -1093,7 +1096,7 @@ impl App {
 
     fn handle_log_key(&mut self, code: KeyCode) {
         match code {
-            KeyCode::Char('j') | KeyCode::Down if self.log_scroll + 1 < self.commits.len() => {
+            KeyCode::Char('j') | KeyCode::Down if self.log_scroll + 1 < self.raw.commits.len() => {
                 self.log_scroll += 1;
             }
             KeyCode::Char('k') | KeyCode::Up => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -269,7 +269,6 @@ pub struct App {
 
     // Main View — unified entries
     pub entries: Vec<BranchEntry>,
-    pub entries_loaded: bool,
     pub main_filter: MainFilter,
     pub sidebar_scroll: usize,
     pub sidebar_offset: usize,
@@ -356,7 +355,6 @@ impl App {
             log_scroll: 0,
             history_scroll: 0,
             entries: Vec::new(),
-            entries_loaded: false,
             main_filter: MainFilter::default(),
             sidebar_scroll: 0,
             sidebar_offset: 0,

--- a/src/app.rs
+++ b/src/app.rs
@@ -256,6 +256,77 @@ pub struct Inflight {
     pub wt_lists: HashSet<crate::git::types::RepoId>,
 }
 
+/// Per-filter PR list caches keyed by `MainFilter`, their fetch parameters,
+/// and the PR-detail cache (issue #220).
+#[derive(Default)]
+pub struct PrCaches {
+    pub local: Vec<PullRequest>,
+    pub my: Vec<PullRequest>,
+    pub review: Vec<PullRequest>,
+    pub local_loaded: bool,
+    pub my_loaded: bool,
+    pub review_loaded: bool,
+    pub show_merged: bool,
+    pub include_team_reviews: bool,
+    /// PR detail bodies for the detail pane, cached by `(RepoId, PR number)`.
+    pub detail: HashMap<(crate::git::types::RepoId, u64), PrDetail>,
+}
+
+impl PrCaches {
+    pub fn current(&self, filter: MainFilter) -> &[PullRequest] {
+        match filter {
+            MainFilter::Local => &self.local,
+            MainFilter::MyPr => &self.my,
+            MainFilter::ReviewRequested => &self.review,
+        }
+    }
+
+    /// A filter's list counts as loading until its first fetch lands.
+    pub fn is_loading(&self, filter: MainFilter) -> bool {
+        match filter {
+            MainFilter::Local => !self.local_loaded,
+            MainFilter::MyPr => !self.my_loaded,
+            MainFilter::ReviewRequested => !self.review_loaded,
+        }
+    }
+
+    /// Store a fetched PR list for `filter` and mark it loaded.
+    pub fn set(&mut self, filter: MainFilter, prs: Vec<PullRequest>) {
+        match filter {
+            MainFilter::Local => {
+                self.local = prs;
+                self.local_loaded = true;
+            }
+            MainFilter::MyPr => {
+                self.my = prs;
+                self.my_loaded = true;
+            }
+            MainFilter::ReviewRequested => {
+                self.review = prs;
+                self.review_loaded = true;
+            }
+        }
+    }
+
+    /// Drop a filter's cached list so the next fetch is forced.
+    pub fn invalidate(&mut self, filter: MainFilter) {
+        match filter {
+            MainFilter::Local => {
+                self.local.clear();
+                self.local_loaded = false;
+            }
+            MainFilter::MyPr => {
+                self.my.clear();
+                self.my_loaded = false;
+            }
+            MainFilter::ReviewRequested => {
+                self.review.clear();
+                self.review_loaded = false;
+            }
+        }
+    }
+}
+
 /// Raw data fetched from `git`/`gh`: inputs to `rebuild_entries` and the Log
 /// view, plus the gh identity used for review-status computation (issue #220).
 #[derive(Default)]
@@ -355,18 +426,10 @@ pub struct App {
     // Raw data fetched from git/gh (issue #220).
     pub raw: RawData,
 
-    // Per-view PR caches
-    pub local_prs: Vec<PullRequest>,
-    pub my_prs: Vec<PullRequest>,
-    pub review_prs: Vec<PullRequest>,
-    pub local_prs_loaded: bool,
-    pub my_prs_loaded: bool,
-    pub review_prs_loaded: bool,
-    pub show_merged: bool,
-    pub include_team_reviews: bool,
+    // Per-filter PR caches and the PR-detail cache (issue #220).
+    pub prs: PrCaches,
 
-    // PR Detail (for detail pane, cached by (RepoId, PR number))
-    pub pr_detail_cache: HashMap<(crate::git::types::RepoId, u64), PrDetail>,
+    // Detail-pane scroll position.
     pub pr_detail_scroll: usize,
 
     // Verbose mode
@@ -422,15 +485,7 @@ impl App {
             search_query: String::new(),
             search_pre_scroll: 0,
             raw: RawData::default(),
-            local_prs: Vec::new(),
-            my_prs: Vec::new(),
-            review_prs: Vec::new(),
-            local_prs_loaded: false,
-            my_prs_loaded: false,
-            review_prs_loaded: false,
-            show_merged: false,
-            include_team_reviews: false,
-            pr_detail_cache: HashMap::new(),
+            prs: PrCaches::default(),
             pr_detail_scroll: 0,
             verbose: false,
             verbose_errors: Vec::new(),
@@ -469,11 +524,7 @@ impl App {
     }
 
     pub fn current_prs(&self) -> &[PullRequest] {
-        match self.main_filter {
-            MainFilter::Local => &self.local_prs,
-            MainFilter::MyPr => &self.my_prs,
-            MainFilter::ReviewRequested => &self.review_prs,
-        }
+        self.prs.current(self.main_filter)
     }
 
     const SPINNER_FRAMES: &'static [&'static str] =
@@ -523,11 +574,7 @@ impl App {
     }
 
     pub fn is_current_view_loading(&self) -> bool {
-        match self.main_filter {
-            MainFilter::Local => !self.local_prs_loaded,
-            MainFilter::MyPr => !self.my_prs_loaded,
-            MainFilter::ReviewRequested => !self.review_prs_loaded,
-        }
+        self.prs.is_loading(self.main_filter)
     }
 
     pub fn rebuild_entries(&mut self) {
@@ -671,7 +718,7 @@ impl App {
     pub fn selected_pr_detail(&self) -> Option<&PrDetail> {
         let entry = self.selected_entry()?;
         let pr_num = entry.pr_number()?;
-        self.pr_detail_cache.get(&(entry.repo_id.clone(), pr_num))
+        self.prs.detail.get(&(entry.repo_id.clone(), pr_num))
     }
 
     /// Signal that the selection changed. The actual detail fetches are
@@ -695,7 +742,8 @@ impl App {
             // Request PR detail if entry has a PR and it's not cached
             if let Some(pr_num) = entry.pr_number()
                 && !self
-                    .pr_detail_cache
+                    .prs
+                    .detail
                     .contains_key(&(entry.repo_id.clone(), pr_num))
             {
                 self.push_command(Command::FetchPrDetail(entry.repo_id.clone(), pr_num));
@@ -807,7 +855,7 @@ impl App {
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
-                if !self.local_prs_loaded {
+                if !self.prs.local_loaded {
                     self.push_command(Command::FetchPrs(MainFilter::Local));
                 }
                 self.request_details_for_selection();
@@ -820,7 +868,7 @@ impl App {
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
-                if !self.my_prs_loaded {
+                if !self.prs.my_loaded {
                     self.push_command(Command::FetchPrs(MainFilter::MyPr));
                 }
                 self.request_details_for_selection();
@@ -833,7 +881,7 @@ impl App {
                 self.sidebar_offset = 0;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
-                if !self.review_prs_loaded {
+                if !self.prs.review_loaded {
                     self.push_command(Command::FetchPrs(MainFilter::ReviewRequested));
                 }
                 self.request_details_for_selection();
@@ -841,24 +889,11 @@ impl App {
             KeyCode::Char('r') => match self.active_view {
                 ActiveView::Main => {
                     // Invalidate current filter's PR cache so the fetch is forced
-                    match self.main_filter {
-                        MainFilter::Local => {
-                            self.local_prs.clear();
-                            self.local_prs_loaded = false;
-                        }
-                        MainFilter::MyPr => {
-                            self.my_prs.clear();
-                            self.my_prs_loaded = false;
-                        }
-                        MainFilter::ReviewRequested => {
-                            self.review_prs.clear();
-                            self.review_prs_loaded = false;
-                        }
-                    }
+                    self.prs.invalidate(self.main_filter);
                     // Clear PR detail cache for ALL filters, not just the current
                     // one — stale detail bodies are risky after a refresh, and the
                     // detail pane will refetch on the next selection.
-                    self.pr_detail_cache.clear();
+                    self.prs.detail.clear();
                     // Invalidate cross-repo worktree list caches so they re-fetch.
                     self.cross_repo.wt_lists_per_repo.clear();
                     self.inflight.wt_lists.clear();
@@ -1062,12 +1097,10 @@ impl App {
                     self.main_filter,
                     MainFilter::MyPr | MainFilter::ReviewRequested
                 ) {
-                    self.show_merged = !self.show_merged;
+                    self.prs.show_merged = !self.prs.show_merged;
                     // Invalidate both caches since merged state changed
-                    self.my_prs.clear();
-                    self.my_prs_loaded = false;
-                    self.review_prs.clear();
-                    self.review_prs_loaded = false;
+                    self.prs.invalidate(MainFilter::MyPr);
+                    self.prs.invalidate(MainFilter::ReviewRequested);
                     self.rebuild_entries();
                     self.push_command(Command::FetchPrs(self.main_filter));
                     self.sidebar_scroll = 0;
@@ -1076,9 +1109,8 @@ impl App {
                 }
             }
             KeyCode::Char('t') if self.main_filter == MainFilter::ReviewRequested => {
-                self.include_team_reviews = !self.include_team_reviews;
-                self.review_prs.clear();
-                self.review_prs_loaded = false;
+                self.prs.include_team_reviews = !self.prs.include_team_reviews;
+                self.prs.invalidate(MainFilter::ReviewRequested);
                 self.rebuild_entries();
                 self.push_command(Command::FetchPrs(MainFilter::ReviewRequested));
                 self.sidebar_scroll = 0;
@@ -1729,13 +1761,11 @@ mod pr_detail_cache_tests {
             additions: 0,
             deletions: 0,
         };
-        app.pr_detail_cache
-            .insert((id_a.clone(), 1), detail_a.clone());
-        app.pr_detail_cache
-            .insert((id_b.clone(), 1), detail_b.clone());
-        assert_eq!(app.pr_detail_cache.len(), 2);
-        assert_eq!(app.pr_detail_cache.get(&(id_a, 1)).unwrap().body, "A");
-        assert_eq!(app.pr_detail_cache.get(&(id_b, 1)).unwrap().body, "B");
+        app.prs.detail.insert((id_a.clone(), 1), detail_a.clone());
+        app.prs.detail.insert((id_b.clone(), 1), detail_b.clone());
+        assert_eq!(app.prs.detail.len(), 2);
+        assert_eq!(app.prs.detail.get(&(id_a, 1)).unwrap().body, "A");
+        assert_eq!(app.prs.detail.get(&(id_b, 1)).unwrap().body, "B");
     }
 }
 
@@ -2523,7 +2553,7 @@ mod command_queue_tests {
         assert!(app.commands.contains(&Command::FetchPrs(MainFilter::MyPr)));
 
         let mut loaded = App::new(Config::default());
-        loaded.my_prs_loaded = true;
+        loaded.prs.my_loaded = true;
         loaded.handle_key(key(KeyCode::Char('2')));
         assert!(
             !loaded
@@ -2615,7 +2645,7 @@ mod command_queue_tests {
         use crate::git::types::PrDetail;
         let mut app = app_with_pr_entries();
         let repo = app.entries[0].repo_id.clone();
-        app.pr_detail_cache.insert(
+        app.prs.detail.insert(
             (repo, 1),
             PrDetail {
                 number: 1,

--- a/src/app.rs
+++ b/src/app.rs
@@ -256,6 +256,72 @@ pub struct Inflight {
     pub wt_lists: HashSet<crate::git::types::RepoId>,
 }
 
+/// Cross-repo context: active repo, clone root, lazily-populated per-repo
+/// metadata and worktree lists, and the merged global config layers used to
+/// resolve per-repo effective configs (issue #220).
+#[derive(Default)]
+pub struct CrossRepoState {
+    /// Set at startup; `None` when startup couldn't infer a repo.
+    pub active_repo: Option<crate::git::types::RepoId>,
+    pub clone_root: Option<std::path::PathBuf>,
+    /// Per-repo metadata (populated lazily as repos are selected).
+    pub repos: std::collections::HashMap<crate::git::types::RepoId, crate::git::types::RepoMeta>,
+    /// Worktree lists per repo (populated lazily as cross-repo PRs are selected).
+    pub wt_lists_per_repo:
+        std::collections::HashMap<crate::git::types::RepoId, Vec<crate::git::types::Worktree>>,
+    /// Merged global config layers (home-dir files only), used to resolve a
+    /// per-repo effective config for cross-repo worktree operations.
+    pub global_layers: toml::Table,
+}
+
+impl CrossRepoState {
+    /// Hosts the user can reasonably be expected to have PRs on, derived from
+    /// the origin remotes of every repo we have metadata for. Empty repo map
+    /// falls back to `[None]` (default host = github.com) so cross-repo
+    /// aggregation behaves identically to the single-host case before any
+    /// repo metadata is collected. The output is unique-by-host and sorted
+    /// (None first) for deterministic ordering.
+    pub fn known_hosts(&self) -> Vec<Option<String>> {
+        use std::collections::BTreeSet;
+        let set: BTreeSet<Option<String>> = self.repos.keys().map(|id| id.host.clone()).collect();
+        if set.is_empty() {
+            vec![None]
+        } else {
+            set.into_iter().collect()
+        }
+    }
+
+    /// Effective config for a specific repo root: the global layers overlaid
+    /// with `<repo_root>/.gct.toml`. Used for cross-repo worktree operations so
+    /// the target repo's own `.gct.toml` applies (not the launching repo's).
+    pub fn resolve_repo_config(&self, repo_root: &std::path::Path) -> crate::config::Config {
+        crate::config::resolve_config(&self.global_layers, Some(repo_root))
+    }
+
+    /// Resolve a repo's local clone path under `clone_root`. Idempotent: only
+    /// hits the filesystem once per repo. Sets `local_path_resolved = true`
+    /// regardless of outcome to prevent re-tries.
+    pub fn resolve_local_path(&mut self, id: &crate::git::types::RepoId) {
+        // Snapshot clone_root first (no borrow on self.repos held).
+        let root = self.clone_root.clone();
+        let Some(meta) = self.repos.get_mut(id) else {
+            return;
+        };
+        if meta.local_path_resolved {
+            return;
+        }
+        meta.local_path_resolved = true;
+        let Some(root) = root else {
+            return;
+        };
+        let host = id.host.as_deref().unwrap_or("github.com");
+        let candidate = root.join(host).join(&id.owner).join(&id.name);
+        if candidate.is_dir() {
+            meta.local_path = Some(candidate);
+        }
+    }
+}
+
 pub struct App {
     pub active_view: ActiveView,
     pub should_quit: bool,
@@ -330,20 +396,8 @@ pub struct App {
     // Loaded TOML config (protected_branches, worktree, …) for the active repo.
     pub config: crate::config::Config,
 
-    // Merged global config layers (home-dir files only), used to resolve a
-    // per-repo effective config for cross-repo worktree operations.
-    pub global_layers: toml::Table,
-
-    // Cross-repo context (set at startup)
-    pub active_repo: Option<crate::git::types::RepoId>,
-    pub clone_root: Option<std::path::PathBuf>,
-
-    // Per-repo metadata (populated lazily as repos are selected)
-    pub repos: std::collections::HashMap<crate::git::types::RepoId, crate::git::types::RepoMeta>,
-
-    // Worktree lists per repo (populated lazily as cross-repo PRs are selected)
-    pub wt_lists_per_repo:
-        std::collections::HashMap<crate::git::types::RepoId, Vec<crate::git::types::Worktree>>,
+    // Cross-repo context and per-repo metadata (issue #220).
+    pub cross_repo: CrossRepoState,
 }
 
 impl App {
@@ -391,11 +445,7 @@ impl App {
             branch_selected: HashSet::new(),
             spinner_tick: 0,
             config,
-            global_layers: toml::Table::new(),
-            active_repo: None,
-            clone_root: None,
-            repos: HashMap::new(),
-            wt_lists_per_repo: HashMap::new(),
+            cross_repo: CrossRepoState::default(),
         }
     }
 
@@ -482,13 +532,13 @@ impl App {
         // produces a sentinel empty RepoId. It can't collide with any real PR's repo_id,
         // so cross-repo entries are still keyed correctly and worktree injection no-ops
         // safely.
-        let active = self.active_repo.clone().unwrap_or_default();
+        let active = self.cross_repo.active_repo.clone().unwrap_or_default();
         self.entries = crate::data::merge_entries(
             &active,
             &self.branches,
             &self.worktrees,
             self.current_prs(),
-            &self.wt_lists_per_repo,
+            &self.cross_repo.wt_lists_per_repo,
         );
     }
 
@@ -658,12 +708,16 @@ impl App {
 
         // Signal lazy load of cross-repo worktree list if not yet fetched (use the same `selected` binding)
         if let Some(entry) = &selected
-            && self.active_repo.as_ref() != Some(&entry.repo_id)
-            && !self.wt_lists_per_repo.contains_key(&entry.repo_id)
+            && self.cross_repo.active_repo.as_ref() != Some(&entry.repo_id)
+            && !self
+                .cross_repo
+                .wt_lists_per_repo
+                .contains_key(&entry.repo_id)
             && !self.inflight.wt_lists.contains(&entry.repo_id)
         {
             self.resolve_local_path(&entry.repo_id);
             if self
+                .cross_repo
                 .repos
                 .get(&entry.repo_id)
                 .and_then(|m| m.local_path.as_ref())
@@ -803,7 +857,7 @@ impl App {
                     // detail pane will refetch on the next selection.
                     self.pr_detail_cache.clear();
                     // Invalidate cross-repo worktree list caches so they re-fetch.
-                    self.wt_lists_per_repo.clear();
+                    self.cross_repo.wt_lists_per_repo.clear();
                     self.inflight.wt_lists.clear();
                     // Signal branches/worktrees reload + PR fetch
                     self.push_command(Command::ReloadBranches);
@@ -844,7 +898,7 @@ impl App {
                 if let Some(entry) = self.selected_entry().cloned()
                     && !entry.is_current()
                     && !self.is_protected_branch(&entry.name)
-                    && self.active_repo.as_ref() == Some(&entry.repo_id)
+                    && self.cross_repo.active_repo.as_ref() == Some(&entry.repo_id)
                 {
                     if self.branch_selected.contains(&entry.name) {
                         self.branch_selected.remove(&entry.name);
@@ -861,7 +915,7 @@ impl App {
                         (e.is_merged() || e.pr_is_merged())
                             && !e.is_current()
                             && !self.is_protected_branch(&e.name)
-                            && self.active_repo.as_ref() == Some(&e.repo_id)
+                            && self.cross_repo.active_repo.as_ref() == Some(&e.repo_id)
                     })
                     .map(|e| e.name.clone())
                     .collect();
@@ -957,12 +1011,13 @@ impl App {
                 {
                     return;
                 }
-                let is_active = self.active_repo.as_ref() == Some(&entry.repo_id);
+                let is_active = self.cross_repo.active_repo.as_ref() == Some(&entry.repo_id);
                 let clone_path: Option<std::path::PathBuf> = if is_active {
                     None
                 } else {
                     self.resolve_local_path(&entry.repo_id);
-                    self.repos
+                    self.cross_repo
+                        .repos
                         .get(&entry.repo_id)
                         .and_then(|m| m.local_path.clone())
                 };
@@ -1110,13 +1165,14 @@ impl App {
             Some(e) => e,
             None => return,
         };
-        let is_active_repo = self.active_repo.as_ref() == Some(&entry.repo_id);
+        let is_active_repo = self.cross_repo.active_repo.as_ref() == Some(&entry.repo_id);
         let clone_path: Option<std::path::PathBuf> = if is_active_repo {
             None // active repo runs in CWD, no clone path needed
         } else {
             // cross-repo: resolve once, then read
             self.resolve_local_path(&entry.repo_id);
-            self.repos
+            self.cross_repo
+                .repos
                 .get(&entry.repo_id)
                 .and_then(|m| m.local_path.clone())
         };
@@ -1183,6 +1239,7 @@ impl App {
 
         if cross_repo_no_clone {
             let hint_root = self
+                .cross_repo
                 .clone_root
                 .as_ref()
                 .map(|p| p.display().to_string())
@@ -1372,20 +1429,8 @@ impl App {
         self.config.protected_branches.iter().any(|b| b == name)
     }
 
-    /// Hosts the user can reasonably be expected to have PRs on, derived from
-    /// the origin remotes of every repo we have metadata for. Empty repo map
-    /// falls back to `[None]` (default host = github.com) so cross-repo
-    /// aggregation behaves identically to the single-host case before any
-    /// repo metadata is collected. The output is unique-by-host and sorted
-    /// (None first) for deterministic ordering.
     pub fn known_hosts(&self) -> Vec<Option<String>> {
-        use std::collections::BTreeSet;
-        let set: BTreeSet<Option<String>> = self.repos.keys().map(|id| id.host.clone()).collect();
-        if set.is_empty() {
-            vec![None]
-        } else {
-            set.into_iter().collect()
-        }
+        self.cross_repo.known_hosts()
     }
 
     /// Remember a background-operation error for the error list shown in
@@ -1398,34 +1443,12 @@ impl App {
         }
     }
 
-    /// Effective config for a specific repo root: the global layers overlaid
-    /// with `<repo_root>/.gct.toml`. Used for cross-repo worktree operations so
-    /// the target repo's own `.gct.toml` applies (not the launching repo's).
     pub fn resolve_repo_config(&self, repo_root: &std::path::Path) -> crate::config::Config {
-        crate::config::resolve_config(&self.global_layers, Some(repo_root))
+        self.cross_repo.resolve_repo_config(repo_root)
     }
 
-    /// Resolve a repo's local clone path under `clone_root`. Idempotent: only
-    /// hits the filesystem once per repo. Sets `local_path_resolved = true`
-    /// regardless of outcome to prevent re-tries.
     pub fn resolve_local_path(&mut self, id: &crate::git::types::RepoId) {
-        // Snapshot clone_root first (no borrow on self.repos held).
-        let root = self.clone_root.clone();
-        let Some(meta) = self.repos.get_mut(id) else {
-            return;
-        };
-        if meta.local_path_resolved {
-            return;
-        }
-        meta.local_path_resolved = true;
-        let Some(root) = root else {
-            return;
-        };
-        let host = id.host.as_deref().unwrap_or("github.com");
-        let candidate = root.join(host).join(&id.owner).join(&id.name);
-        if candidate.is_dir() {
-            meta.local_path = Some(candidate);
-        }
+        self.cross_repo.resolve_local_path(id)
     }
 }
 
@@ -1738,7 +1761,7 @@ mod known_hosts_tests {
     fn known_hosts_dedups_multiple_repos_per_host() {
         let mut app = App::new(Config::default());
         for (owner, name) in [("a", "x"), ("b", "y"), ("c", "z")] {
-            app.repos.insert(
+            app.cross_repo.repos.insert(
                 RepoId {
                     host: None,
                     owner: owner.into(),
@@ -1761,7 +1784,7 @@ mod known_hosts_tests {
             (Some("ghe.example.com"), "team", "infra"),
             (Some("ghe.other.com"), "alice", "tools"),
         ] {
-            app.repos.insert(
+            app.cross_repo.repos.insert(
                 RepoId {
                     host: host.map(|s| s.to_string()),
                     owner: owner.into(),
@@ -1797,13 +1820,13 @@ mod resolve_local_path_tests {
         std::fs::create_dir_all(&host_dir).unwrap();
 
         let mut app = App::new(Config::default());
-        app.clone_root = Some(tmp.path().to_path_buf());
+        app.cross_repo.clone_root = Some(tmp.path().to_path_buf());
         let id = RepoId {
             host: None,
             owner: "owner".into(),
             name: "name".into(),
         };
-        app.repos.insert(
+        app.cross_repo.repos.insert(
             id.clone(),
             crate::git::types::RepoMeta {
                 local_path: None,
@@ -1811,7 +1834,7 @@ mod resolve_local_path_tests {
             },
         );
         app.resolve_local_path(&id);
-        let meta = app.repos.get(&id).unwrap();
+        let meta = app.cross_repo.repos.get(&id).unwrap();
         assert!(meta.local_path_resolved);
         assert_eq!(meta.local_path.as_ref().unwrap(), &host_dir);
     }
@@ -1822,13 +1845,13 @@ mod resolve_local_path_tests {
         use crate::git::types::RepoId;
         let tmp = tempfile::tempdir().unwrap();
         let mut app = App::new(Config::default());
-        app.clone_root = Some(tmp.path().to_path_buf());
+        app.cross_repo.clone_root = Some(tmp.path().to_path_buf());
         let id = RepoId {
             host: None,
             owner: "x".into(),
             name: "y".into(),
         };
-        app.repos.insert(
+        app.cross_repo.repos.insert(
             id.clone(),
             crate::git::types::RepoMeta {
                 local_path: None,
@@ -1836,7 +1859,7 @@ mod resolve_local_path_tests {
             },
         );
         app.resolve_local_path(&id);
-        let meta = app.repos.get(&id).unwrap();
+        let meta = app.cross_repo.repos.get(&id).unwrap();
         assert!(meta.local_path_resolved);
         assert!(meta.local_path.is_none());
     }
@@ -1863,7 +1886,7 @@ mod cursor_skip_tests {
             owner: "b".into(),
             name: "y".into(),
         };
-        app.active_repo = Some(active.clone());
+        app.cross_repo.active_repo = Some(active.clone());
         app.main_filter = MainFilter::ReviewRequested;
         let make_pr = |num: u64, head: &str, repo: &RepoId| PullRequest {
             number: num,
@@ -1935,7 +1958,7 @@ mod sidebar_rows_tests {
             owner: "b".into(),
             name: "r2".into(),
         };
-        app.active_repo = Some(active.clone());
+        app.cross_repo.active_repo = Some(active.clone());
         app.main_filter = MainFilter::ReviewRequested;
         let make_pr = |num: u64, head: &str, repo: &RepoId| PullRequest {
             number: num,
@@ -1992,7 +2015,7 @@ mod sidebar_rows_tests {
             owner: "a".into(),
             name: "r1".into(),
         };
-        app.active_repo = Some(active.clone());
+        app.cross_repo.active_repo = Some(active.clone());
         app.main_filter = MainFilter::ReviewRequested;
         let make_pr = |num: u64, head: &str| PullRequest {
             number: num,
@@ -2046,7 +2069,7 @@ mod sidebar_rows_tests {
             owner: "a".into(),
             name: "r1".into(),
         };
-        app.active_repo = Some(active.clone());
+        app.cross_repo.active_repo = Some(active.clone());
         app.main_filter = MainFilter::Local;
         // Local mode: filtered_entries requires has_local. Give entries a local branch.
         let make_branch = |name: &str| crate::git::types::Branch {
@@ -2154,8 +2177,8 @@ mod action_menu_cross_repo_tests {
             owner: "b".into(),
             name: "y".into(),
         };
-        app.active_repo = Some(active.clone());
-        app.repos.insert(
+        app.cross_repo.active_repo = Some(active.clone());
+        app.cross_repo.repos.insert(
             other.clone(),
             RepoMeta {
                 local_path: None,
@@ -2213,8 +2236,8 @@ mod action_menu_cross_repo_tests {
         let tmp = tempfile::tempdir().unwrap();
         let clone_path = tmp.path().join("github.com").join("b").join("y");
         std::fs::create_dir_all(&clone_path).unwrap();
-        app.active_repo = Some(active.clone());
-        app.repos.insert(
+        app.cross_repo.active_repo = Some(active.clone());
+        app.cross_repo.repos.insert(
             other.clone(),
             RepoMeta {
                 local_path: Some(clone_path),
@@ -2265,7 +2288,7 @@ mod action_menu_cross_repo_tests {
             owner: "b".into(),
             name: "y".into(),
         };
-        app.active_repo = Some(active);
+        app.cross_repo.active_repo = Some(active);
         app.entries = vec![BranchEntry {
             name: "feat".into(),
             repo_id: other.clone(),
@@ -2301,7 +2324,7 @@ mod action_menu_cross_repo_tests {
             owner: "other".into(),
             name: "y".into(),
         };
-        app.active_repo = Some(active.clone());
+        app.cross_repo.active_repo = Some(active.clone());
 
         // Active repo has a local branch called feature/auth
         let active_entry = BranchEntry {
@@ -2376,9 +2399,9 @@ mod wt_list_lazy_load_tests {
             owner: "b".into(),
             name: "y".into(),
         };
-        app.active_repo = Some(active);
-        app.clone_root = Some(tmp.path().to_path_buf());
-        app.repos.insert(
+        app.cross_repo.active_repo = Some(active);
+        app.cross_repo.clone_root = Some(tmp.path().to_path_buf());
+        app.cross_repo.repos.insert(
             other.clone(),
             RepoMeta {
                 local_path: None,
@@ -2425,7 +2448,7 @@ mod wt_list_lazy_load_tests {
             owner: "a".into(),
             name: "x".into(),
         };
-        app.active_repo = Some(active.clone());
+        app.cross_repo.active_repo = Some(active.clone());
         let make_branch = |name: &str| crate::git::types::Branch {
             name: name.into(),
             is_current: false,
@@ -2543,7 +2566,7 @@ mod command_queue_tests {
     fn app_with_pr_entries() -> App {
         use crate::git::types::RepoId;
         let mut app = App::new(Config::default());
-        app.active_repo = Some(RepoId {
+        app.cross_repo.active_repo = Some(RepoId {
             host: None,
             owner: "o".into(),
             name: "r".into(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -256,6 +256,16 @@ pub struct Inflight {
     pub wt_lists: HashSet<crate::git::types::RepoId>,
 }
 
+/// Modal/overlay UI state, listed in `handle_key` priority order (issue #220).
+#[derive(Default)]
+pub struct Overlays {
+    pub show_help: bool,
+    pub confirm_dialog: Option<PendingConfirm>,
+    pub action_menu: Option<ActionMenu>,
+    pub branch_create_input: Option<BranchCreateInput>,
+    pub notification: Option<Notification>,
+}
+
 /// Per-filter PR list caches keyed by `MainFilter`, their fetch parameters,
 /// and the PR-detail cache (issue #220).
 #[derive(Default)]
@@ -436,12 +446,8 @@ pub struct App {
     pub verbose: bool,
     pub verbose_errors: Vec<String>,
 
-    // Overlays
-    pub confirm_dialog: Option<PendingConfirm>,
-    pub action_menu: Option<ActionMenu>,
-    pub branch_create_input: Option<BranchCreateInput>,
-    pub notification: Option<Notification>,
-    pub show_help: bool,
+    // Modal/overlay UI state (issue #220).
+    pub overlays: Overlays,
 
     // Exit with cd path
     pub cd_path: Option<String>,
@@ -489,11 +495,7 @@ impl App {
             pr_detail_scroll: 0,
             verbose: false,
             verbose_errors: Vec::new(),
-            confirm_dialog: None,
-            action_menu: None,
-            branch_create_input: None,
-            notification: None,
-            show_help: false,
+            overlays: Overlays::default(),
             cd_path: None,
             commands: VecDeque::new(),
             selection_details_pending: false,
@@ -537,12 +539,12 @@ impl App {
         }
         // Don't auto-dismiss while a worktree operation is in progress
         if self.inflight.worktrees.is_empty()
-            && let Some(ref mut n) = self.notification
+            && let Some(ref mut n) = self.overlays.notification
         {
             if n.ticks_remaining > 0 {
                 n.ticks_remaining -= 1;
             } else {
-                self.notification = None;
+                self.overlays.notification = None;
             }
         }
     }
@@ -781,10 +783,10 @@ impl App {
 
     pub fn handle_key(&mut self, key: KeyEvent) {
         // Help overlay takes priority
-        if self.show_help {
+        if self.overlays.show_help {
             match key.code {
                 KeyCode::Esc | KeyCode::Char('q') | KeyCode::Char('?') => {
-                    self.show_help = false;
+                    self.overlays.show_help = false;
                 }
                 _ => {}
             }
@@ -792,19 +794,19 @@ impl App {
         }
 
         // Confirm dialog takes priority
-        if self.confirm_dialog.is_some() {
+        if self.overlays.confirm_dialog.is_some() {
             self.handle_confirm_key(key.code);
             return;
         }
 
         // Action menu takes priority
-        if self.action_menu.is_some() {
+        if self.overlays.action_menu.is_some() {
             self.handle_action_menu_key(key.code);
             return;
         }
 
         // Branch-create input modal takes priority
-        if self.branch_create_input.is_some() {
+        if self.overlays.branch_create_input.is_some() {
             self.handle_branch_create_input_key(key.code);
             return;
         }
@@ -816,7 +818,7 @@ impl App {
         }
 
         match key.code {
-            KeyCode::Char('?') => self.show_help = true,
+            KeyCode::Char('?') => self.overlays.show_help = true,
             KeyCode::Char('q') => {
                 if !self.progress.is_active() || self.quit_pressed_during_progress {
                     self.should_quit = true;
@@ -900,11 +902,11 @@ impl App {
                     // Signal branches/worktrees reload + PR fetch
                     self.push_command(Command::ReloadBranches);
                     self.push_command(Command::FetchPrs(self.main_filter));
-                    self.notification = Some(Notification::success("Refreshing…"));
+                    self.overlays.notification = Some(Notification::success("Refreshing…"));
                 }
                 ActiveView::Log => {
                     self.push_command(Command::ReloadCommits);
-                    self.notification = Some(Notification::success("Refreshing…"));
+                    self.overlays.notification = Some(Notification::success("Refreshing…"));
                 }
                 ActiveView::History => {
                     // History updates live as commands run — no manual refresh needed.
@@ -1013,7 +1015,7 @@ impl App {
                     // Snapshot the whole selection — the dispatcher re-filters
                     // (current/protected/inflight) at execution time.
                     let names: Vec<String> = self.branch_selected.iter().cloned().collect();
-                    self.confirm_dialog = Some(PendingConfirm {
+                    self.overlays.confirm_dialog = Some(PendingConfirm {
                         dialog: ConfirmDialog::new(title, msg),
                         on_confirm: Command::DeleteBranches(names),
                     });
@@ -1021,7 +1023,7 @@ impl App {
                     // Non-empty selection but nothing deletable (e.g. PR-only entries
                     // with no local branch and no worktree). Tell the user rather
                     // than silently no-op.
-                    self.notification = Some(Notification::error(
+                    self.overlays.notification = Some(Notification::error(
                         "Nothing to delete in selection".to_string(),
                     ));
                 } else if let Some(entry) = self.selected_entry().cloned()
@@ -1030,7 +1032,7 @@ impl App {
                     && !self.inflight.worktrees.contains(wt_path)
                 {
                     let path = wt_path.to_string();
-                    self.confirm_dialog = Some(PendingConfirm {
+                    self.overlays.confirm_dialog = Some(PendingConfirm {
                         dialog: ConfirmDialog::new(
                             "Delete Worktree",
                             format!("Remove worktree at {path}?"),
@@ -1061,7 +1063,7 @@ impl App {
                 };
                 let cross_repo_no_clone = !is_active && clone_path.is_none();
                 if cross_repo_no_clone {
-                    self.notification = Some(Notification::error(format!(
+                    self.overlays.notification = Some(Notification::error(format!(
                         "{} not cloned. Set [workspace] clone_root.",
                         entry.repo_id
                     )));
@@ -1087,7 +1089,8 @@ impl App {
                     entry.repo_id.clone(),
                     entry.name.clone(),
                 ));
-                self.notification = Some(Notification::success("Creating worktree...".to_string()));
+                self.overlays.notification =
+                    Some(Notification::success("Creating worktree...".to_string()));
             }
             KeyCode::Enter => {
                 self.open_action_menu();
@@ -1286,7 +1289,7 @@ impl App {
         }
 
         if !items.is_empty() {
-            self.action_menu = Some(ActionMenu {
+            self.overlays.action_menu = Some(ActionMenu {
                 items,
                 scroll: 0,
                 target: (entry.repo_id.clone(), entry.name.clone()),
@@ -1296,7 +1299,7 @@ impl App {
     }
 
     fn handle_action_menu_key(&mut self, code: KeyCode) {
-        let menu = match &mut self.action_menu {
+        let menu = match &mut self.overlays.action_menu {
             Some(m) => m,
             None => return,
         };
@@ -1310,11 +1313,11 @@ impl App {
             KeyCode::Enter => {
                 let action = menu.items[menu.scroll];
                 let (repo_id, branch_name) = menu.target.clone();
-                self.action_menu = None;
+                self.overlays.action_menu = None;
                 self.execute_action(action, &repo_id, &branch_name);
             }
             KeyCode::Esc => {
-                self.action_menu = None;
+                self.overlays.action_menu = None;
             }
             _ => {}
         }
@@ -1341,7 +1344,8 @@ impl App {
                     entry.repo_id.clone(),
                     entry.name.clone(),
                 ));
-                self.notification = Some(Notification::success("Creating worktree...".to_string()));
+                self.overlays.notification =
+                    Some(Notification::success("Creating worktree...".to_string()));
             }
             ActionItem::CdIntoWorktree => {
                 if let Some(path) = entry.worktree_path() {
@@ -1355,7 +1359,7 @@ impl App {
                     // Deleting via the action menu targets one worktree only —
                     // drop any checkbox selection so the sidebar reflects that.
                     self.branch_selected.clear();
-                    self.confirm_dialog = Some(PendingConfirm {
+                    self.overlays.confirm_dialog = Some(PendingConfirm {
                         dialog: ConfirmDialog::new(
                             "Delete Worktree",
                             format!("Remove worktree at {path}?"),
@@ -1365,7 +1369,7 @@ impl App {
                 }
             }
             ActionItem::CreateBranch => {
-                self.branch_create_input = Some(BranchCreateInput {
+                self.overlays.branch_create_input = Some(BranchCreateInput {
                     source: entry.name.clone(),
                     name: String::new(),
                     cursor: 0,
@@ -1379,7 +1383,7 @@ impl App {
                 } else {
                     format!("Delete branch {name}?")
                 };
-                self.confirm_dialog = Some(PendingConfirm {
+                self.overlays.confirm_dialog = Some(PendingConfirm {
                     dialog: ConfirmDialog::new("Delete Branch", msg),
                     on_confirm: Command::DeleteBranches(vec![name]),
                 });
@@ -1391,13 +1395,14 @@ impl App {
             }
             ActionItem::CopyBranchName => {
                 self.push_command(Command::CopyBranchName(entry.name.clone()));
-                self.notification = Some(Notification::success(format!("Copied: {}", entry.name)));
+                self.overlays.notification =
+                    Some(Notification::success(format!("Copied: {}", entry.name)));
             }
         }
     }
 
     fn handle_branch_create_input_key(&mut self, code: KeyCode) {
-        let input = match &mut self.branch_create_input {
+        let input = match &mut self.overlays.branch_create_input {
             Some(i) => i,
             None => return,
         };
@@ -1405,12 +1410,12 @@ impl App {
         input.cursor = input.cursor.min(char_len);
         match code {
             KeyCode::Esc => {
-                self.branch_create_input = None;
+                self.overlays.branch_create_input = None;
             }
             KeyCode::Enter if !input.name.is_empty() => {
                 let source = input.source.clone();
                 let name = input.name.clone();
-                self.branch_create_input = None;
+                self.overlays.branch_create_input = None;
                 self.push_command(Command::CreateBranch { source, name });
             }
             KeyCode::Left => {
@@ -1443,12 +1448,12 @@ impl App {
     fn handle_confirm_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('y') => {
-                if let Some(pending) = self.confirm_dialog.take() {
+                if let Some(pending) = self.overlays.confirm_dialog.take() {
                     self.push_command(pending.on_confirm);
                 }
             }
             KeyCode::Char('n') | KeyCode::Esc => {
-                if let Some(pending) = self.confirm_dialog.take()
+                if let Some(pending) = self.overlays.confirm_dialog.take()
                     && let Command::ForceDeleteWorktree(path) = pending.on_confirm
                 {
                     // Declining force-delete ends the op — release the path so
@@ -2241,7 +2246,7 @@ mod action_menu_cross_repo_tests {
         }];
         app.snap_scroll_to_entry();
         app.open_action_menu();
-        let menu = app.action_menu.as_ref().unwrap();
+        let menu = app.overlays.action_menu.as_ref().unwrap();
         assert!(menu.items.contains(&ActionItem::OpenPrInBrowser));
         assert!(menu.items.contains(&ActionItem::CopyBranchName));
         assert!(!menu.items.contains(&ActionItem::CreateWorktree));
@@ -2300,7 +2305,7 @@ mod action_menu_cross_repo_tests {
         }];
         app.snap_scroll_to_entry();
         app.open_action_menu();
-        let menu = app.action_menu.as_ref().unwrap();
+        let menu = app.overlays.action_menu.as_ref().unwrap();
         assert!(menu.items.contains(&ActionItem::CreateWorktree));
         assert!(menu.footer.is_none());
     }
@@ -2669,9 +2674,9 @@ mod command_queue_tests {
     #[test]
     fn confirm_y_pushes_on_confirm_and_closes_dialog() {
         let mut app = App::new(Config::default());
-        app.confirm_dialog = Some(pending(Command::DeleteWorktree("/wt/p".into())));
+        app.overlays.confirm_dialog = Some(pending(Command::DeleteWorktree("/wt/p".into())));
         app.handle_key(key(KeyCode::Char('y')));
-        assert!(app.confirm_dialog.is_none());
+        assert!(app.overlays.confirm_dialog.is_none());
         assert!(
             app.commands
                 .contains(&Command::DeleteWorktree("/wt/p".into()))
@@ -2681,9 +2686,9 @@ mod command_queue_tests {
     #[test]
     fn confirm_decline_pushes_nothing() {
         let mut app = App::new(Config::default());
-        app.confirm_dialog = Some(pending(Command::DeleteWorktree("/wt/p".into())));
+        app.overlays.confirm_dialog = Some(pending(Command::DeleteWorktree("/wt/p".into())));
         app.handle_key(key(KeyCode::Esc));
-        assert!(app.confirm_dialog.is_none());
+        assert!(app.overlays.confirm_dialog.is_none());
         assert!(app.commands.is_empty());
     }
 
@@ -2691,9 +2696,9 @@ mod command_queue_tests {
     fn confirm_decline_force_delete_releases_inflight_path() {
         let mut app = App::new(Config::default());
         app.inflight.worktrees.insert("/wt/p".to_string());
-        app.confirm_dialog = Some(pending(Command::ForceDeleteWorktree("/wt/p".into())));
+        app.overlays.confirm_dialog = Some(pending(Command::ForceDeleteWorktree("/wt/p".into())));
         app.handle_key(key(KeyCode::Char('n')));
-        assert!(app.confirm_dialog.is_none());
+        assert!(app.overlays.confirm_dialog.is_none());
         assert!(app.commands.is_empty());
         assert!(!app.inflight.worktrees.contains("/wt/p"));
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -256,6 +256,161 @@ pub struct Inflight {
     pub wt_lists: HashSet<crate::git::types::RepoId>,
 }
 
+/// What the user is looking at: the main-view entry list and its
+/// cursor/filter/search/multi-select state, plus the scroll positions of the
+/// other views (issue #220).
+#[derive(Default)]
+pub struct ViewState {
+    pub entries: Vec<BranchEntry>,
+    pub main_filter: MainFilter,
+    pub sidebar_scroll: usize,
+    pub sidebar_offset: usize,
+    pub search_active: bool,
+    pub search_query: String,
+    search_pre_scroll: usize, // saved scroll position before search
+    /// Branch names multi-selected in the sidebar (space / `a` keys).
+    pub branch_selected: HashSet<String>,
+    pub log_scroll: usize,
+    pub history_scroll: usize,
+    pub pr_detail_scroll: usize,
+}
+
+impl ViewState {
+    pub fn adjust_sidebar_offset(&mut self, visible_height: usize, item_count: usize) {
+        if visible_height == 0 {
+            return;
+        }
+        // Clamp scroll to valid range
+        if item_count > 0 {
+            self.sidebar_scroll = self.sidebar_scroll.min(item_count - 1);
+        } else {
+            self.sidebar_scroll = 0;
+        }
+        // Adjust offset when cursor exceeds viewport bounds
+        if self.sidebar_scroll >= self.sidebar_offset + visible_height {
+            self.sidebar_offset = self.sidebar_scroll - visible_height + 1;
+        }
+        if self.sidebar_scroll < self.sidebar_offset {
+            self.sidebar_offset = self.sidebar_scroll;
+        }
+        // Clamp offset so list doesn't show blank space
+        let max_offset = item_count.saturating_sub(visible_height);
+        self.sidebar_offset = self.sidebar_offset.min(max_offset);
+    }
+
+    pub fn filtered_entries(&self) -> Vec<&BranchEntry> {
+        let search_query = if !self.search_query.is_empty() {
+            Some(self.search_query.to_lowercase())
+        } else {
+            None
+        };
+        self.entries
+            .iter()
+            .filter(|entry| {
+                let passes_filter = match self.main_filter {
+                    MainFilter::Local => entry.has_local(),
+                    // My PR / Review: server-side filtered, just check PR exists
+                    MainFilter::MyPr | MainFilter::ReviewRequested => entry.pull_request.is_some(),
+                };
+                let passes_search = match &search_query {
+                    Some(q) => entry.name.to_lowercase().contains(q.as_str()),
+                    None => true,
+                };
+                passes_filter && passes_search
+            })
+            .collect()
+    }
+
+    /// Build the sidebar rendering rows. Returns a flat list of headers and
+    /// entries; cross-repo grouping kicks in only for My PR / Review when
+    /// `entries` span more than one repo.
+    pub fn sidebar_rows(&self) -> Vec<SidebarRow<'_>> {
+        let filtered = self.filtered_entries();
+        let group_active = matches!(
+            self.main_filter,
+            MainFilter::MyPr | MainFilter::ReviewRequested
+        );
+        let repo_set: std::collections::HashSet<_> =
+            filtered.iter().map(|e| e.repo_id.clone()).collect();
+        let do_group = group_active && repo_set.len() > 1;
+
+        let mut rows = Vec::with_capacity(filtered.len() + repo_set.len());
+        if !do_group {
+            for e in filtered {
+                rows.push(SidebarRow::Entry(e));
+            }
+            return rows;
+        }
+        let mut last_repo: Option<crate::git::types::RepoId> = None;
+        for e in filtered {
+            if last_repo.as_ref() != Some(&e.repo_id) {
+                rows.push(SidebarRow::Header {
+                    repo_id: e.repo_id.clone(),
+                });
+                last_repo = Some(e.repo_id.clone());
+            }
+            rows.push(SidebarRow::Entry(e));
+        }
+        rows
+    }
+
+    pub fn selected_entry(&self) -> Option<&BranchEntry> {
+        let rows = self.sidebar_rows();
+        match rows.get(self.sidebar_scroll)? {
+            SidebarRow::Entry(e) => Some(*e),
+            SidebarRow::Header { .. } => None,
+        }
+    }
+
+    /// If `sidebar_scroll` lands on a Header, advance to the next Entry. If past
+    /// the end, clamp to the last Entry. No-op if already on an Entry.
+    pub fn snap_scroll_to_entry(&mut self) {
+        // Collect row kinds into a plain bool vec (true = is_header) to avoid holding
+        // a borrow on self while mutating sidebar_scroll.
+        let is_header: Vec<bool> = self
+            .sidebar_rows()
+            .iter()
+            .map(|r| matches!(r, SidebarRow::Header { .. }))
+            .collect();
+        if is_header.is_empty() {
+            self.sidebar_scroll = 0;
+            return;
+        }
+        while self.sidebar_scroll < is_header.len() && is_header[self.sidebar_scroll] {
+            self.sidebar_scroll += 1;
+        }
+        if self.sidebar_scroll >= is_header.len() {
+            self.sidebar_scroll = is_header.len().saturating_sub(1);
+        }
+    }
+
+    /// Find the next entry-row index after `from`, skipping headers. None if no entry follows.
+    fn next_entry_index(&self, from: usize) -> Option<usize> {
+        let rows = self.sidebar_rows();
+        let mut next = from + 1;
+        while next < rows.len() && matches!(rows[next], SidebarRow::Header { .. }) {
+            next += 1;
+        }
+        if next < rows.len() { Some(next) } else { None }
+    }
+
+    /// Find the previous entry-row index before `from`, skipping headers. None if no entry precedes.
+    fn prev_entry_index(&self, from: usize) -> Option<usize> {
+        if from == 0 {
+            return None;
+        }
+        let rows = self.sidebar_rows();
+        let mut prev = from - 1;
+        while matches!(rows.get(prev), Some(SidebarRow::Header { .. })) {
+            if prev == 0 {
+                return None;
+            }
+            prev -= 1;
+        }
+        Some(prev)
+    }
+}
+
 /// Modal/overlay UI state, listed in `handle_key` priority order (issue #220).
 #[derive(Default)]
 pub struct Overlays {
@@ -418,29 +573,15 @@ pub struct App {
     pub active_view: ActiveView,
     pub should_quit: bool,
 
-    // Log View
-    pub log_scroll: usize,
-
-    // History View
-    pub history_scroll: usize,
-
-    // Main View — unified entries
-    pub entries: Vec<BranchEntry>,
-    pub main_filter: MainFilter,
-    pub sidebar_scroll: usize,
-    pub sidebar_offset: usize,
-    pub search_active: bool,
-    pub search_query: String,
-    search_pre_scroll: usize, // saved scroll position before search
+    // What the user is looking at: entry list, cursor/filter/search state,
+    // and per-view scroll positions (issue #220).
+    pub view: ViewState,
 
     // Raw data fetched from git/gh (issue #220).
     pub raw: RawData,
 
     // Per-filter PR caches and the PR-detail cache (issue #220).
     pub prs: PrCaches,
-
-    // Detail-pane scroll position.
-    pub pr_detail_scroll: usize,
 
     // Verbose mode
     pub verbose: bool,
@@ -464,7 +605,6 @@ pub struct App {
     pub inflight: Inflight,
     pub progress: ProgressTracker,
     pub quit_pressed_during_progress: bool,
-    pub branch_selected: HashSet<String>,
 
     // Spinner animation
     spinner_tick: usize,
@@ -481,18 +621,9 @@ impl App {
         Self {
             active_view: ActiveView::default(),
             should_quit: false,
-            log_scroll: 0,
-            history_scroll: 0,
-            entries: Vec::new(),
-            main_filter: MainFilter::default(),
-            sidebar_scroll: 0,
-            sidebar_offset: 0,
-            search_active: false,
-            search_query: String::new(),
-            search_pre_scroll: 0,
+            view: ViewState::default(),
             raw: RawData::default(),
             prs: PrCaches::default(),
-            pr_detail_scroll: 0,
             verbose: false,
             verbose_errors: Vec::new(),
             overlays: Overlays::default(),
@@ -502,7 +633,6 @@ impl App {
             inflight: Inflight::default(),
             progress: ProgressTracker::default(),
             quit_pressed_during_progress: false,
-            branch_selected: HashSet::new(),
             spinner_tick: 0,
             config,
             cross_repo: CrossRepoState::default(),
@@ -526,7 +656,7 @@ impl App {
     }
 
     pub fn current_prs(&self) -> &[PullRequest] {
-        self.prs.current(self.main_filter)
+        self.prs.current(self.view.main_filter)
     }
 
     const SPINNER_FRAMES: &'static [&'static str] =
@@ -554,29 +684,11 @@ impl App {
     }
 
     pub fn adjust_sidebar_offset(&mut self, visible_height: usize, item_count: usize) {
-        if visible_height == 0 {
-            return;
-        }
-        // Clamp scroll to valid range
-        if item_count > 0 {
-            self.sidebar_scroll = self.sidebar_scroll.min(item_count - 1);
-        } else {
-            self.sidebar_scroll = 0;
-        }
-        // Adjust offset when cursor exceeds viewport bounds
-        if self.sidebar_scroll >= self.sidebar_offset + visible_height {
-            self.sidebar_offset = self.sidebar_scroll - visible_height + 1;
-        }
-        if self.sidebar_scroll < self.sidebar_offset {
-            self.sidebar_offset = self.sidebar_scroll;
-        }
-        // Clamp offset so list doesn't show blank space
-        let max_offset = item_count.saturating_sub(visible_height);
-        self.sidebar_offset = self.sidebar_offset.min(max_offset);
+        self.view.adjust_sidebar_offset(visible_height, item_count)
     }
 
     pub fn is_current_view_loading(&self) -> bool {
-        self.prs.is_loading(self.main_filter)
+        self.prs.is_loading(self.view.main_filter)
     }
 
     pub fn rebuild_entries(&mut self) {
@@ -585,7 +697,7 @@ impl App {
         // so cross-repo entries are still keyed correctly and worktree injection no-ops
         // safely.
         let active = self.cross_repo.active_repo.clone().unwrap_or_default();
-        self.entries = crate::data::merge_entries(
+        self.view.entries = crate::data::merge_entries(
             &active,
             &self.raw.branches,
             &self.raw.worktrees,
@@ -599,121 +711,25 @@ impl App {
     pub fn rebuild_entries_and_clamp(&mut self) {
         self.rebuild_entries();
         let filtered_len = self.filtered_entries().len();
-        if self.sidebar_scroll >= filtered_len && filtered_len > 0 {
-            self.sidebar_scroll = filtered_len - 1;
+        if self.view.sidebar_scroll >= filtered_len && filtered_len > 0 {
+            self.view.sidebar_scroll = filtered_len - 1;
         }
     }
 
     pub fn filtered_entries(&self) -> Vec<&BranchEntry> {
-        let search_query = if !self.search_query.is_empty() {
-            Some(self.search_query.to_lowercase())
-        } else {
-            None
-        };
-        self.entries
-            .iter()
-            .filter(|entry| {
-                let passes_filter = match self.main_filter {
-                    MainFilter::Local => entry.has_local(),
-                    // My PR / Review: server-side filtered, just check PR exists
-                    MainFilter::MyPr | MainFilter::ReviewRequested => entry.pull_request.is_some(),
-                };
-                let passes_search = match &search_query {
-                    Some(q) => entry.name.to_lowercase().contains(q.as_str()),
-                    None => true,
-                };
-                passes_filter && passes_search
-            })
-            .collect()
+        self.view.filtered_entries()
     }
 
-    /// Build the sidebar rendering rows. Returns a flat list of headers and
-    /// entries; cross-repo grouping kicks in only for My PR / Review when
-    /// `entries` span more than one repo.
     pub fn sidebar_rows(&self) -> Vec<SidebarRow<'_>> {
-        let filtered = self.filtered_entries();
-        let group_active = matches!(
-            self.main_filter,
-            MainFilter::MyPr | MainFilter::ReviewRequested
-        );
-        let repo_set: std::collections::HashSet<_> =
-            filtered.iter().map(|e| e.repo_id.clone()).collect();
-        let do_group = group_active && repo_set.len() > 1;
-
-        let mut rows = Vec::with_capacity(filtered.len() + repo_set.len());
-        if !do_group {
-            for e in filtered {
-                rows.push(SidebarRow::Entry(e));
-            }
-            return rows;
-        }
-        let mut last_repo: Option<crate::git::types::RepoId> = None;
-        for e in filtered {
-            if last_repo.as_ref() != Some(&e.repo_id) {
-                rows.push(SidebarRow::Header {
-                    repo_id: e.repo_id.clone(),
-                });
-                last_repo = Some(e.repo_id.clone());
-            }
-            rows.push(SidebarRow::Entry(e));
-        }
-        rows
+        self.view.sidebar_rows()
     }
 
     pub fn selected_entry(&self) -> Option<&BranchEntry> {
-        let rows = self.sidebar_rows();
-        match rows.get(self.sidebar_scroll)? {
-            SidebarRow::Entry(e) => Some(*e),
-            SidebarRow::Header { .. } => None,
-        }
+        self.view.selected_entry()
     }
 
-    /// If `sidebar_scroll` lands on a Header, advance to the next Entry. If past
-    /// the end, clamp to the last Entry. No-op if already on an Entry.
     pub fn snap_scroll_to_entry(&mut self) {
-        // Collect row kinds into a plain bool vec (true = is_header) to avoid holding
-        // a borrow on self while mutating sidebar_scroll.
-        let is_header: Vec<bool> = self
-            .sidebar_rows()
-            .iter()
-            .map(|r| matches!(r, SidebarRow::Header { .. }))
-            .collect();
-        if is_header.is_empty() {
-            self.sidebar_scroll = 0;
-            return;
-        }
-        while self.sidebar_scroll < is_header.len() && is_header[self.sidebar_scroll] {
-            self.sidebar_scroll += 1;
-        }
-        if self.sidebar_scroll >= is_header.len() {
-            self.sidebar_scroll = is_header.len().saturating_sub(1);
-        }
-    }
-
-    /// Find the next entry-row index after `from`, skipping headers. None if no entry follows.
-    fn next_entry_index(&self, from: usize) -> Option<usize> {
-        let rows = self.sidebar_rows();
-        let mut next = from + 1;
-        while next < rows.len() && matches!(rows[next], SidebarRow::Header { .. }) {
-            next += 1;
-        }
-        if next < rows.len() { Some(next) } else { None }
-    }
-
-    /// Find the previous entry-row index before `from`, skipping headers. None if no entry precedes.
-    fn prev_entry_index(&self, from: usize) -> Option<usize> {
-        if from == 0 {
-            return None;
-        }
-        let rows = self.sidebar_rows();
-        let mut prev = from - 1;
-        while matches!(rows.get(prev), Some(SidebarRow::Header { .. })) {
-            if prev == 0 {
-                return None;
-            }
-            prev -= 1;
-        }
-        Some(prev)
+        self.view.snap_scroll_to_entry()
     }
 
     /// Return the cached PR detail for the currently selected entry, if available.
@@ -729,7 +745,7 @@ impl App {
     /// fetch for the final selection ~80ms after scrolling settles, instead
     /// of spawning a `gh`/`git` subprocess per row passed through.
     pub fn request_details_for_selection(&mut self) {
-        self.pr_detail_scroll = 0;
+        self.view.pr_detail_scroll = 0;
         self.selection_details_pending = true;
     }
 
@@ -812,7 +828,7 @@ impl App {
         }
 
         // Search mode takes priority in Main view
-        if self.search_active && self.active_view == ActiveView::Main {
+        if self.view.search_active && self.active_view == ActiveView::Main {
             self.handle_search_key(key.code);
             return;
         }
@@ -827,11 +843,11 @@ impl App {
                 }
             }
             KeyCode::Esc => {
-                if !self.search_query.is_empty() {
+                if !self.view.search_query.is_empty() {
                     // Clear search filter and restore scroll
-                    self.search_query.clear();
-                    self.sidebar_scroll = self.search_pre_scroll;
-                    self.sidebar_offset = 0;
+                    self.view.search_query.clear();
+                    self.view.sidebar_scroll = self.view.search_pre_scroll;
+                    self.view.sidebar_offset = 0;
                     self.snap_scroll_to_entry();
                     self.request_details_for_selection();
                 } else if matches!(self.active_view, ActiveView::Log | ActiveView::History) {
@@ -846,15 +862,15 @@ impl App {
             KeyCode::Char('h') => {
                 if self.active_view != ActiveView::History {
                     self.active_view = ActiveView::History;
-                    self.history_scroll = 0;
+                    self.view.history_scroll = 0;
                 }
             }
             KeyCode::Char('1') => {
-                self.main_filter = MainFilter::Local;
+                self.view.main_filter = MainFilter::Local;
                 self.active_view = ActiveView::Main;
-                self.search_query.clear();
-                self.sidebar_scroll = 0;
-                self.sidebar_offset = 0;
+                self.view.search_query.clear();
+                self.view.sidebar_scroll = 0;
+                self.view.sidebar_offset = 0;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.prs.local_loaded {
@@ -863,11 +879,11 @@ impl App {
                 self.request_details_for_selection();
             }
             KeyCode::Char('2') => {
-                self.main_filter = MainFilter::MyPr;
+                self.view.main_filter = MainFilter::MyPr;
                 self.active_view = ActiveView::Main;
-                self.search_query.clear();
-                self.sidebar_scroll = 0;
-                self.sidebar_offset = 0;
+                self.view.search_query.clear();
+                self.view.sidebar_scroll = 0;
+                self.view.sidebar_offset = 0;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.prs.my_loaded {
@@ -876,11 +892,11 @@ impl App {
                 self.request_details_for_selection();
             }
             KeyCode::Char('3') => {
-                self.main_filter = MainFilter::ReviewRequested;
+                self.view.main_filter = MainFilter::ReviewRequested;
                 self.active_view = ActiveView::Main;
-                self.search_query.clear();
-                self.sidebar_scroll = 0;
-                self.sidebar_offset = 0;
+                self.view.search_query.clear();
+                self.view.sidebar_scroll = 0;
+                self.view.sidebar_offset = 0;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.prs.review_loaded {
@@ -891,7 +907,7 @@ impl App {
             KeyCode::Char('r') => match self.active_view {
                 ActiveView::Main => {
                     // Invalidate current filter's PR cache so the fetch is forced
-                    self.prs.invalidate(self.main_filter);
+                    self.prs.invalidate(self.view.main_filter);
                     // Clear PR detail cache for ALL filters, not just the current
                     // one — stale detail bodies are risky after a refresh, and the
                     // detail pane will refetch on the next selection.
@@ -901,7 +917,7 @@ impl App {
                     self.inflight.wt_lists.clear();
                     // Signal branches/worktrees reload + PR fetch
                     self.push_command(Command::ReloadBranches);
-                    self.push_command(Command::FetchPrs(self.main_filter));
+                    self.push_command(Command::FetchPrs(self.view.main_filter));
                     self.overlays.notification = Some(Notification::success("Refreshing…"));
                 }
                 ActiveView::Log => {
@@ -923,14 +939,14 @@ impl App {
     fn handle_main_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Char('j') | KeyCode::Down => {
-                if let Some(next) = self.next_entry_index(self.sidebar_scroll) {
-                    self.sidebar_scroll = next;
+                if let Some(next) = self.view.next_entry_index(self.view.sidebar_scroll) {
+                    self.view.sidebar_scroll = next;
                     self.request_details_for_selection();
                 }
             }
-            KeyCode::Char('k') | KeyCode::Up if self.sidebar_scroll > 0 => {
-                if let Some(prev) = self.prev_entry_index(self.sidebar_scroll) {
-                    self.sidebar_scroll = prev;
+            KeyCode::Char('k') | KeyCode::Up if self.view.sidebar_scroll > 0 => {
+                if let Some(prev) = self.view.prev_entry_index(self.view.sidebar_scroll) {
+                    self.view.sidebar_scroll = prev;
                     self.request_details_for_selection();
                 }
             }
@@ -940,15 +956,16 @@ impl App {
                     && !self.is_protected_branch(&entry.name)
                     && self.cross_repo.active_repo.as_ref() == Some(&entry.repo_id)
                 {
-                    if self.branch_selected.contains(&entry.name) {
-                        self.branch_selected.remove(&entry.name);
+                    if self.view.branch_selected.contains(&entry.name) {
+                        self.view.branch_selected.remove(&entry.name);
                     } else {
-                        self.branch_selected.insert(entry.name);
+                        self.view.branch_selected.insert(entry.name);
                     }
                 }
             }
             KeyCode::Char('a') => {
                 let to_select: Vec<String> = self
+                    .view
                     .entries
                     .iter()
                     .filter(|e| {
@@ -959,7 +976,7 @@ impl App {
                     })
                     .map(|e| e.name.clone())
                     .collect();
-                self.branch_selected.extend(to_select);
+                self.view.branch_selected.extend(to_select);
             }
             KeyCode::Char('d') => {
                 // Only entries that will actually be processed (i.e. have a
@@ -970,9 +987,9 @@ impl App {
                 let mut worktree_count = 0usize;
                 let mut unmerged_count = 0usize;
                 let mut deletable_names: Vec<&str> = Vec::new();
-                if !self.branch_selected.is_empty() {
-                    for name in &self.branch_selected {
-                        if let Some(entry) = self.entries.iter().find(|e| &e.name == name) {
+                if !self.view.branch_selected.is_empty() {
+                    for name in &self.view.branch_selected {
+                        if let Some(entry) = self.view.entries.iter().find(|e| &e.name == name) {
                             let has_branch = entry.local_branch.is_some();
                             let has_worktree = entry.worktree.is_some();
                             if !has_branch && !has_worktree {
@@ -1014,12 +1031,12 @@ impl App {
                     };
                     // Snapshot the whole selection — the dispatcher re-filters
                     // (current/protected/inflight) at execution time.
-                    let names: Vec<String> = self.branch_selected.iter().cloned().collect();
+                    let names: Vec<String> = self.view.branch_selected.iter().cloned().collect();
                     self.overlays.confirm_dialog = Some(PendingConfirm {
                         dialog: ConfirmDialog::new(title, msg),
                         on_confirm: Command::DeleteBranches(names),
                     });
-                } else if !self.branch_selected.is_empty() {
+                } else if !self.view.branch_selected.is_empty() {
                     // Non-empty selection but nothing deletable (e.g. PR-only entries
                     // with no local branch and no worktree). Tell the user rather
                     // than silently no-op.
@@ -1097,7 +1114,7 @@ impl App {
             }
             KeyCode::Char('m') => {
                 if matches!(
-                    self.main_filter,
+                    self.view.main_filter,
                     MainFilter::MyPr | MainFilter::ReviewRequested
                 ) {
                     self.prs.show_merged = !self.prs.show_merged;
@@ -1105,25 +1122,25 @@ impl App {
                     self.prs.invalidate(MainFilter::MyPr);
                     self.prs.invalidate(MainFilter::ReviewRequested);
                     self.rebuild_entries();
-                    self.push_command(Command::FetchPrs(self.main_filter));
-                    self.sidebar_scroll = 0;
-                    self.sidebar_offset = 0;
+                    self.push_command(Command::FetchPrs(self.view.main_filter));
+                    self.view.sidebar_scroll = 0;
+                    self.view.sidebar_offset = 0;
                     self.snap_scroll_to_entry();
                 }
             }
-            KeyCode::Char('t') if self.main_filter == MainFilter::ReviewRequested => {
+            KeyCode::Char('t') if self.view.main_filter == MainFilter::ReviewRequested => {
                 self.prs.include_team_reviews = !self.prs.include_team_reviews;
                 self.prs.invalidate(MainFilter::ReviewRequested);
                 self.rebuild_entries();
                 self.push_command(Command::FetchPrs(MainFilter::ReviewRequested));
-                self.sidebar_scroll = 0;
-                self.sidebar_offset = 0;
+                self.view.sidebar_scroll = 0;
+                self.view.sidebar_offset = 0;
                 self.snap_scroll_to_entry();
             }
             KeyCode::Char('/') => {
-                self.search_pre_scroll = self.sidebar_scroll;
-                self.search_active = true;
-                self.search_query.clear();
+                self.view.search_pre_scroll = self.view.sidebar_scroll;
+                self.view.search_active = true;
+                self.view.search_query.clear();
             }
             _ => {}
         }
@@ -1131,11 +1148,13 @@ impl App {
 
     fn handle_log_key(&mut self, code: KeyCode) {
         match code {
-            KeyCode::Char('j') | KeyCode::Down if self.log_scroll + 1 < self.raw.commits.len() => {
-                self.log_scroll += 1;
+            KeyCode::Char('j') | KeyCode::Down
+                if self.view.log_scroll + 1 < self.raw.commits.len() =>
+            {
+                self.view.log_scroll += 1;
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.log_scroll = self.log_scroll.saturating_sub(1);
+                self.view.log_scroll = self.view.log_scroll.saturating_sub(1);
             }
             _ => {}
         }
@@ -1144,11 +1163,11 @@ impl App {
     fn handle_history_key(&mut self, code: KeyCode) {
         let len = crate::git::command::command_history_len();
         match code {
-            KeyCode::Char('j') | KeyCode::Down if len > 0 && self.history_scroll + 1 < len => {
-                self.history_scroll += 1;
+            KeyCode::Char('j') | KeyCode::Down if len > 0 && self.view.history_scroll + 1 < len => {
+                self.view.history_scroll += 1;
             }
             KeyCode::Char('k') | KeyCode::Up => {
-                self.history_scroll = self.history_scroll.saturating_sub(1);
+                self.view.history_scroll = self.view.history_scroll.saturating_sub(1);
             }
             _ => {}
         }
@@ -1157,40 +1176,40 @@ impl App {
     fn handle_search_key(&mut self, code: KeyCode) {
         match code {
             KeyCode::Esc => {
-                self.search_active = false;
-                self.search_query.clear();
-                self.sidebar_scroll = self.search_pre_scroll;
+                self.view.search_active = false;
+                self.view.search_query.clear();
+                self.view.sidebar_scroll = self.view.search_pre_scroll;
                 self.snap_scroll_to_entry();
                 self.request_details_for_selection();
             }
             KeyCode::Enter => {
-                self.search_active = false;
+                self.view.search_active = false;
                 self.request_details_for_selection();
                 self.open_action_menu();
             }
             KeyCode::Backspace => {
-                self.search_query.pop();
-                self.sidebar_scroll = 0;
-                self.sidebar_offset = 0;
+                self.view.search_query.pop();
+                self.view.sidebar_scroll = 0;
+                self.view.sidebar_offset = 0;
                 self.snap_scroll_to_entry();
                 self.request_details_for_selection();
             }
             KeyCode::Char(c) => {
-                self.search_query.push(c);
-                self.sidebar_scroll = 0;
-                self.sidebar_offset = 0;
+                self.view.search_query.push(c);
+                self.view.sidebar_scroll = 0;
+                self.view.sidebar_offset = 0;
                 self.snap_scroll_to_entry();
                 self.request_details_for_selection();
             }
             KeyCode::Down => {
-                if let Some(next) = self.next_entry_index(self.sidebar_scroll) {
-                    self.sidebar_scroll = next;
+                if let Some(next) = self.view.next_entry_index(self.view.sidebar_scroll) {
+                    self.view.sidebar_scroll = next;
                     self.request_details_for_selection();
                 }
             }
-            KeyCode::Up if self.sidebar_scroll > 0 => {
-                if let Some(prev) = self.prev_entry_index(self.sidebar_scroll) {
-                    self.sidebar_scroll = prev;
+            KeyCode::Up if self.view.sidebar_scroll > 0 => {
+                if let Some(prev) = self.view.prev_entry_index(self.view.sidebar_scroll) {
+                    self.view.sidebar_scroll = prev;
                     self.request_details_for_selection();
                 }
             }
@@ -1330,6 +1349,7 @@ impl App {
         name: &str,
     ) {
         let entry = match self
+            .view
             .entries
             .iter()
             .find(|e| e.repo_id == *repo_id && e.name == name)
@@ -1358,7 +1378,7 @@ impl App {
                     let path = wt_path.to_string();
                     // Deleting via the action menu targets one worktree only —
                     // drop any checkbox selection so the sidebar reflects that.
-                    self.branch_selected.clear();
+                    self.view.branch_selected.clear();
                     self.overlays.confirm_dialog = Some(PendingConfirm {
                         dialog: ConfirmDialog::new(
                             "Delete Worktree",
@@ -1925,7 +1945,7 @@ mod cursor_skip_tests {
             name: "y".into(),
         };
         app.cross_repo.active_repo = Some(active.clone());
-        app.main_filter = MainFilter::ReviewRequested;
+        app.view.main_filter = MainFilter::ReviewRequested;
         let make_pr = |num: u64, head: &str, repo: &RepoId| PullRequest {
             number: num,
             title: "t".into(),
@@ -1939,7 +1959,7 @@ mod cursor_skip_tests {
             review_status: None,
             repo_id: repo.clone(),
         };
-        app.entries = vec![
+        app.view.entries = vec![
             BranchEntry {
                 name: "e1".into(),
                 repo_id: active.clone(),
@@ -1960,19 +1980,25 @@ mod cursor_skip_tests {
         // rows = [Header(active), Entry(e1), Header(other), Entry(e2)] → indices 0..=3
         // Initial: snap to first Entry (= 1)
         app.snap_scroll_to_entry();
-        assert_eq!(app.sidebar_scroll, 1);
+        assert_eq!(app.view.sidebar_scroll, 1);
 
         // j → should jump from index 1 to index 3 (skip Header at index 2)
         app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
         let rows = app.sidebar_rows();
-        assert_eq!(app.sidebar_scroll, 3);
-        assert!(matches!(rows[app.sidebar_scroll], SidebarRow::Entry(_)));
+        assert_eq!(app.view.sidebar_scroll, 3);
+        assert!(matches!(
+            rows[app.view.sidebar_scroll],
+            SidebarRow::Entry(_)
+        ));
 
         // k → should jump back from 3 to 1
         app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
         let rows = app.sidebar_rows();
-        assert_eq!(app.sidebar_scroll, 1);
-        assert!(matches!(rows[app.sidebar_scroll], SidebarRow::Entry(_)));
+        assert_eq!(app.view.sidebar_scroll, 1);
+        assert!(matches!(
+            rows[app.view.sidebar_scroll],
+            SidebarRow::Entry(_)
+        ));
     }
 }
 
@@ -1997,7 +2023,7 @@ mod sidebar_rows_tests {
             name: "r2".into(),
         };
         app.cross_repo.active_repo = Some(active.clone());
-        app.main_filter = MainFilter::ReviewRequested;
+        app.view.main_filter = MainFilter::ReviewRequested;
         let make_pr = |num: u64, head: &str, repo: &RepoId| PullRequest {
             number: num,
             title: "x".into(),
@@ -2011,7 +2037,7 @@ mod sidebar_rows_tests {
             review_status: None,
             repo_id: repo.clone(),
         };
-        app.entries = vec![
+        app.view.entries = vec![
             BranchEntry {
                 name: "f1".into(),
                 repo_id: active.clone(),
@@ -2054,7 +2080,7 @@ mod sidebar_rows_tests {
             name: "r1".into(),
         };
         app.cross_repo.active_repo = Some(active.clone());
-        app.main_filter = MainFilter::ReviewRequested;
+        app.view.main_filter = MainFilter::ReviewRequested;
         let make_pr = |num: u64, head: &str| PullRequest {
             number: num,
             title: "x".into(),
@@ -2068,7 +2094,7 @@ mod sidebar_rows_tests {
             review_status: None,
             repo_id: active.clone(),
         };
-        app.entries = vec![
+        app.view.entries = vec![
             BranchEntry {
                 name: "f1".into(),
                 repo_id: active.clone(),
@@ -2108,7 +2134,7 @@ mod sidebar_rows_tests {
             name: "r1".into(),
         };
         app.cross_repo.active_repo = Some(active.clone());
-        app.main_filter = MainFilter::Local;
+        app.view.main_filter = MainFilter::Local;
         // Local mode: filtered_entries requires has_local. Give entries a local branch.
         let make_branch = |name: &str| crate::git::types::Branch {
             name: name.into(),
@@ -2116,7 +2142,7 @@ mod sidebar_rows_tests {
             upstream: None,
             is_merged: false,
         };
-        app.entries = vec![BranchEntry {
+        app.view.entries = vec![BranchEntry {
             name: "f1".into(),
             repo_id: active.clone(),
             local_branch: Some(make_branch("f1")),
@@ -2223,8 +2249,8 @@ mod action_menu_cross_repo_tests {
                 local_path_resolved: true,
             },
         );
-        app.main_filter = MainFilter::ReviewRequested;
-        app.entries = vec![BranchEntry {
+        app.view.main_filter = MainFilter::ReviewRequested;
+        app.view.entries = vec![BranchEntry {
             name: "feat".into(),
             repo_id: other.clone(),
             local_branch: None,
@@ -2282,8 +2308,8 @@ mod action_menu_cross_repo_tests {
                 local_path_resolved: true,
             },
         );
-        app.main_filter = MainFilter::ReviewRequested;
-        app.entries = vec![BranchEntry {
+        app.view.main_filter = MainFilter::ReviewRequested;
+        app.view.entries = vec![BranchEntry {
             name: "feat".into(),
             repo_id: other.clone(),
             local_branch: None,
@@ -2327,7 +2353,7 @@ mod action_menu_cross_repo_tests {
             name: "y".into(),
         };
         app.cross_repo.active_repo = Some(active);
-        app.entries = vec![BranchEntry {
+        app.view.entries = vec![BranchEntry {
             name: "feat".into(),
             repo_id: other.clone(),
             local_branch: None,
@@ -2405,7 +2431,7 @@ mod action_menu_cross_repo_tests {
             git_status: None,
         };
         // Active repo first per merge_entries sort
-        app.entries = vec![active_entry, cross_entry];
+        app.view.entries = vec![active_entry, cross_entry];
 
         // Dispatch CdIntoWorktree targeting cross-repo branch.
         // The tuple-based execute_action must NOT pick the active-repo entry.
@@ -2446,8 +2472,8 @@ mod wt_list_lazy_load_tests {
                 local_path_resolved: false,
             },
         );
-        app.main_filter = MainFilter::ReviewRequested;
-        app.entries = vec![BranchEntry {
+        app.view.main_filter = MainFilter::ReviewRequested;
+        app.view.entries = vec![BranchEntry {
             name: "feat".into(),
             repo_id: other.clone(),
             local_branch: None,
@@ -2493,7 +2519,7 @@ mod wt_list_lazy_load_tests {
             upstream: None,
             is_merged: false,
         };
-        app.entries = vec![BranchEntry {
+        app.view.entries = vec![BranchEntry {
             name: "feat".into(),
             repo_id: active.clone(),
             local_branch: Some(make_branch("feat")),
@@ -2609,7 +2635,7 @@ mod command_queue_tests {
             owner: "o".into(),
             name: "r".into(),
         });
-        app.entries = vec![pr_entry("a", 1), pr_entry("b", 2)];
+        app.view.entries = vec![pr_entry("a", 1), pr_entry("b", 2)];
         app
     }
 
@@ -2631,7 +2657,7 @@ mod command_queue_tests {
         let mut app = app_with_pr_entries();
         // Two selection changes before any tick — like holding `j`.
         app.request_details_for_selection();
-        app.sidebar_scroll = 1;
+        app.view.sidebar_scroll = 1;
         app.request_details_for_selection();
         app.tick();
         let fetches: Vec<u64> = app
@@ -2649,7 +2675,7 @@ mod command_queue_tests {
     fn cached_detail_queues_no_fetch_after_tick() {
         use crate::git::types::PrDetail;
         let mut app = app_with_pr_entries();
-        let repo = app.entries[0].repo_id.clone();
+        let repo = app.view.entries[0].repo_id.clone();
         app.prs.detail.insert(
             (repo, 1),
             PrDetail {

--- a/src/main.rs
+++ b/src/main.rs
@@ -795,7 +795,7 @@ async fn startup(
         } else {
             String::new()
         };
-        app.notification = Some(Notification::error(format!(
+        app.overlays.notification = Some(Notification::error(format!(
             "Config warning: {first}{suffix}"
         )));
         app.verbose_errors
@@ -929,7 +929,8 @@ fn handle_result(app: &mut App, result: AsyncResult) {
             error,
         } => {
             app.inflight.pr_detail.remove(&(repo_id, number));
-            app.notification = Some(Notification::error(format!("Failed to load PR #{number}")));
+            app.overlays.notification =
+                Some(Notification::error(format!("Failed to load PR #{number}")));
             app.record_error(error);
         }
         AsyncResult::GitStatus { wt_path, status } => {
@@ -945,7 +946,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         AsyncResult::GitStatusError(wt_path) => {
             app.inflight.git_status.remove(&wt_path);
             let msg = format!("git status failed for {wt_path}");
-            app.notification = Some(Notification::error(msg.clone()));
+            app.overlays.notification = Some(Notification::error(msg.clone()));
             app.record_error(msg);
         }
         AsyncResult::UserLogin(user) => {
@@ -960,7 +961,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         }
         AsyncResult::UserLoginError(error_msg) => {
             app.raw.gh_user_load_failed = true;
-            app.notification = Some(Notification::error(
+            app.overlays.notification = Some(Notification::error(
                 "Failed to load GitHub user — is `gh` authenticated?".to_string(),
             ));
             app.record_error(error_msg);
@@ -981,11 +982,11 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         } => {
             app.inflight.worktrees.remove(&wt_path);
             if copy_errors.is_empty() {
-                app.notification = Some(Notification::success(format!(
+                app.overlays.notification = Some(Notification::success(format!(
                     "Worktree created: {wt_path}"
                 )));
             } else {
-                app.notification = Some(Notification::success(format!(
+                app.overlays.notification = Some(Notification::success(format!(
                     "Worktree created: {wt_path} (copy errors: {})",
                     copy_errors.len()
                 )));
@@ -998,8 +999,8 @@ fn handle_result(app: &mut App, result: AsyncResult) {
             if let Some(repo_id) = target_repo {
                 app.cross_repo.wt_lists_per_repo.remove(&repo_id);
             }
-            if app.confirm_dialog.is_none() {
-                app.confirm_dialog = Some(crate::app::PendingConfirm {
+            if app.overlays.confirm_dialog.is_none() {
+                app.overlays.confirm_dialog = Some(crate::app::PendingConfirm {
                     dialog: crate::ui::confirm_dialog::ConfirmDialog::new(
                         "Move to Worktree",
                         format!(
@@ -1012,7 +1013,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         }
         AsyncResult::WtCreateError { wt_path, message } => {
             app.inflight.worktrees.remove(&wt_path);
-            app.notification = Some(Notification::error(message));
+            app.overlays.notification = Some(Notification::error(message));
         }
         AsyncResult::OpStarted { op_id, label } => {
             app.progress.insert(op_id, OpProgress::new(label));
@@ -1048,7 +1049,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
                 } else {
                     format!("Deleted {}", success_parts.join(", "))
                 };
-                app.notification = Some(Notification::success(msg));
+                app.overlays.notification = Some(Notification::success(msg));
             } else {
                 let short: Vec<String> = failures
                     .iter()
@@ -1063,7 +1064,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
                         short.join("; ")
                     )
                 };
-                app.notification = Some(Notification::error(summary));
+                app.overlays.notification = Some(Notification::error(summary));
                 for err in failures {
                     app.record_error(err);
                 }
@@ -1074,7 +1075,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         }
         AsyncResult::WtForceDecisionRequested { path, reason } => {
             // Plain remove failed; ask the user whether to force.
-            app.confirm_dialog = Some(crate::app::PendingConfirm {
+            app.overlays.confirm_dialog = Some(crate::app::PendingConfirm {
                 dialog: crate::ui::confirm_dialog::ConfirmDialog::new(
                     "Force Delete Worktree",
                     format!("{reason}\nForce remove {path}?"),
@@ -1107,14 +1108,14 @@ fn handle_result(app: &mut App, result: AsyncResult) {
             }
         }
         AsyncResult::BranchCreated { name, source } => {
-            app.notification = Some(Notification::success(format!(
+            app.overlays.notification = Some(Notification::success(format!(
                 "Created branch '{name}' from '{source}'"
             )));
             app.push_command(Command::ReloadBranches);
         }
         AsyncResult::BranchCreateError(err_str) => {
             let short = err_str.lines().next().unwrap_or(&err_str).to_string();
-            app.notification = Some(Notification::error(short));
+            app.overlays.notification = Some(Notification::error(short));
             app.record_error(err_str);
         }
     }
@@ -1240,7 +1241,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
                 Some(p) => p,
                 None if is_active => std::env::current_dir().unwrap_or_default(),
                 None => {
-                    app.notification =
+                    app.overlays.notification =
                         Some(Notification::error(format!("{target_repo} not cloned")));
                     return;
                 }
@@ -1357,7 +1358,8 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
             }
 
             if work.is_empty() {
-                app.notification = Some(Notification::error("Nothing to delete".to_string()));
+                app.overlays.notification =
+                    Some(Notification::error("Nothing to delete".to_string()));
             } else {
                 let ids: Vec<u64> = app.progress.allocate_ids(work.len()).collect();
                 let mut set: JoinSet<DeleteOpResult> = JoinSet::new();
@@ -1645,7 +1647,7 @@ fn report_fetch_errors(app: &mut App, context: &str, errors: Vec<String>) {
         String::new()
     };
     let toast = format!("{context}: {first}{suffix}");
-    app.notification = Some(Notification::error(toast));
+    app.overlays.notification = Some(Notification::error(toast));
     for e in errors {
         app.record_error(e);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -833,10 +833,10 @@ async fn startup(
 
     // Phase 1: Fast local loads (blocking, ~170ms)
     if let Ok(output) = run_git(LOG_ARGS).await {
-        app.commits = parse_log(&output);
+        app.raw.commits = parse_log(&output);
     }
     if let Ok(output) = run_git(&["worktree", "list", "--porcelain"]).await {
-        app.worktrees = parse_worktrees(&output);
+        app.raw.worktrees = parse_worktrees(&output);
     }
     load_branches(app).await;
     let repo_info = active_id;
@@ -876,7 +876,7 @@ async fn startup(
     // Fetch Local PRs via GraphQL (startup default view)
     if let Some(ref info) = repo_info {
         let tx_local = tx.clone();
-        let branch_names: Vec<String> = app.branches.iter().map(|b| b.name.clone()).collect();
+        let branch_names: Vec<String> = app.raw.branches.iter().map(|b| b.name.clone()).collect();
         let owner = info.owner.clone();
         let repo = info.name.clone();
         let hostname = info.host.clone();
@@ -903,7 +903,7 @@ fn apply_pr_list(
 ) {
     if filter == MainFilter::ReviewRequested {
         for pr in &mut prs {
-            pr.review_status = Some(compute_review_status(pr, &app.gh_user));
+            pr.review_status = Some(compute_review_status(pr, &app.raw.gh_user));
         }
     }
     report_fetch_errors(app, "PR fetch failed", errors);
@@ -962,17 +962,17 @@ fn handle_result(app: &mut App, result: AsyncResult) {
             app.record_error(msg);
         }
         AsyncResult::UserLogin(user) => {
-            app.gh_user = user;
+            app.raw.gh_user = user;
             // Recompute review status now that we know the user
             for pr in &mut app.review_prs {
-                pr.review_status = Some(compute_review_status(pr, &app.gh_user));
+                pr.review_status = Some(compute_review_status(pr, &app.raw.gh_user));
             }
             if app.main_filter == MainFilter::ReviewRequested {
                 app.rebuild_entries();
             }
         }
         AsyncResult::UserLoginError(error_msg) => {
-            app.gh_user_load_failed = true;
+            app.raw.gh_user_load_failed = true;
             app.notification = Some(Notification::error(
                 "Failed to load GitHub user — is `gh` authenticated?".to_string(),
             ));
@@ -1104,10 +1104,10 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         AsyncResult::BranchesReloaded(data) => {
             app.inflight.branches_reload = false;
             if let Some(branches) = data.branches {
-                app.branches = branches;
+                app.raw.branches = branches;
             }
             if let Some(worktrees) = data.worktrees {
-                app.worktrees = worktrees;
+                app.raw.worktrees = worktrees;
             }
             report_fetch_errors(app, "Branch reload failed", data.errors);
             app.rebuild_entries_and_clamp();
@@ -1116,7 +1116,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         AsyncResult::CommitsReloaded(commits) => {
             app.inflight.commits_reload = false;
             if let Some(commits) = commits {
-                app.commits = commits;
+                app.raw.commits = commits;
             }
         }
         AsyncResult::BranchCreated { name, source } => {
@@ -1274,7 +1274,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
             }
 
             let is_active_with_local =
-                is_active && app.branches.iter().any(|b| b.name == branch_name);
+                is_active && app.raw.branches.iter().any(|b| b.name == branch_name);
             let post_create = cfg.worktree.post_create.clone();
             let target_repo_for_send = if is_active {
                 None
@@ -1587,7 +1587,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
                 MainFilter::Local => {
                     if let Some(ref info) = tasks.repo_info {
                         let branch_names: Vec<String> =
-                            app.branches.iter().map(|b| b.name.clone()).collect();
+                            app.raw.branches.iter().map(|b| b.name.clone()).collect();
                         let owner = info.owner.clone();
                         let repo = info.name.clone();
                         let hostname = info.host.clone();
@@ -1618,15 +1618,15 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
                     // this guard, switching to Review right after startup can show
                     // team PRs even in me-only mode. If the user-login fetch failed,
                     // proceed anyway — no point in spinning forever.
-                    if app.gh_user.is_empty()
+                    if app.raw.gh_user.is_empty()
                         && !app.include_team_reviews
-                        && !app.gh_user_load_failed
+                        && !app.raw.gh_user_load_failed
                     {
                         app.push_command(Command::FetchPrs(MainFilter::ReviewRequested));
                     } else {
                         let show_merged = app.show_merged;
                         let include_team = app.include_team_reviews;
-                        let gh_user = app.gh_user.clone();
+                        let gh_user = app.raw.gh_user.clone();
                         let hosts = app.known_hosts();
                         tokio::spawn(async move {
                             let (prs, errors) =
@@ -1693,7 +1693,7 @@ async fn load_branches(app: &mut App) {
             String::new()
         }
     };
-    app.branches = parse_branches(&branch_output, &merged_output, base_hash.trim());
+    app.raw.branches = parse_branches(&branch_output, &merged_output, base_hash.trim());
 }
 
 async fn detect_default_branch() -> String {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1071,7 +1071,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
                 }
             }
             app.progress.clear();
-            app.quit_pressed_during_progress = false;
+            app.progress.quit_pressed = false;
             app.push_command(Command::ReloadBranches);
         }
         AsyncResult::WtForceDecisionRequested { path, reason } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -887,7 +887,7 @@ async fn startup(
         });
     } else {
         // No repo info available (no origin remote or unsupported URL format)
-        app.local_prs_loaded = true;
+        app.prs.local_loaded = true;
     }
 
     repo_info
@@ -908,20 +908,7 @@ fn apply_pr_list(
     }
     report_fetch_errors(app, "PR fetch failed", errors);
     seed_repos_from_prs(&mut app.cross_repo.repos, &prs);
-    match filter {
-        MainFilter::Local => {
-            app.local_prs = prs;
-            app.local_prs_loaded = true;
-        }
-        MainFilter::MyPr => {
-            app.my_prs = prs;
-            app.my_prs_loaded = true;
-        }
-        MainFilter::ReviewRequested => {
-            app.review_prs = prs;
-            app.review_prs_loaded = true;
-        }
-    }
+    app.prs.set(filter, prs);
     if app.main_filter == filter {
         app.rebuild_entries_and_clamp();
         app.request_details_for_selection();
@@ -934,7 +921,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         AsyncResult::PrDetail { repo_id, detail } => {
             let key = (repo_id.clone(), detail.number);
             app.inflight.pr_detail.remove(&key);
-            app.pr_detail_cache.insert(key, detail);
+            app.prs.detail.insert(key, detail);
         }
         AsyncResult::PrDetailError {
             repo_id,
@@ -964,7 +951,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         AsyncResult::UserLogin(user) => {
             app.raw.gh_user = user;
             // Recompute review status now that we know the user
-            for pr in &mut app.review_prs {
+            for pr in &mut app.prs.review {
                 pr.review_status = Some(compute_review_status(pr, &app.raw.gh_user));
             }
             if app.main_filter == MainFilter::ReviewRequested {
@@ -1604,7 +1591,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
                     }
                 }
                 MainFilter::MyPr => {
-                    let show_merged = app.show_merged;
+                    let show_merged = app.prs.show_merged;
                     let hosts = app.known_hosts();
                     tokio::spawn(async move {
                         let (prs, errors) = data::fetch_my_prs(show_merged, &hosts).await;
@@ -1619,13 +1606,13 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
                     // team PRs even in me-only mode. If the user-login fetch failed,
                     // proceed anyway — no point in spinning forever.
                     if app.raw.gh_user.is_empty()
-                        && !app.include_team_reviews
+                        && !app.prs.include_team_reviews
                         && !app.raw.gh_user_load_failed
                     {
                         app.push_command(Command::FetchPrs(MainFilter::ReviewRequested));
                     } else {
-                        let show_merged = app.show_merged;
-                        let include_team = app.include_team_reviews;
+                        let show_merged = app.prs.show_merged;
+                        let include_team = app.prs.include_team_reviews;
                         let gh_user = app.raw.gh_user.clone();
                         let hosts = app.known_hosts();
                         tokio::spawn(async move {

--- a/src/main.rs
+++ b/src/main.rs
@@ -909,7 +909,7 @@ fn apply_pr_list(
     report_fetch_errors(app, "PR fetch failed", errors);
     seed_repos_from_prs(&mut app.cross_repo.repos, &prs);
     app.prs.set(filter, prs);
-    if app.main_filter == filter {
+    if app.view.main_filter == filter {
         app.rebuild_entries_and_clamp();
         app.request_details_for_selection();
     }
@@ -936,6 +936,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         AsyncResult::GitStatus { wt_path, status } => {
             app.inflight.git_status.remove(&wt_path);
             if let Some(entry) = app
+                .view
                 .entries
                 .iter_mut()
                 .find(|e| e.worktree_path() == Some(wt_path.as_str()))
@@ -955,7 +956,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
             for pr in &mut app.prs.review {
                 pr.review_status = Some(compute_review_status(pr, &app.raw.gh_user));
             }
-            if app.main_filter == MainFilter::ReviewRequested {
+            if app.view.main_filter == MainFilter::ReviewRequested {
                 app.rebuild_entries();
             }
         }
@@ -1218,6 +1219,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
         Command::CreateWorktree(req_repo_id, branch_name) => {
             // Resolve target repo (active or cross-repo) and its root path.
             let entry = app
+                .view
                 .entries
                 .iter()
                 .find(|e| e.repo_id == req_repo_id && e.name == branch_name)
@@ -1320,7 +1322,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
         Command::DeleteBranches(selected) => {
             // The op is starting — clear the sidebar checkboxes now
             // (a declined dialog keeps the selection intact).
-            app.branch_selected.clear();
+            app.view.branch_selected.clear();
             struct Work {
                 name: String,
                 wt_path: Option<String>,
@@ -1331,6 +1333,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
             let active_repo = app.cross_repo.active_repo.clone();
             for name in selected {
                 let Some(entry) = app
+                    .view
                     .entries
                     .iter()
                     .find(|e| e.name == name && active_repo.as_ref() == Some(&e.repo_id))

--- a/src/main.rs
+++ b/src/main.rs
@@ -840,7 +840,6 @@ async fn startup(
     load_branches(app).await;
     let repo_info = active_id;
     app.rebuild_entries();
-    app.entries_loaded = true;
     app.request_details_for_selection();
 
     // Phase 2: Slow network loads (background, non-blocking)

--- a/src/main.rs
+++ b/src/main.rs
@@ -803,7 +803,7 @@ async fn startup(
     }
     // Global (home-dir) config layers, used to resolve a per-target-repo
     // effective config for cross-repo worktree operations.
-    app.global_layers = config::load_global_layers();
+    app.cross_repo.global_layers = config::load_global_layers();
 
     let active_root = run_git(&["rev-parse", "--show-toplevel"])
         .await
@@ -813,16 +813,17 @@ async fn startup(
         .await
         .ok()
         .and_then(|url| extract_repo_info(url.trim()));
-    app.active_repo = active_id.clone();
-    app.clone_root = match (&active_root, &active_id) {
+    app.cross_repo.active_repo = active_id.clone();
+    app.cross_repo.clone_root = match (&active_root, &active_id) {
         (Some(p), Some(id)) => infer_clone_root(p, id),
         _ => None,
     }
     .or_else(|| app.config.workspace.clone_root_expanded());
 
     // Seed repos with the active repo immediately (local_path and resolved flag known now).
-    if let Some(id) = app.active_repo.clone() {
-        app.repos
+    if let Some(id) = app.cross_repo.active_repo.clone() {
+        app.cross_repo
+            .repos
             .entry(id.clone())
             .or_insert_with(|| crate::git::types::RepoMeta {
                 local_path: active_root.clone(),
@@ -906,7 +907,7 @@ fn apply_pr_list(
         }
     }
     report_fetch_errors(app, "PR fetch failed", errors);
-    seed_repos_from_prs(&mut app.repos, &prs);
+    seed_repos_from_prs(&mut app.cross_repo.repos, &prs);
     match filter {
         MainFilter::Local => {
             app.local_prs = prs;
@@ -1008,7 +1009,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
             app.push_command(Command::ReloadBranches);
             // Cross-repo: invalidate worktree-list cache for target so next selection re-fetches.
             if let Some(repo_id) = target_repo {
-                app.wt_lists_per_repo.remove(&repo_id);
+                app.cross_repo.wt_lists_per_repo.remove(&repo_id);
             }
             if app.confirm_dialog.is_none() {
                 app.confirm_dialog = Some(crate::app::PendingConfirm {
@@ -1096,7 +1097,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         }
         AsyncResult::WtListLoaded { repo_id, list } => {
             app.inflight.wt_lists.remove(&repo_id);
-            app.wt_lists_per_repo.insert(repo_id, list);
+            app.cross_repo.wt_lists_per_repo.insert(repo_id, list);
             app.rebuild_entries();
             app.snap_scroll_to_entry();
         }
@@ -1237,13 +1238,14 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
                 return;
             };
             let target_repo = entry.repo_id.clone();
-            let active_repo = app.active_repo.clone();
+            let active_repo = app.cross_repo.active_repo.clone();
             let is_active = active_repo.as_ref() == Some(&target_repo);
 
-            // The active repo's root is already cached in `app.repos` (seeded
+            // The active repo's root is already cached in `app.cross_repo.repos` (seeded
             // at startup), so this never needs a blocking `rev-parse` call —
             // cross-repo targets rely on the same cached `local_path` too.
             let target_root: std::path::PathBuf = match app
+                .cross_repo
                 .repos
                 .get(&target_repo)
                 .and_then(|m| m.local_path.clone())
@@ -1262,7 +1264,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
             let cfg = if is_active {
                 app.config.clone()
             } else {
-                config::resolve_config(&app.global_layers, Some(&target_root))
+                config::resolve_config(&app.cross_repo.global_layers, Some(&target_root))
             };
 
             let wt_path = cfg.worktree_path_for(&target_root, &entry.repo_id.name, &branch_name);
@@ -1338,7 +1340,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
             }
             let mut work: Vec<Work> = Vec::with_capacity(selected.len());
             let mut wt_paths_claimed: Vec<String> = Vec::new();
-            let active_repo = app.active_repo.clone();
+            let active_repo = app.cross_repo.active_repo.clone();
             for name in selected {
                 let Some(entry) = app
                     .entries
@@ -1495,7 +1497,12 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
             if app.inflight.wt_lists.contains(&repo_id) {
                 return;
             }
-            let Some(path) = app.repos.get(&repo_id).and_then(|m| m.local_path.clone()) else {
+            let Some(path) = app
+                .cross_repo
+                .repos
+                .get(&repo_id)
+                .and_then(|m| m.local_path.clone())
+            else {
                 return;
             };
             app.inflight.wt_lists.insert(repo_id.clone());

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -34,7 +34,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
             entry,
             app.selected_pr_detail(),
             spinner,
-            app.active_repo.as_ref(),
+            app.cross_repo.active_repo.as_ref(),
         );
     } else {
         lines.push(Line::from(Span::styled(

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -59,7 +59,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     let paragraph = Paragraph::new(lines)
         .block(block)
         .wrap(Wrap { trim: false })
-        .scroll((app.pr_detail_scroll as u16, 0));
+        .scroll((app.view.pr_detail_scroll as u16, 0));
     frame.render_widget(paragraph, area);
 }
 

--- a/src/ui/history_view.rs
+++ b/src/ui/history_view.rs
@@ -35,8 +35,8 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
     let mut state = ListState::default();
-    if app.history_scroll < records.len() {
-        state.select(Some(app.history_scroll));
+    if app.view.history_scroll < records.len() {
+        state.select(Some(app.view.history_scroll));
     } else {
         // records is guaranteed non-empty here by the early return above
         state.select(Some(records.len() - 1));

--- a/src/ui/log_view.rs
+++ b/src/ui/log_view.rs
@@ -44,7 +44,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
         .highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 
     let mut state = ListState::default();
-    state.select(Some(app.log_scroll));
+    state.select(Some(app.view.log_scroll));
 
     frame.render_stateful_widget(list, area, &mut state);
 }

--- a/src/ui/log_view.rs
+++ b/src/ui/log_view.rs
@@ -13,13 +13,14 @@ use crate::ui::theme;
 pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
     let block = Block::default().borders(Borders::ALL).title(" Log ");
 
-    if app.commits.is_empty() {
+    if app.raw.commits.is_empty() {
         let loading = List::new(vec![ListItem::new("Loading...")]).block(block);
         frame.render_widget(loading, area);
         return;
     }
 
     let items: Vec<ListItem> = app
+        .raw
         .commits
         .iter()
         .map(|commit| {

--- a/src/ui/main_view.rs
+++ b/src/ui/main_view.rs
@@ -20,12 +20,12 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
     detail_pane::draw(frame, chunks[1], app);
 
     // Confirm dialog overlay
-    if let Some(pending) = &app.confirm_dialog {
+    if let Some(pending) = &app.overlays.confirm_dialog {
         confirm_dialog::draw(frame, &pending.dialog);
     }
 
     // Action menu overlay
-    if let Some(menu) = &app.action_menu {
+    if let Some(menu) = &app.overlays.action_menu {
         draw_action_menu(frame, menu);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -34,21 +34,21 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     let status_text = match app.active_view {
         ActiveView::Main => {
             let merged_hint = if matches!(
-                app.main_filter,
+                app.view.main_filter,
                 MainFilter::MyPr | MainFilter::ReviewRequested
             ) {
                 "  m:Merged"
             } else {
                 ""
             };
-            let team_hint = if app.main_filter == MainFilter::ReviewRequested {
+            let team_hint = if app.view.main_filter == MainFilter::ReviewRequested {
                 "  t:Team"
             } else {
                 ""
             };
             format!(
                 " [{}]  1:Local  2:My PR  3:Review  Enter:Actions  /:Search{merged_hint}{team_hint}  l:Log  h:History  ?:Help  q:Quit",
-                app.main_filter.label()
+                app.view.main_filter.label()
             )
         }
         ActiveView::Log => {

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -61,19 +61,19 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
     frame.render_widget(status, chunks[1]);
 
     // Branch-create input modal
-    if let Some(input) = &app.branch_create_input {
+    if let Some(input) = &app.overlays.branch_create_input {
         branch_create_input::draw(frame, input);
     }
 
     // Progress panel takes priority over notification while a delete batch runs.
     if app.progress.is_active() {
         progress_panel::draw(frame, &app.progress, app.quit_pressed_during_progress);
-    } else if let Some(notif) = &app.notification {
+    } else if let Some(notif) = &app.overlays.notification {
         notification::draw(frame, notif);
     }
 
     // Help overlay
-    if app.show_help {
+    if app.overlays.show_help {
         help_overlay::draw(frame);
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -67,7 +67,7 @@ pub fn draw(frame: &mut Frame, app: &mut App) {
 
     // Progress panel takes priority over notification while a delete batch runs.
     if app.progress.is_active() {
-        progress_panel::draw(frame, &app.progress, app.quit_pressed_during_progress);
+        progress_panel::draw(frame, &app.progress);
     } else if let Some(notif) = &app.overlays.notification {
         notification::draw(frame, notif);
     }

--- a/src/ui/progress_panel.rs
+++ b/src/ui/progress_panel.rs
@@ -14,8 +14,8 @@ use crate::ui::theme;
 
 const MAX_VISIBLE_OPS: usize = 7;
 
-pub fn draw(frame: &mut Frame, tracker: &ProgressTracker, quit_warning: bool) {
-    let lines = build_lines(tracker, quit_warning, Instant::now());
+pub fn draw(frame: &mut Frame, tracker: &ProgressTracker) {
+    let lines = build_lines(tracker, tracker.quit_pressed, Instant::now());
     let height = (lines.len() as u16) + 2; // borders
     let area = bottom_rect(80, height, frame.area());
     frame.render_widget(Clear, area);

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -19,7 +19,7 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
 }
 
 fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
-    let bar = if app.search_active {
+    let bar = if app.view.search_active {
         Line::from(vec![
             Span::styled(
                 " /",
@@ -27,11 +27,14 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
                     .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(app.search_query.clone(), Style::default().fg(theme::TEXT)),
+            Span::styled(
+                app.view.search_query.clone(),
+                Style::default().fg(theme::TEXT),
+            ),
             Span::styled("_", Style::default().fg(theme::ACCENT)),
         ])
     } else {
-        let label = app.main_filter.label();
+        let label = app.view.main_filter.label();
         let mut spans = vec![
             Span::styled(" Filter: ", Style::default().fg(theme::TEXT_DIM)),
             Span::styled(
@@ -43,7 +46,7 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
         ];
         // Show merged toggle indicator for My PR / Review views
         if matches!(
-            app.main_filter,
+            app.view.main_filter,
             MainFilter::MyPr | MainFilter::ReviewRequested
         ) && app.prs.show_merged
         {
@@ -53,14 +56,14 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
             ));
         }
         // Show active search filter
-        if !app.search_query.is_empty() {
+        if !app.view.search_query.is_empty() {
             spans.push(Span::styled(
-                format!(" /{}", app.search_query),
+                format!(" /{}", app.view.search_query),
                 Style::default().fg(theme::ACCENT),
             ));
         }
         // Show team toggle indicator for Review view
-        if app.main_filter == MainFilter::ReviewRequested {
+        if app.view.main_filter == MainFilter::ReviewRequested {
             let team_label = if app.prs.include_team_reviews {
                 " [+team]"
             } else {
@@ -70,7 +73,7 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
         }
         // Show repo/PR counter when multiple repos are present
         if matches!(
-            app.main_filter,
+            app.view.main_filter,
             MainFilter::MyPr | MainFilter::ReviewRequested
         ) {
             let filtered = app.filtered_entries();
@@ -96,7 +99,7 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
 }
 
 fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
-    let show_checkboxes = !app.branch_selected.is_empty();
+    let show_checkboxes = !app.view.branch_selected.is_empty();
     let is_loading = app.is_current_view_loading();
 
     // Build items and capture count before mutably borrowing app
@@ -110,10 +113,10 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                 Style::default().fg(theme::TEXT_DIM),
             )))]
         } else if rows.is_empty() {
-            let msg = if !app.search_query.is_empty() {
+            let msg = if !app.view.search_query.is_empty() {
                 "  No branches match the search"
             } else {
-                match app.main_filter {
+                match app.view.main_filter {
                     MainFilter::Local => "  No local branches",
                     MainFilter::MyPr => "  No branches with your PRs",
                     MainFilter::ReviewRequested => "  No branches awaiting review",
@@ -124,7 +127,7 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                 Style::default().fg(theme::TEXT_DIM),
             )))]
         } else {
-            let search_query = &app.search_query;
+            let search_query = &app.view.search_query;
             rows.iter()
                 .map(|row| match row {
                     crate::app::SidebarRow::Header { repo_id } => {
@@ -136,7 +139,7 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                         )]))
                     }
                     crate::app::SidebarRow::Entry(entry) => {
-                        let is_selected = app.branch_selected.contains(&entry.name);
+                        let is_selected = app.view.branch_selected.contains(&entry.name);
                         let is_protected = app.is_protected_branch(&entry.name);
                         ListItem::new(format_entry_line(
                             entry,
@@ -167,9 +170,9 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
 
     let mut state = ListState::default();
     if item_count > 0 {
-        state.select(Some(app.sidebar_scroll));
+        state.select(Some(app.view.sidebar_scroll));
     }
-    *state.offset_mut() = app.sidebar_offset;
+    *state.offset_mut() = app.view.sidebar_offset;
     frame.render_stateful_widget(list, area, &mut state);
 }
 

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -45,7 +45,7 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
         if matches!(
             app.main_filter,
             MainFilter::MyPr | MainFilter::ReviewRequested
-        ) && app.show_merged
+        ) && app.prs.show_merged
         {
             spans.push(Span::styled(
                 " [+merged]",
@@ -61,7 +61,7 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
         }
         // Show team toggle indicator for Review view
         if app.main_filter == MainFilter::ReviewRequested {
-            let team_label = if app.include_team_reviews {
+            let team_label = if app.prs.include_team_reviews {
                 " [+team]"
             } else {
                 " [me]"


### PR DESCRIPTION
## Summary

`App` in `src/app.rs` had grown to 48 fields spanning eight unrelated concerns, making every change risky and the struct impossible to reason about in isolation. This PR decomposes it into five cohesive sub-structs owned by `App` — following the existing `Inflight`/`ProgressTracker` precedent (pub fields, `derive(Default)`, direct field projection) — shrinking `App` to 16 fields with zero behavior change.

## Related Issues

Closes #220

## Type of Change

- [x] Refactoring

## Changes

- **`ViewState` (`app.view`)** — entry list, cursor/filter/search/multi-select state, and per-view scroll positions. The row/selection helpers that touch only this state (`filtered_entries`, `sidebar_rows`, `selected_entry`, `snap_scroll_to_entry`, `next/prev_entry_index`, `adjust_sidebar_offset`) move onto it verbatim.
- **`RawData` (`app.raw`)** — raw git/gh fetch results (branches, worktrees, commits, gh_user) feeding `merge_entries` and the Log view.
- **`PrCaches` (`app.prs`)** — per-filter PR lists, loaded flags, fetch parameters, and the PR-detail cache. The three duplicated match-on-filter blocks become `current` / `is_loading` / `set` / `invalidate` methods; `main_filter` itself stays in `ViewState` and is passed as a `Copy` param.
- **`Overlays` (`app.overlays`)** — help, confirm dialog, action menu, branch-create input, notification, in `handle_key` priority order.
- **`CrossRepoState` (`app.cross_repo`)** — active repo, clone root, per-repo metadata, worktree lists, global config layers, plus `known_hosts` / `resolve_repo_config` / `resolve_local_path` moved verbatim.
- `quit_pressed_during_progress` folds into `ProgressTracker::quit_pressed` (it was always co-read with `progress.is_active()`); `progress_panel::draw` reads it from the tracker instead of a separate bool param.
- Deletes the dead `entries_loaded` field (written once, never read) — the only intended behavior-adjacent change.
- `App` keeps one-line delegators with unchanged signatures (`filtered_entries`, `current_prs`, `known_hosts`, …), so main.rs/ui call sites and tests needed only mechanical path rewrites.

Behavior guards preserved deliberately: the `m` toggle still invalidates both my+review caches; the `r` refresh still clears the detail cache for **all** filters while invalidating only the current filter's list; `quit_pressed` is still reset only when the op batch finishes, not in `clear()`.

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`, `cargo fmt -- --check`)
- [x] Unit + integration tests pass locally (214 unit, 8 CLI, 5 MCP); the `tui_e2e` suite fails in this local sandbox for pre-existing environmental reasons (fails identically on `main`) — CI is authoritative for it

## Test Plan

- `cargo test` — all suites green in CI; each of the 7 commits passes build/test/clippy/fmt individually
- Manual smoke: filter switch 1/2/3, `/` search + Esc restore, `r` refresh, `m`/`t` toggles, action menu, delete-with-confirm, help overlay, notification decay during a worktree op, `l` log / `h` history scroll
- Initial-state equivalence: every moved field's `App::new` initializer was its type default, so `derive(Default)` on the sub-structs reproduces the exact startup state