### PR TITLE
fix(ui): make the PR detail pane scrollable (focusable pane + J/K)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ name = "gct"
 path = "src/main.rs"
 
 [dependencies]
-ratatui = "0.30"
+ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 crossterm = "0.29"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "process", "sync", "time"] }
 anyhow = "1"

--- a/src/app.rs
+++ b/src/app.rs
@@ -886,9 +886,15 @@ impl App {
                     self.progress.quit_pressed = true;
                 }
             }
-            KeyCode::Char('l') => self.active_view = ActiveView::Log,
+            KeyCode::Char('l') => {
+                // Leaving the Main view drops detail-pane focus so j/k drive
+                // the sidebar again when the user comes back.
+                self.view.pane_focus = PaneFocus::Sidebar;
+                self.active_view = ActiveView::Log;
+            }
             KeyCode::Char('h') => {
                 if self.active_view != ActiveView::History {
+                    self.view.pane_focus = PaneFocus::Sidebar;
                     self.active_view = ActiveView::History;
                     self.view.history_scroll = 0;
                 }
@@ -2921,6 +2927,23 @@ mod detail_scroll_tests {
         app.handle_key(key(KeyCode::Right));
         assert_eq!(app.view.pane_focus, PaneFocus::Detail);
         app.handle_key(key(KeyCode::Char('1')));
+        assert_eq!(app.view.pane_focus, PaneFocus::Sidebar);
+    }
+
+    #[test]
+    fn leaving_main_view_resets_focus() {
+        let mut app = App::new(Config::default());
+        app.handle_key(key(KeyCode::Right));
+        assert_eq!(app.view.pane_focus, PaneFocus::Detail);
+        // Switch to the Log view and come back: focus must be gone so j/k
+        // drive the sidebar again.
+        app.handle_key(key(KeyCode::Char('l')));
+        app.handle_key(key(KeyCode::Esc));
+        assert_eq!(app.active_view, ActiveView::Main);
+        assert_eq!(app.view.pane_focus, PaneFocus::Sidebar);
+
+        app.handle_key(key(KeyCode::Right));
+        app.handle_key(key(KeyCode::Char('h')));
         assert_eq!(app.view.pane_focus, PaneFocus::Sidebar);
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -442,6 +442,12 @@ pub struct PrCaches {
 }
 
 impl PrCaches {
+    /// Cached PR detail for `entry`, if the entry has a PR and it is cached.
+    pub fn detail_for(&self, entry: &BranchEntry) -> Option<&PrDetail> {
+        let pr_num = entry.pr_number()?;
+        self.detail.get(&(entry.repo_id.clone(), pr_num))
+    }
+
     pub fn current(&self, filter: MainFilter) -> &[PullRequest] {
         match filter {
             MainFilter::Local => &self.local,
@@ -734,13 +740,6 @@ impl App {
 
     pub fn snap_scroll_to_entry(&mut self) {
         self.view.snap_scroll_to_entry()
-    }
-
-    /// Return the cached PR detail for the currently selected entry, if available.
-    pub fn selected_pr_detail(&self) -> Option<&PrDetail> {
-        let entry = self.selected_entry()?;
-        let pr_num = entry.pr_number()?;
-        self.prs.detail.get(&(entry.repo_id.clone(), pr_num))
     }
 
     /// Signal that the selection changed. The actual detail fetches are

--- a/src/app.rs
+++ b/src/app.rs
@@ -260,6 +260,14 @@ pub struct Inflight {
     pub wt_lists: HashSet<crate::git::types::RepoId>,
 }
 
+/// Which Main-view pane receives `j`/`k` input (issue #269).
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub enum PaneFocus {
+    #[default]
+    Sidebar,
+    Detail,
+}
+
 /// What the user is looking at: the main-view entry list and its
 /// cursor/filter/search/multi-select state, plus the scroll positions of the
 /// other views (issue #220).
@@ -277,6 +285,7 @@ pub struct ViewState {
     pub log_scroll: usize,
     pub history_scroll: usize,
     pub pr_detail_scroll: usize,
+    pub pane_focus: PaneFocus,
 }
 
 impl ViewState {
@@ -300,6 +309,18 @@ impl ViewState {
         // Clamp offset so list doesn't show blank space
         let max_offset = item_count.saturating_sub(visible_height);
         self.sidebar_offset = self.sidebar_offset.min(max_offset);
+    }
+
+    /// Clamp the PR-detail scroll so the last page stays visible. Called
+    /// during render (like `adjust_sidebar_offset`), where the viewport
+    /// height and the wrapped line count are known.
+    pub fn clamp_pr_detail_scroll(&mut self, visible_height: usize, total_lines: usize) {
+        if visible_height == 0 {
+            return;
+        }
+        self.pr_detail_scroll = self
+            .pr_detail_scroll
+            .min(total_lines.saturating_sub(visible_height));
     }
 
     pub fn filtered_entries(&self) -> Vec<&BranchEntry> {
@@ -846,7 +867,11 @@ impl App {
                 }
             }
             KeyCode::Esc => {
-                if !self.view.search_query.is_empty() {
+                if self.active_view == ActiveView::Main && self.view.pane_focus == PaneFocus::Detail
+                {
+                    // Peel the innermost layer first: focus back to the sidebar.
+                    self.view.pane_focus = PaneFocus::Sidebar;
+                } else if !self.view.search_query.is_empty() {
                     // Clear search filter and restore scroll
                     self.view.search_query.clear();
                     self.view.sidebar_scroll = self.view.search_pre_scroll;
@@ -874,6 +899,7 @@ impl App {
                 self.view.search_query.clear();
                 self.view.sidebar_scroll = 0;
                 self.view.sidebar_offset = 0;
+                self.view.pane_focus = PaneFocus::Sidebar;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.prs.local_loaded {
@@ -887,6 +913,7 @@ impl App {
                 self.view.search_query.clear();
                 self.view.sidebar_scroll = 0;
                 self.view.sidebar_offset = 0;
+                self.view.pane_focus = PaneFocus::Sidebar;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.prs.my_loaded {
@@ -900,6 +927,7 @@ impl App {
                 self.view.search_query.clear();
                 self.view.sidebar_scroll = 0;
                 self.view.sidebar_offset = 0;
+                self.view.pane_focus = PaneFocus::Sidebar;
                 self.rebuild_entries();
                 self.snap_scroll_to_entry();
                 if !self.prs.review_loaded {
@@ -941,6 +969,28 @@ impl App {
 
     fn handle_main_key(&mut self, code: KeyCode) {
         match code {
+            // Detail-pane focus and scrolling (issue #269). The focused-pane
+            // arms must precede the sidebar j/k arms below so focus decides
+            // which pane the keys drive.
+            KeyCode::Right => {
+                self.view.pane_focus = PaneFocus::Detail;
+            }
+            KeyCode::Left if self.view.pane_focus == PaneFocus::Detail => {
+                self.view.pane_focus = PaneFocus::Sidebar;
+            }
+            KeyCode::Char('j') | KeyCode::Down if self.view.pane_focus == PaneFocus::Detail => {
+                self.view.pr_detail_scroll = self.view.pr_detail_scroll.saturating_add(1);
+            }
+            KeyCode::Char('k') | KeyCode::Up if self.view.pane_focus == PaneFocus::Detail => {
+                self.view.pr_detail_scroll = self.view.pr_detail_scroll.saturating_sub(1);
+            }
+            // Shift+J/K scroll the detail pane regardless of focus.
+            KeyCode::Char('J') => {
+                self.view.pr_detail_scroll = self.view.pr_detail_scroll.saturating_add(1);
+            }
+            KeyCode::Char('K') => {
+                self.view.pr_detail_scroll = self.view.pr_detail_scroll.saturating_sub(1);
+            }
             KeyCode::Char('j') | KeyCode::Down => {
                 if let Some(next) = self.view.next_entry_index(self.view.sidebar_scroll) {
                     self.view.sidebar_scroll = next;
@@ -2759,5 +2809,140 @@ mod notify_tests {
         let n = app.overlays.notification.as_ref().unwrap();
         assert!(n.is_error);
         assert_eq!(n.message, "second");
+    }
+}
+
+#[cfg(test)]
+mod detail_scroll_tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::git::types::{BranchEntry, PrState, PullRequest, RepoId};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    /// Two local entries so sidebar j/k would move the selection if it
+    /// (wrongly) received the key while the detail pane is focused.
+    fn app_with_entries() -> App {
+        let mut app = App::new(Config::default());
+        let repo = RepoId {
+            host: None,
+            owner: "o".into(),
+            name: "r".into(),
+        };
+        app.cross_repo.active_repo = Some(repo.clone());
+        let make_entry = |name: &str, num: u64| BranchEntry {
+            name: name.into(),
+            repo_id: repo.clone(),
+            local_branch: None,
+            worktree: None,
+            pull_request: Some(PullRequest {
+                number: num,
+                title: "t".into(),
+                author: "u".into(),
+                state: PrState::Open,
+                head_ref: name.into(),
+                updated_at: "2024".into(),
+                is_draft: false,
+                review_requests: vec![],
+                latest_reviews: vec![],
+                review_status: None,
+                repo_id: repo.clone(),
+            }),
+            git_status: None,
+        };
+        app.view.main_filter = MainFilter::MyPr;
+        app.view.entries = vec![make_entry("e1", 1), make_entry("e2", 2)];
+        app
+    }
+
+    #[test]
+    fn right_focuses_detail_left_and_esc_unfocus() {
+        let mut app = App::new(Config::default());
+        assert_eq!(app.view.pane_focus, PaneFocus::Sidebar);
+        app.handle_key(key(KeyCode::Right));
+        assert_eq!(app.view.pane_focus, PaneFocus::Detail);
+        app.handle_key(key(KeyCode::Left));
+        assert_eq!(app.view.pane_focus, PaneFocus::Sidebar);
+
+        app.handle_key(key(KeyCode::Right));
+        app.handle_key(key(KeyCode::Esc));
+        assert_eq!(app.view.pane_focus, PaneFocus::Sidebar);
+        // Unfocusing with Esc must not fall through to the quit logic.
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn focused_jk_scrolls_detail_not_sidebar() {
+        let mut app = app_with_entries();
+        app.handle_key(key(KeyCode::Right));
+        app.handle_key(key(KeyCode::Char('j')));
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(app.view.pr_detail_scroll, 2);
+        assert_eq!(app.view.sidebar_scroll, 0);
+        app.handle_key(key(KeyCode::Char('k')));
+        assert_eq!(app.view.pr_detail_scroll, 1);
+    }
+
+    #[test]
+    fn shift_jk_scrolls_detail_from_sidebar_focus() {
+        let mut app = app_with_entries();
+        assert_eq!(app.view.pane_focus, PaneFocus::Sidebar);
+        app.handle_key(key(KeyCode::Char('J')));
+        assert_eq!(app.view.pr_detail_scroll, 1);
+        assert_eq!(app.view.sidebar_scroll, 0);
+        app.handle_key(key(KeyCode::Char('K')));
+        assert_eq!(app.view.pr_detail_scroll, 0);
+    }
+
+    #[test]
+    fn detail_scroll_saturates_at_zero() {
+        let mut app = App::new(Config::default());
+        app.handle_key(key(KeyCode::Char('K')));
+        assert_eq!(app.view.pr_detail_scroll, 0);
+    }
+
+    #[test]
+    fn sidebar_jk_resets_detail_scroll_via_selection_change() {
+        let mut app = app_with_entries();
+        app.handle_key(key(KeyCode::Char('J')));
+        assert_eq!(app.view.pr_detail_scroll, 1);
+        // Sidebar navigation changes the selection, which resets the scroll.
+        app.handle_key(key(KeyCode::Char('j')));
+        assert_eq!(app.view.pr_detail_scroll, 0);
+        assert_eq!(app.view.sidebar_scroll, 1);
+    }
+
+    #[test]
+    fn filter_switch_resets_focus() {
+        let mut app = App::new(Config::default());
+        app.handle_key(key(KeyCode::Right));
+        assert_eq!(app.view.pane_focus, PaneFocus::Detail);
+        app.handle_key(key(KeyCode::Char('1')));
+        assert_eq!(app.view.pane_focus, PaneFocus::Sidebar);
+    }
+
+    #[test]
+    fn clamp_pr_detail_scroll_bounds() {
+        let mut view = ViewState::default();
+        view.pr_detail_scroll = 100;
+        view.clamp_pr_detail_scroll(10, 50);
+        assert_eq!(view.pr_detail_scroll, 40);
+
+        view.pr_detail_scroll = 5;
+        view.clamp_pr_detail_scroll(10, 50);
+        assert_eq!(view.pr_detail_scroll, 5);
+
+        // Content shorter than the viewport pins to the top.
+        view.pr_detail_scroll = 5;
+        view.clamp_pr_detail_scroll(10, 3);
+        assert_eq!(view.pr_detail_scroll, 0);
+
+        // Zero-height viewport is a no-op guard.
+        view.pr_detail_scroll = 7;
+        view.clamp_pr_detail_scroll(0, 50);
+        assert_eq!(view.pr_detail_scroll, 7);
     }
 }

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -6,7 +6,7 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
-use crate::app::{PrCaches, ViewState};
+use crate::app::{PaneFocus, PrCaches, ViewState};
 use crate::git::types::{BranchEntry, PrDetail, RepoId};
 use crate::ui::markdown;
 
@@ -68,15 +68,29 @@ pub fn draw(frame: &mut Frame, area: Rect, view: &mut ViewState, ctx: &DetailPan
         (title, lines)
     };
 
+    // Highlight the border while the pane has key focus (issue #269).
+    let border_color = if view.pane_focus == PaneFocus::Detail {
+        theme::ACCENT
+    } else {
+        theme::TEXT_DIM
+    };
     let block = Block::default()
         .borders(Borders::ALL)
         .title(title)
-        .border_style(Style::default().fg(theme::TEXT_DIM));
+        .border_style(Style::default().fg(border_color));
 
     let paragraph = Paragraph::new(lines)
         .block(block)
-        .wrap(Wrap { trim: false })
-        .scroll((view.pr_detail_scroll as u16, 0));
+        .wrap(Wrap { trim: false });
+
+    // Clamp to the wrapped line count so the last page stays reachable —
+    // the render is the only place viewport height and line count are known
+    // (same pattern as adjust_sidebar_offset in the sidebar).
+    let total_lines = paragraph.line_count(area.width.saturating_sub(2));
+    let visible_height = area.height.saturating_sub(2) as usize;
+    view.clamp_pr_detail_scroll(visible_height, total_lines);
+
+    let paragraph = paragraph.scroll((view.pr_detail_scroll.min(u16::MAX as usize) as u16, 0));
     frame.render_widget(paragraph, area);
 }
 

--- a/src/ui/detail_pane.rs
+++ b/src/ui/detail_pane.rs
@@ -6,60 +6,77 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph, Wrap},
 };
 
-use crate::app::App;
+use crate::app::{PrCaches, ViewState};
 use crate::git::types::{BranchEntry, PrDetail, RepoId};
 use crate::ui::markdown;
 
 use crate::ui::theme;
 
-pub fn draw(frame: &mut Frame, area: Rect, app: &App) {
-    let entry = app.selected_entry();
+/// Read-only state the detail pane needs from outside `ViewState`.
+pub struct DetailPaneContext<'a> {
+    /// Current spinner animation frame for loading indicators.
+    pub spinner: &'static str,
+    /// PR caches, for the detail-body lookup of the selected entry.
+    pub prs: &'a PrCaches,
+    /// Active repo, to label cross-repo entries.
+    pub active_repo: Option<&'a RepoId>,
+    /// Errors to render at the bottom; empty unless verbose mode is on.
+    pub verbose_errors: &'a [String],
+}
+
+pub fn draw(frame: &mut Frame, area: Rect, view: &mut ViewState, ctx: &DetailPaneContext<'_>) {
+    // Build owned title + lines in a scoped block so the selected-entry
+    // borrow of `view` ends before the scroll state is touched below.
+    let (title, lines): (String, Vec<Line<'static>>) = {
+        let entry = view.selected_entry();
+        let title = match &entry {
+            Some(e) => format!(" {} ", e.name),
+            None => " Detail ".to_string(),
+        };
+
+        let mut lines: Vec<Line> = Vec::new();
+        if let Some(entry) = &entry {
+            draw_git_status_section(&mut lines, entry, ctx.spinner);
+            draw_worktree_section(&mut lines, entry);
+            draw_pr_section(
+                &mut lines,
+                entry,
+                ctx.prs.detail_for(entry),
+                ctx.spinner,
+                ctx.active_repo,
+            );
+        } else {
+            lines.push(Line::from(Span::styled(
+                " No branch selected",
+                Style::default().fg(theme::TEXT_DIM),
+            )));
+            lines.push(Line::from(""));
+        }
+
+        // Errors section — always drawn, even with no entry (the slice is
+        // empty unless verbose mode is on).
+        if !ctx.verbose_errors.is_empty() {
+            draw_errors_section(&mut lines, ctx.verbose_errors);
+        }
+
+        if lines.is_empty() {
+            lines.push(Line::from(Span::styled(
+                " No additional information",
+                Style::default().fg(theme::TEXT_DIM),
+            )));
+        }
+        (title, lines)
+    };
 
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(match &entry {
-            Some(e) => format!(" {} ", e.name),
-            None => " Detail ".to_string(),
-        })
+        .title(title)
         .border_style(Style::default().fg(theme::TEXT_DIM));
-
-    let mut lines: Vec<Line> = Vec::new();
-
-    let spinner = app.spinner_frame();
-    if let Some(entry) = &entry {
-        draw_git_status_section(&mut lines, entry, spinner);
-        draw_worktree_section(&mut lines, entry);
-        draw_pr_section(
-            &mut lines,
-            entry,
-            app.selected_pr_detail(),
-            spinner,
-            app.cross_repo.active_repo.as_ref(),
-        );
-    } else {
-        lines.push(Line::from(Span::styled(
-            " No branch selected",
-            Style::default().fg(theme::TEXT_DIM),
-        )));
-        lines.push(Line::from(""));
-    }
-
-    // Errors section (verbose mode only) — always drawn, even with no entry
-    if app.verbose && !app.verbose_errors.is_empty() {
-        draw_errors_section(&mut lines, &app.verbose_errors);
-    }
-
-    if lines.is_empty() {
-        lines.push(Line::from(Span::styled(
-            " No additional information",
-            Style::default().fg(theme::TEXT_DIM),
-        )));
-    }
 
     let paragraph = Paragraph::new(lines)
         .block(block)
         .wrap(Wrap { trim: false })
-        .scroll((app.view.pr_detail_scroll as u16, 0));
+        .scroll((view.pr_detail_scroll as u16, 0));
     frame.render_widget(paragraph, area);
 }
 

--- a/src/ui/help_overlay.rs
+++ b/src/ui/help_overlay.rs
@@ -29,6 +29,8 @@ pub fn draw(frame: &mut Frame) {
         Line::from(""),
         section("Main View"),
         key_line("j/k ↑/↓", "Navigate sidebar"),
+        key_line("→/←", "Focus PR detail / back"),
+        key_line("J/K", "Scroll PR detail (j/k when focused)"),
         key_line("Space", "Toggle selection"),
         key_line("a", "Select all merged"),
         key_line("d", "Delete branch/worktree"),

--- a/src/ui/main_view.rs
+++ b/src/ui/main_view.rs
@@ -24,7 +24,18 @@ pub fn draw(frame: &mut Frame, area: Rect, app: &mut App) {
         protected_branches: &app.config.protected_branches,
     };
     sidebar::draw(frame, chunks[0], &mut app.view, &sidebar_ctx);
-    detail_pane::draw(frame, chunks[1], app);
+
+    let detail_ctx = detail_pane::DetailPaneContext {
+        spinner: app.spinner_frame(),
+        prs: &app.prs,
+        active_repo: app.cross_repo.active_repo.as_ref(),
+        verbose_errors: if app.verbose {
+            app.verbose_errors.as_slice()
+        } else {
+            &[]
+        },
+    };
+    detail_pane::draw(frame, chunks[1], &mut app.view, &detail_ctx);
 
     // Confirm dialog overlay
     if let Some(pending) = &app.overlays.confirm_dialog {

--- a/src/ui/sidebar.rs
+++ b/src/ui/sidebar.rs
@@ -15,9 +15,13 @@ use crate::ui::theme;
 pub struct SidebarContext<'a> {
     /// Whether the current filter's PR list is still loading.
     pub is_loading: bool,
+    /// Current spinner animation frame for the loading indicator.
     pub spinner: &'static str,
+    /// Whether merged PRs are included (`[+merged]` indicator).
     pub show_merged: bool,
+    /// Whether team review requests are included (`[+team]` / `[me]`).
     pub include_team_reviews: bool,
+    /// Branches that never get merged/deletable styling.
     pub protected_branches: &'a [String],
 }
 


### PR DESCRIPTION
## Summary

`ViewState::pr_detail_scroll` was reset and rendered but never changed, so long PR descriptions were unreachable past the first screenful. This PR makes the detail pane a focusable, scrollable pane: `→` focuses it (border highlights), `j/k` scroll while focused, `Shift+J/K` scroll from either focus, `←`/`Esc` return to the sidebar.

## Related Issues

Closes #269

## Type of Change

- [x] Bug fix
- [x] New feature

## Changes

- **Commit 1 (behavior-neutral):** `detail_pane::draw` takes `&mut ViewState` + a read-only `DetailPaneContext` (same pattern as the sidebar in #268); line building moves into a scoped block returning owned title+lines; PR-detail lookup becomes `PrCaches::detail_for` (single-caller `App::selected_pr_detail` removed). Also completes the `SidebarContext` field docs suggested in the #272 review.
- **Commit 2 (the feature):**
  - `PaneFocus { Sidebar, Detail }` on `ViewState`; `→` focuses, `←`/`Esc` unfocus (Esc peels focus before the search-clear/quit chain), `1/2/3` reset focus.
  - Focused `j/k`/`Up/Down` scroll the detail pane without moving the sidebar selection; `Shift+J/K` work from either focus (shifted chars arrive as uppercase `KeyCode::Char` — no modifier plumbing).
  - Render-time clamp (`ViewState::clamp_pr_detail_scroll`) against the exact wrapped line count via `Paragraph::line_count`, enabled through ratatui's `unstable-rendered-line-info` cargo feature — logical line counts would leave the wrapped tail of long bodies unreachable.
  - ACCENT border on the focused detail pane; help overlay documents the new keys.
  - 7 new tests: focus transitions (incl. Esc not falling through to quit), focused-scroll isolation, Shift+J/K, saturation, selection-reset, filter-switch reset, clamp bounds.

## Checklist

- [x] Code compiles / builds without warnings
- [x] Linter passes (`cargo clippy -- -D warnings`, `cargo fmt -- --check`)
- [x] Tests pass locally (224 unit, 8 CLI, 5 MCP); `tui_e2e` fails locally for known pre-existing environmental reasons — CI is authoritative

## Test Plan

- `cargo test` — 7 new tests in `detail_scroll_tests`
- Manual smoke: select a PR with a long body → `→` (border highlights) → `j` to the wrapped tail (clamped, reachable) → `←`/`Esc` back → `J/K` from sidebar focus → `j/k` selection change resets scroll

## Note on the unstable feature

`unstable-rendered-line-info` is semver-exempt in ratatui; if a future bump breaks it, the fallback is clamping on logical `lines.len()` (slightly under-scrolls wrapped content). Chosen deliberately — exact wrapped-tail reachability is the entire point of this fix.