### PR TITLE
refactor(ui): stop threading &mut App through the sidebar render path

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -695,10 +695,6 @@ impl App {
         self.overlays.notification = Some(Notification::error(message));
     }
 
-    pub fn adjust_sidebar_offset(&mut self, visible_height: usize, item_count: usize) {
-        self.view.adjust_sidebar_offset(visible_height, item_count)
-    }
-
     pub fn is_current_view_loading(&self) -> bool {
         self.prs.is_loading(self.view.main_filter)
     }
@@ -730,10 +726,6 @@ impl App {
 
     pub fn filtered_entries(&self) -> Vec<&BranchEntry> {
         self.view.filtered_entries()
-    }
-
-    pub fn sidebar_rows(&self) -> Vec<SidebarRow<'_>> {
-        self.view.sidebar_rows()
     }
 
     pub fn selected_entry(&self) -> Option<&BranchEntry> {
@@ -1991,7 +1983,7 @@ mod cursor_skip_tests {
 
         // j → should jump from index 1 to index 3 (skip Header at index 2)
         app.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::NONE));
-        let rows = app.sidebar_rows();
+        let rows = app.view.sidebar_rows();
         assert_eq!(app.view.sidebar_scroll, 3);
         assert!(matches!(
             rows[app.view.sidebar_scroll],
@@ -2000,7 +1992,7 @@ mod cursor_skip_tests {
 
         // k → should jump back from 3 to 1
         app.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::NONE));
-        let rows = app.sidebar_rows();
+        let rows = app.view.sidebar_rows();
         assert_eq!(app.view.sidebar_scroll, 1);
         assert!(matches!(
             rows[app.view.sidebar_scroll],
@@ -2062,7 +2054,7 @@ mod sidebar_rows_tests {
                 git_status: None,
             },
         ];
-        let rows = app.sidebar_rows();
+        let rows = app.view.sidebar_rows();
         let header_count = rows
             .iter()
             .filter(|r| matches!(r, SidebarRow::Header { .. }))
@@ -2119,7 +2111,7 @@ mod sidebar_rows_tests {
                 git_status: None,
             },
         ];
-        let rows = app.sidebar_rows();
+        let rows = app.view.sidebar_rows();
         assert_eq!(
             rows.iter()
                 .filter(|r| matches!(r, SidebarRow::Header { .. }))
@@ -2157,7 +2149,7 @@ mod sidebar_rows_tests {
             pull_request: None,
             git_status: None,
         }];
-        let rows = app.sidebar_rows();
+        let rows = app.view.sidebar_rows();
         assert_eq!(
             rows.iter()
                 .filter(|r| matches!(r, SidebarRow::Header { .. }))

--- a/src/ui/main_view.rs
+++ b/src/ui/main_view.rs
@@ -16,7 +16,14 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
     let chunks =
         Layout::horizontal([Constraint::Percentage(35), Constraint::Percentage(65)]).split(area);
 
-    sidebar::draw(frame, chunks[0], app);
+    let sidebar_ctx = sidebar::SidebarContext {
+        is_loading: app.is_current_view_loading(),
+        spinner: app.spinner_frame(),
+        show_merged: app.prs.show_merged,
+        include_team_reviews: app.prs.include_team_reviews,
+        protected_branches: &app.config.protected_branches,
+    };
+    sidebar::draw(frame, chunks[0], &mut app.view, &sidebar_ctx);
     detail_pane::draw(frame, chunks[1], app);
 
     // Confirm dialog overlay

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -6,20 +6,30 @@ use ratatui::{
     widgets::{Block, Borders, List, ListItem, ListState},
 };
 
-use crate::app::{App, MainFilter};
+use crate::app::{MainFilter, SidebarRow, ViewState};
 use crate::git::types::BranchEntry;
 
 use crate::ui::theme;
 
-pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
-    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(area);
-
-    draw_filter_bar(frame, chunks[0], app);
-    draw_entry_list(frame, chunks[1], app);
+/// Read-only state the sidebar needs from outside `ViewState`.
+pub struct SidebarContext<'a> {
+    /// Whether the current filter's PR list is still loading.
+    pub is_loading: bool,
+    pub spinner: &'static str,
+    pub show_merged: bool,
+    pub include_team_reviews: bool,
+    pub protected_branches: &'a [String],
 }
 
-fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
-    let bar = if app.view.search_active {
+pub fn draw(frame: &mut Frame, area: Rect, view: &mut ViewState, ctx: &SidebarContext<'_>) {
+    let chunks = Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).split(area);
+
+    draw_filter_bar(frame, chunks[0], view, ctx);
+    draw_entry_list(frame, chunks[1], view, ctx);
+}
+
+fn draw_filter_bar(frame: &mut Frame, area: Rect, view: &ViewState, ctx: &SidebarContext<'_>) {
+    let bar = if view.search_active {
         Line::from(vec![
             Span::styled(
                 " /",
@@ -27,14 +37,11 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
                     .fg(theme::ACCENT)
                     .add_modifier(Modifier::BOLD),
             ),
-            Span::styled(
-                app.view.search_query.clone(),
-                Style::default().fg(theme::TEXT),
-            ),
+            Span::styled(view.search_query.clone(), Style::default().fg(theme::TEXT)),
             Span::styled("_", Style::default().fg(theme::ACCENT)),
         ])
     } else {
-        let label = app.view.main_filter.label();
+        let label = view.main_filter.label();
         let mut spans = vec![
             Span::styled(" Filter: ", Style::default().fg(theme::TEXT_DIM)),
             Span::styled(
@@ -46,9 +53,9 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
         ];
         // Show merged toggle indicator for My PR / Review views
         if matches!(
-            app.view.main_filter,
+            view.main_filter,
             MainFilter::MyPr | MainFilter::ReviewRequested
-        ) && app.prs.show_merged
+        ) && ctx.show_merged
         {
             spans.push(Span::styled(
                 " [+merged]",
@@ -56,15 +63,15 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
             ));
         }
         // Show active search filter
-        if !app.view.search_query.is_empty() {
+        if !view.search_query.is_empty() {
             spans.push(Span::styled(
-                format!(" /{}", app.view.search_query),
+                format!(" /{}", view.search_query),
                 Style::default().fg(theme::ACCENT),
             ));
         }
         // Show team toggle indicator for Review view
-        if app.view.main_filter == MainFilter::ReviewRequested {
-            let team_label = if app.prs.include_team_reviews {
+        if view.main_filter == MainFilter::ReviewRequested {
+            let team_label = if ctx.include_team_reviews {
                 " [+team]"
             } else {
                 " [me]"
@@ -73,10 +80,10 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
         }
         // Show repo/PR counter when multiple repos are present
         if matches!(
-            app.view.main_filter,
+            view.main_filter,
             MainFilter::MyPr | MainFilter::ReviewRequested
         ) {
-            let filtered = app.filtered_entries();
+            let filtered = view.filtered_entries();
             let repo_count = filtered
                 .iter()
                 .map(|e| e.repo_id.clone())
@@ -98,25 +105,25 @@ fn draw_filter_bar(frame: &mut Frame, area: Rect, app: &App) {
     );
 }
 
-fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
-    let show_checkboxes = !app.view.branch_selected.is_empty();
-    let is_loading = app.is_current_view_loading();
+fn draw_entry_list(frame: &mut Frame, area: Rect, view: &mut ViewState, ctx: &SidebarContext<'_>) {
+    let show_checkboxes = !view.branch_selected.is_empty();
+    let is_loading = ctx.is_loading;
 
     // Build items and capture count before mutably borrowing app
     let (items, item_count): (Vec<ListItem>, usize) = {
-        let rows = app.sidebar_rows();
+        let rows = view.sidebar_rows();
         let item_count = rows.len();
         let items = if rows.is_empty() && is_loading {
-            let spinner = app.spinner_frame();
+            let spinner = ctx.spinner;
             vec![ListItem::new(Line::from(Span::styled(
                 format!("  {spinner} Loading"),
                 Style::default().fg(theme::TEXT_DIM),
             )))]
         } else if rows.is_empty() {
-            let msg = if !app.view.search_query.is_empty() {
+            let msg = if !view.search_query.is_empty() {
                 "  No branches match the search"
             } else {
-                match app.view.main_filter {
+                match view.main_filter {
                     MainFilter::Local => "  No local branches",
                     MainFilter::MyPr => "  No branches with your PRs",
                     MainFilter::ReviewRequested => "  No branches awaiting review",
@@ -127,10 +134,10 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                 Style::default().fg(theme::TEXT_DIM),
             )))]
         } else {
-            let search_query = &app.view.search_query;
+            let search_query = &view.search_query;
             rows.iter()
                 .map(|row| match row {
-                    crate::app::SidebarRow::Header { repo_id } => {
+                    SidebarRow::Header { repo_id } => {
                         ListItem::new(Line::from(vec![Span::styled(
                             format!(" ▾ {repo_id} "),
                             Style::default()
@@ -138,9 +145,9 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
                                 .add_modifier(Modifier::DIM | Modifier::BOLD),
                         )]))
                     }
-                    crate::app::SidebarRow::Entry(entry) => {
-                        let is_selected = app.view.branch_selected.contains(&entry.name);
-                        let is_protected = app.is_protected_branch(&entry.name);
+                    SidebarRow::Entry(entry) => {
+                        let is_selected = view.branch_selected.contains(&entry.name);
+                        let is_protected = ctx.protected_branches.iter().any(|b| b == &entry.name);
                         ListItem::new(format_entry_line(
                             entry,
                             show_checkboxes,
@@ -157,7 +164,7 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
 
     // Adjust viewport offset and clamp scroll/offset to valid ranges
     let visible_height = area.height.saturating_sub(2) as usize;
-    app.adjust_sidebar_offset(visible_height, item_count);
+    view.adjust_sidebar_offset(visible_height, item_count);
 
     let block = Block::default()
         .borders(Borders::ALL)
@@ -170,9 +177,9 @@ fn draw_entry_list(frame: &mut Frame, area: Rect, app: &mut App) {
 
     let mut state = ListState::default();
     if item_count > 0 {
-        state.select(Some(app.view.sidebar_scroll));
+        state.select(Some(view.sidebar_scroll));
     }
-    *state.offset_mut() = app.view.sidebar_offset;
+    *state.offset_mut() = view.sidebar_offset;
     frame.render_stateful_widget(list, area, &mut state);
 }
 


### PR DESCRIPTION
## Summary

`ui::draw` needed `&mut App` through the whole render tree solely because `sidebar::draw_entry_list` clamps scroll state during rendering. Since `ViewState` owns that state (#266), the sidebar now takes `&mut ViewState` plus a read-only `SidebarContext`, documenting what rendering can actually mutate.

## Related Issues

Closes #268

## Type of Change

- [x] Refactoring

## Changes

- New `sidebar::SidebarContext<'a>` (loading flag, spinner frame, `show_merged` / `include_team_reviews`, protected branches slice).
- `sidebar::draw` / `draw_filter_bar` / `draw_entry_list` take `&mut ViewState` (or `&ViewState`) + `&SidebarContext` instead of `&mut App` / `&App`.
- `main_view::draw` keeps `&mut App` and becomes the split-borrow point: it builds the ctx from temporary `&App` borrows, then passes the disjoint `&mut app.view`.
- The protected-branch check inlines against `ctx.protected_branches`; `App::is_protected_branch` stays for key handlers.
- Deleted the `App::adjust_sidebar_offset` and `App::sidebar_rows` delegators (no production callers remain — clippy dead-code caught the latter); render-row tests call `app.view.sidebar_rows()` directly.

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`, `cargo fmt -- --check`)
- [x] Tests pass locally (217 unit, 8 CLI, 5 MCP); `tui_e2e` fails locally for known pre-existing environmental reasons — CI is authoritative

## Test Plan

- `cargo test` — render-row tests re-pointed, no assertion changes
- `grep -rn "&mut App" src/ui/` returns only `mod.rs` and `main_view.rs`
- Manual smoke: scroll a long branch list — viewport clamping behavior unchanged