### PR TITLE
refactor(app): add notify helpers to replace direct notification writes

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -685,6 +685,16 @@ impl App {
         Self::SPINNER_FRAMES[self.spinner_tick % Self::SPINNER_FRAMES.len()]
     }
 
+    /// Show a success toast (~3s). Replaces any toast currently shown.
+    pub fn notify_success(&mut self, message: impl Into<String>) {
+        self.overlays.notification = Some(Notification::success(message));
+    }
+
+    /// Show an error toast (~5s). Replaces any toast currently shown.
+    pub fn notify_error(&mut self, message: impl Into<String>) {
+        self.overlays.notification = Some(Notification::error(message));
+    }
+
     pub fn adjust_sidebar_offset(&mut self, visible_height: usize, item_count: usize) {
         self.view.adjust_sidebar_offset(visible_height, item_count)
     }
@@ -920,11 +930,11 @@ impl App {
                     // Signal branches/worktrees reload + PR fetch
                     self.push_command(Command::ReloadBranches);
                     self.push_command(Command::FetchPrs(self.view.main_filter));
-                    self.overlays.notification = Some(Notification::success("Refreshing…"));
+                    self.notify_success("Refreshing…");
                 }
                 ActiveView::Log => {
                     self.push_command(Command::ReloadCommits);
-                    self.overlays.notification = Some(Notification::success("Refreshing…"));
+                    self.notify_success("Refreshing…");
                 }
                 ActiveView::History => {
                     // History updates live as commands run — no manual refresh needed.
@@ -1042,9 +1052,7 @@ impl App {
                     // Non-empty selection but nothing deletable (e.g. PR-only entries
                     // with no local branch and no worktree). Tell the user rather
                     // than silently no-op.
-                    self.overlays.notification = Some(Notification::error(
-                        "Nothing to delete in selection".to_string(),
-                    ));
+                    self.notify_error("Nothing to delete in selection");
                 } else if let Some(entry) = self.selected_entry().cloned()
                     && let Some(wt_path) = entry.worktree_path()
                     && !entry.is_current()
@@ -1082,10 +1090,10 @@ impl App {
                 };
                 let cross_repo_no_clone = !is_active && clone_path.is_none();
                 if cross_repo_no_clone {
-                    self.overlays.notification = Some(Notification::error(format!(
+                    self.notify_error(format!(
                         "{} not cloned. Set [workspace] clone_root.",
                         entry.repo_id
-                    )));
+                    ));
                     return;
                 }
                 let wt_path = if is_active {
@@ -1108,8 +1116,7 @@ impl App {
                     entry.repo_id.clone(),
                     entry.name.clone(),
                 ));
-                self.overlays.notification =
-                    Some(Notification::success("Creating worktree...".to_string()));
+                self.notify_success("Creating worktree...");
             }
             KeyCode::Enter => {
                 self.open_action_menu();
@@ -1366,8 +1373,7 @@ impl App {
                     entry.repo_id.clone(),
                     entry.name.clone(),
                 ));
-                self.overlays.notification =
-                    Some(Notification::success("Creating worktree...".to_string()));
+                self.notify_success("Creating worktree...");
             }
             ActionItem::CdIntoWorktree => {
                 if let Some(path) = entry.worktree_path() {
@@ -1417,8 +1423,7 @@ impl App {
             }
             ActionItem::CopyBranchName => {
                 self.push_command(Command::CopyBranchName(entry.name.clone()));
-                self.overlays.notification =
-                    Some(Notification::success(format!("Copied: {}", entry.name)));
+                self.notify_success(format!("Copied: {}", entry.name));
             }
         }
     }
