### PR TITLE
docs: add AI collaboration rules to AGENT.md

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -43,3 +43,17 @@ Key design principles:
 
 - Comments and code should be in English.
 - All PR titles, descriptions, commit messages, and issue content must be written in English.
+
+## AI Collaboration Rules
+
+- When an implementation approach has user-facing alternatives (e.g. adding a
+  dependency vs extending in-house code), do NOT start implementing until the
+  user's explicit answer is received. Plan approval does not substitute for
+  answering the question, and a "recommended" option is not a default.
+- If a question tool fails or errors out, assume the user's answer may have
+  been sent but lost: say so first, then re-ask in plain text before doing
+  anything else.
+- Any assumption made in place of a user decision must be declared prominently
+  in the chat message itself — never only inside a plan file or commit message.
+- Before starting implementation (creating branches, editing code), confirm
+  there are no unresolved user decisions pending for the task.


### PR DESCRIPTION
## Summary

Adds an "AI Collaboration Rules" section to `AGENT.md` (which `CLAUDE.md` symlinks to), so the rules load in every future AI session on this repo.

Background: during issue #235, a question about the implementation approach (add a markdown dependency vs extend the in-house renderer) failed to deliver the user's answer due to a tool error, and implementation proceeded on the "recommended" option anyway — directly against the user's actual (lost) choice. These rules prevent a recurrence:

- **User-facing alternatives are blocking**: no implementation starts until the explicit answer arrives; plan approval and "recommended" defaults don't substitute.
- **A failed question tool means the answer may be lost**, not that there was no answer — say so and re-ask in plain text first.
- **Assumptions standing in for user decisions must be declared prominently in the conversation**, never only inside a plan file or commit message.
- **Pre-implementation check**: confirm no unresolved user decisions remain before touching branches or code.

## Test plan

Documentation-only change; no code paths affected. `cargo fmt`/`clippy`/`test` gates are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr

---
_Generated by [Claude Code](https://claude.ai/code/session_011bNx3kwqJsFSGWtKaM1djr)_