@@ -2729,5 +2734,39 @@ mod command_queue_tests {
         assert!(app.overlays.confirm_dialog.is_none());
         assert!(app.commands.is_empty());
         assert!(!app.inflight.worktrees.contains("/wt/p"));
+    }
+}
+
+#[cfg(test)]
+mod notify_tests {
+    use super::*;
+    use crate::config::Config;
+
+    #[test]
+    fn notify_error_sets_error_toast() {
+        let mut app = App::new(Config::default());
+        app.notify_error("boom");
+        let n = app.overlays.notification.as_ref().unwrap();
+        assert!(n.is_error);
+        assert_eq!(n.message, "boom");
+    }
+
+    #[test]
+    fn notify_success_sets_success_toast() {
+        let mut app = App::new(Config::default());
+        app.notify_success(format!("done {}", 1));
+        let n = app.overlays.notification.as_ref().unwrap();
+        assert!(!n.is_error);
+        assert_eq!(n.message, "done 1");
+    }
+
+    #[test]
+    fn second_notify_replaces_first() {
+        let mut app = App::new(Config::default());
+        app.notify_success("first");
+        app.notify_error("second");
+        let n = app.overlays.notification.as_ref().unwrap();
+        assert!(n.is_error);
+        assert_eq!(n.message, "second");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ use crate::event::{Event, EventHandler};
 use crate::git::command::{run_gh, run_git, run_git_in};
 use crate::git::parser::{parse_branches, parse_log, parse_worktrees};
 use crate::git::types::{GitStatus, PrDetail, PullRequest, RepoId, ReviewState, ReviewStatus};
-use crate::ui::notification::Notification;
 
 /// Args used for fetching commits in the Log view (startup + `r` refresh).
 const LOG_ARGS: &[&str] = &[
@@ -795,9 +794,7 @@ async fn startup(
         } else {
             String::new()
         };
-        app.overlays.notification = Some(Notification::error(format!(
-            "Config warning: {first}{suffix}"
-        )));
+        app.notify_error(format!("Config warning: {first}{suffix}"));
         app.verbose_errors
             .extend(config_warnings.iter().map(|w| format!("config: {w}")));
     }
@@ -929,8 +926,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
             error,
         } => {
             app.inflight.pr_detail.remove(&(repo_id, number));
-            app.overlays.notification =
-                Some(Notification::error(format!("Failed to load PR #{number}")));
+            app.notify_error(format!("Failed to load PR #{number}"));
             app.record_error(error);
         }
         AsyncResult::GitStatus { wt_path, status } => {
@@ -947,7 +943,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         AsyncResult::GitStatusError(wt_path) => {
             app.inflight.git_status.remove(&wt_path);
             let msg = format!("git status failed for {wt_path}");
-            app.overlays.notification = Some(Notification::error(msg.clone()));
+            app.notify_error(msg.clone());
             app.record_error(msg);
         }
         AsyncResult::UserLogin(user) => {
@@ -962,9 +958,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         }
         AsyncResult::UserLoginError(error_msg) => {
             app.raw.gh_user_load_failed = true;
-            app.overlays.notification = Some(Notification::error(
-                "Failed to load GitHub user — is `gh` authenticated?".to_string(),
-            ));
+            app.notify_error("Failed to load GitHub user — is `gh` authenticated?");
             app.record_error(error_msg);
         }
         AsyncResult::LocalPrList(prs, errors) => {
@@ -983,14 +977,12 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         } => {
             app.inflight.worktrees.remove(&wt_path);
             if copy_errors.is_empty() {
-                app.overlays.notification = Some(Notification::success(format!(
-                    "Worktree created: {wt_path}"
-                )));
+                app.notify_success(format!("Worktree created: {wt_path}"));
             } else {
-                app.overlays.notification = Some(Notification::success(format!(
+                app.notify_success(format!(
                     "Worktree created: {wt_path} (copy errors: {})",
                     copy_errors.len()
-                )));
+                ));
                 for e in copy_errors {
                     app.record_error(e);
                 }
@@ -1014,7 +1006,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
         }
         AsyncResult::WtCreateError { wt_path, message } => {
             app.inflight.worktrees.remove(&wt_path);
-            app.overlays.notification = Some(Notification::error(message));
+            app.notify_error(message);
         }
         AsyncResult::OpStarted { op_id, label } => {
             app.progress.insert(op_id, OpProgress::new(label));
@@ -1050,7 +1042,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
                 } else {
                     format!("Deleted {}", success_parts.join(", "))
                 };
-                app.overlays.notification = Some(Notification::success(msg));
+                app.notify_success(msg);
             } else {
                 let short: Vec<String> = failures
                     .iter()
@@ -1065,7 +1057,7 @@ fn handle_result(app: &mut App, result: AsyncResult) {
                         short.join("; ")
                     )
                 };
-                app.overlays.notification = Some(Notification::error(summary));
+                app.notify_error(summary);
                 for err in failures {
                     app.record_error(err);
                 }
@@ -1109,14 +1101,12 @@ fn handle_result(app: &mut App, result: AsyncResult) {
             }
         }
         AsyncResult::BranchCreated { name, source } => {
-            app.overlays.notification = Some(Notification::success(format!(
-                "Created branch '{name}' from '{source}'"
-            )));
+            app.notify_success(format!("Created branch '{name}' from '{source}'"));
             app.push_command(Command::ReloadBranches);
         }
         AsyncResult::BranchCreateError(err_str) => {
             let short = err_str.lines().next().unwrap_or(&err_str).to_string();
-            app.overlays.notification = Some(Notification::error(short));
+            app.notify_error(short);
             app.record_error(err_str);
         }
     }
@@ -1243,8 +1233,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
                 Some(p) => p,
                 None if is_active => std::env::current_dir().unwrap_or_default(),
                 None => {
-                    app.overlays.notification =
-                        Some(Notification::error(format!("{target_repo} not cloned")));
+                    app.notify_error(format!("{target_repo} not cloned"));
                     return;
                 }
             };
@@ -1361,8 +1350,7 @@ fn dispatch_command(app: &mut App, cmd: Command, tasks: &mut RunState) {
             }
 
             if work.is_empty() {
-                app.overlays.notification =
-                    Some(Notification::error("Nothing to delete".to_string()));
+                app.notify_error("Nothing to delete");
             } else {
                 let ids: Vec<u64> = app.progress.allocate_ids(work.len()).collect();
                 let mut set: JoinSet<DeleteOpResult> = JoinSet::new();
@@ -1650,7 +1638,7 @@ fn report_fetch_errors(app: &mut App, context: &str, errors: Vec<String>) {
         String::new()
     };
     let toast = format!("{context}: {first}{suffix}");
-    app.overlays.notification = Some(Notification::error(toast));
+    app.notify_error(toast);
     for e in errors {
         app.record_error(e);
     }


### PR DESCRIPTION
## Summary

Every toast was written the long way as `app.overlays.notification = Some(Notification::error(...))` (~21 sites). This PR adds `App::notify_success` / `App::notify_error` (both `impl Into<String>`, matching the `Notification` constructors) and converts all call sites, shortening them and centralizing the pattern.

## Related Issues

Closes #267

## Type of Change

- [x] Refactoring

## Changes

- New `App::notify_success` / `App::notify_error` helpers next to `spinner_frame()`/`tick()` (which owns the toast countdown), documenting the ~3s/~5s TTLs and replace semantics.
- All 21 assignment sites converted (7 in `app.rs`, 14 in `main.rs`); now-redundant `.to_string()` on literals dropped; the then-unused `Notification` import removed from `main.rs`.
- The expiry clear in `tick()` (`= None`) intentionally stays a direct field write — it is not a toast.
- New `notify_tests` module: error/success flags and replace semantics.

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`, `cargo fmt -- --check`)
- [x] Tests pass locally (217 unit, 8 CLI, 5 MCP); `tui_e2e` fails locally for known pre-existing environmental reasons — CI is authoritative

## Test Plan

- `cargo test` — includes 3 new `notify_tests`
- `grep -rn "overlays.notification = Some" src/` returns only the two helper bodies